### PR TITLE
Fix typo

### DIFF
--- a/integrations/jira.mdx
+++ b/integrations/jira.mdx
@@ -31,7 +31,7 @@ To get the most out of this guide, you will need to:
       <Info>For more information about these fields check [Jira Integration](#jira-integration) fields.</Info>
   </Step>
   <Step title="Create templates">
-  With Jira Integrations enabled your organization has access to Jira Templates on the main sibedar.
+  With Jira Integrations enabled your organization has access to Jira Templates on the main sidebar.
   
   <Frame>
     <img src="/images/integrations/jira-3.png" />


### PR DESCRIPTION
This fixes a typo in the jira docs. I made this change via the github editor, so I'm not sure what the change on the last line is, but I think it's probably whitespace related.