### PR TITLE
fix(aws.mdx): correct spelling

### DIFF
--- a/integrations/aws.mdx
+++ b/integrations/aws.mdx
@@ -254,7 +254,7 @@ In the final step of the job, you can send webhooks to an external system for in
 The webhook provider must be configured to send the message properly. More information could be found [here](./svix).
 The payload structure matches the endpoint `GET /api/dbroles/:id`.
 
-In the final step of the job it's possible to send Webhooks to an external system for integration purporses.
+In the final step of the job it's possible to send Webhooks to an external system for integration purposes.
 The Webhook provider must be configured to send the message properly. The payload is the same structure of the endpoint `GET /api/dbroles/:id`.
 
 ```json
@@ -444,7 +444,7 @@ print('response status: ', response['status'])
 
 <Warning>
     Be careful when printing any sensitive information.
-    The content will be available for inspection in the API for adminstrator users.
+    The content will be available for inspection in the API for administrator users.
 </Warning>
 
 ## Vault Secrets Manager


### PR DESCRIPTION
- `purporses` => `purposes`
- `adminstrator` => `administrator`