### PR TITLE
fix(cli.mdx): correct spelling

### DIFF
--- a/clients/cli.mdx
+++ b/clients/cli.mdx
@@ -83,7 +83,7 @@ The authentication process requires either an **access token** or an **API key**
 The following sections outline the various authentication scenarios when using the command line interface.
 
 <Note>
-  The authentication process requires knowning the gateway instance URL where the Hoop gateway is running.
+  The authentication process requires knowing the gateway instance URL where the Hoop gateway is running.
   Our managed instances are hosted under the URL:
 
   ```


### PR DESCRIPTION
- `knowning` => `knowing`