### PR TITLE
Add animated hero sections and grayscale style guide

### DIFF
--- a/clients/webapp/creating-resource-roles.mdx
+++ b/clients/webapp/creating-resource-roles.mdx
@@ -3,9 +3,11 @@ title: "Creating Resource Roles"
 description: "Learn how to set up secure connections to your resources through the Hoop.dev web interface"
 ---
 
-<Frame>
-  <img src="/images/clients/webapp/connection-types.png" alt="Resource Types Selection" />
-</Frame>
+import { JDBCProxy } from '/snippets/annimations/JDBCProxy.jsx';
+
+<div style={{height: 380, overflow: 'hidden', borderRadius: 14}}>
+  <JDBCProxy />
+</div>
 
 Hoop.dev provides an intuitive web interface to create and manage secure connections to your resources. The resource role setup process is divided into three simple steps:
 

--- a/clients/webapp/managing-access.mdx
+++ b/clients/webapp/managing-access.mdx
@@ -3,9 +3,11 @@ title: "Managing Access"
 description: "Learn how to control and organize access to your connections through user groups and permissions"
 ---
 
-<Frame>
-  <img src="/images/clients/webapp/managing-access-users.png" alt="Users Management Interface" />
-</Frame>
+import { SessionAnimation } from '/snippets/annimations/SessionAnimation.jsx';
+
+<div style={{height: 350, overflow: 'hidden', borderRadius: 14}}>
+  <SessionAnimation />
+</div>
 
 Hoop.dev provides a comprehensive access management system that allows administrators to control who can access specific connections. This is primarily managed through user groups and connection-specific configurations.
 

--- a/clients/webapp/monitoring-sessions.mdx
+++ b/clients/webapp/monitoring-sessions.mdx
@@ -3,9 +3,11 @@ title: "Monitoring Sessions"
 description: "Learn how to track and audit connection usage through the Sessions interface"
 ---
 
-<Frame>
-  <img src="/images/clients/webapp/sessions.png" alt="Session Details" />
-</Frame>
+import { AuditTrailDemo } from '/snippets/annimations/AuditTrailDemo.jsx';
+
+<div style={{height: 380, overflow: 'hidden', borderRadius: 14}}>
+  <AuditTrailDemo />
+</div>
 
 The Sessions interface provides a comprehensive view of all connection activities across your organization. You can monitor active sessions, review past activities, and investigate specific actions taken by users.
 

--- a/clients/webapp/overview.mdx
+++ b/clients/webapp/overview.mdx
@@ -3,10 +3,11 @@ title: "Web App Overview"
 description: "Get started with Hoop.dev's powerful web interface for managing secure infrastructure access"
 ---
 
-<Frame>
-  <img src="/images/clients/webapp/webapp-light.png" className="block dark:hidden" />
-  <img src="/images/clients/webapp/webapp-dark.png" className="hidden dark:block" />
-</Frame>
+import { ProductMock } from '/snippets/annimations/ProductMock.jsx';
+
+<div style={{height: 300, overflow: 'hidden', borderRadius: 14}}>
+  <ProductMock />
+</div>
 
 Our Web App is your central interface for managing secure access to your infrastructure. It provides a modern, intuitive interface for creating and managing connections, controlling access policies, and monitoring user sessions - all while maintaining robust security through AI-powered features.
 

--- a/concepts/resource-roles.mdx
+++ b/concepts/resource-roles.mdx
@@ -3,17 +3,11 @@ title: "Resource Roles"
 description: "The bridge between users and resources"
 ---
 
-<img
-  src="/images/concepts/connections-light.png"
-  alt="Connections"
-  className="block dark:hidden"
-/>
+import { GatewayVisualization } from '/snippets/annimations/GatewayVisualization.jsx';
 
-<img
-  src="/images/concepts/connections-dark.png"
-  alt="Connections"
-  className="hidden dark:block"
-/>
+<div style={{height: 350, overflow: 'hidden', borderRadius: 14}}>
+  <GatewayVisualization />
+</div>
 
 # Resource Roles
 

--- a/docs.json
+++ b/docs.json
@@ -3,9 +3,27 @@
   "theme": "mint",
   "name": "Hoop.dev - Automated Access and Data Protection",
   "colors": {
-    "primary": "#111928",
-    "light": "#E5E7EB",
-    "dark": "#111928"
+    "primary": "#333333",
+    "light": "#B0B0B0",
+    "dark": "#333333"
+  },
+  "appearance": {
+    "default": "light"
+  },
+  "background": {
+    "decoration": "gradient"
+  },
+  "styling": {
+    "codeblocks": "dark"
+  },
+  "fonts": {
+    "heading": {
+      "family": "Sora",
+      "weight": 700
+    },
+    "body": {
+      "family": "DM Sans"
+    }
   },
   "favicon": "/favicon.svg",
   "redirects": [

--- a/introduction/getting-started.mdx
+++ b/introduction/getting-started.mdx
@@ -3,15 +3,11 @@ title: "Getting Started"
 description: "Secure gateway access to your infrastructure with AI-powered security"
 ---
 
-<img
-  className="block dark:hidden"
-  src="/images/introduction/lp-hero.png"
-/>
+import { HeroAnimation } from '/snippets/annimations/HeroAnimation.jsx';
 
-<img
-  className="hidden dark:block"
-  src="/images/introduction/lp-hero-2.png"
-/>
+<div style={{background: 'linear-gradient(135deg, #111111 0%, #1A1A1A 35%, #2A2A2A 70%, #3A3A3A 100%)', borderRadius: 14, overflow: 'hidden', padding: 24, height: 350}}>
+  <HeroAnimation />
+</div>
 
 Hoop.dev is an access gateway for databases and servers with AI-powered automations that eliminate cumbersome access policies and break-glass workflows without compromising security. Our platform provides secure, auditable, and easy-to-manage access to your infrastructure.
 

--- a/learn/features/access-control.mdx
+++ b/learn/features/access-control.mdx
@@ -3,9 +3,11 @@ title: "Access Control"
 description: "Control who can access which connections with group-based permissions"
 ---
 
-<Frame>
-  <img src="/images/learn/features/access-control.png" alt="Access Control" />
-</Frame>
+import { ObservabilityAnimation } from '/snippets/annimations/ObservabilityAnimation.jsx';
+
+<div style={{background: 'linear-gradient(135deg, #111111 0%, #1A1A1A 35%, #2A2A2A 70%, #3A3A3A 100%)', borderRadius: 14, overflow: 'hidden', padding: 24, height: 350}}>
+  <ObservabilityAnimation />
+</div>
 
 ## What You'll Accomplish
 

--- a/learn/features/access-requests/action.mdx
+++ b/learn/features/access-requests/action.mdx
@@ -3,9 +3,11 @@ title: "Action Access Requests"
 description: "Require approval for individual commands before they execute"
 ---
 
-<Frame>
-  <img src="/images/learn/features/review-3.png" alt="Action Access Requests" />
-</Frame>
+import { ActionAccessAnimation } from '/snippets/annimations/actionaccessrequest.jsx';
+
+<div style={{height: 400, overflow: 'hidden', borderRadius: 14}}>
+  <ActionAccessAnimation />
+</div>
 
 ## What You'll Accomplish
 

--- a/learn/features/access-requests/jit.mdx
+++ b/learn/features/access-requests/jit.mdx
@@ -3,18 +3,13 @@ title: "Just-in-Time Access Requests"
 description: "Grant temporary, time-limited access to resources with automatic expiration and approval workflows"
 ---
 
-<Frame>
-  <img
-    className="block dark:hidden"
-    src="/images/learn/review_light.png"
-    alt="JIT Access Requests workflow"
-  />
-  <img
-    className="hidden dark:block"
-    src="/images/learn/review_dark.png"
-    alt="JIT Access Requests workflow"
-  />
-</Frame>
+import { LayeredAccess } from '/snippets/annimations/layeredaccess.jsx';
+
+<div style={{background: 'linear-gradient(135deg, #111111 0%, #1A1A1A 35%, #2A2A2A 70%, #3A3A3A 100%)', borderRadius: 14, overflow: 'hidden', padding: 24, maxWidth: '100%', height: 400}}>
+  <div style={{maxWidth: 500, margin: '0 auto'}}>
+    <LayeredAccess />
+  </div>
+</div>
 
 ## What You'll Accomplish
 

--- a/learn/features/ai-query-builder.mdx
+++ b/learn/features/ai-query-builder.mdx
@@ -3,9 +3,11 @@ title: "AI Query Builder"
 description: "Get AI-powered help writing queries and scripts with context-aware suggestions"
 ---
 
-<Frame>
-  <img src="/images/ai-query-builder.png" alt="AI Query Builder" />
-</Frame>
+import { AIChatThread } from '/snippets/annimations/aichat.jsx';
+
+<div style={{height: 400, overflow: 'hidden', borderRadius: 14}}>
+  <AIChatThread />
+</div>
 
 ## What You'll Accomplish
 

--- a/learn/features/guardrails.mdx
+++ b/learn/features/guardrails.mdx
@@ -3,9 +3,11 @@ title: "Guardrails"
 description: "Block dangerous queries before they execute with pattern-based rules"
 ---
 
-<Frame>
-  <img src="/images/learn/features/guardrails.png" alt="Guardrails" />
-</Frame>
+import { GuardrailsAnimation } from '/snippets/annimations/guardrails.jsx';
+
+<div style={{background: 'linear-gradient(135deg, #111111 0%, #1A1A1A 35%, #2A2A2A 70%, #3A3A3A 100%)', borderRadius: 14, overflow: 'hidden', padding: 24, height: 380}}>
+  <GuardrailsAnimation />
+</div>
 
 ## What You'll Accomplish
 

--- a/learn/features/live-data-masking.mdx
+++ b/learn/features/live-data-masking.mdx
@@ -3,9 +3,11 @@ title: "Live Data Masking"
 description: "Automatically detect and mask sensitive data in query results without writing rules"
 ---
 
-<Frame>
-  <img src="/images/learn/features/ai-data-masking.png" alt="Live Data Masking" />
-</Frame>
+import { DataMaskingDemo } from '/snippets/annimations/DataMaskingDemo.jsx';
+
+<div style={{height: 400, overflow: 'hidden', borderRadius: 14}}>
+  <DataMaskingDemo />
+</div>
 
 ## What You'll Accomplish
 

--- a/learn/features/parallel-mode.mdx
+++ b/learn/features/parallel-mode.mdx
@@ -3,9 +3,11 @@ title: "Parallel Mode"
 description: "Execute commands across multiple resource roles simultaneously"
 ---
 
-<Frame>
-  ![Parallel Mode](/images/learn/features/parallel-mode.png)
-</Frame>
+import { RunbooksAnimation } from '/snippets/annimations/runbookparalellmode.jsx';
+
+<div style={{height: 380, overflow: 'hidden', borderRadius: 14}}>
+  <RunbooksAnimation />
+</div>
 
 <Note>
   This feature is currently in Beta. Update to the latest Hoop version to access it.

--- a/learn/features/runbooks.mdx
+++ b/learn/features/runbooks.mdx
@@ -3,9 +3,11 @@ title: "Runbooks"
 description: "Create reusable, parameterized templates for common operations"
 ---
 
-<Frame>
-  <img src="/images/learn/features/runbooks.png" alt="Runbooks" />
-</Frame>
+import { RunbookAnimation } from '/snippets/annimations/RunbookAnimation.jsx';
+
+<div style={{background: 'linear-gradient(135deg, #111111 0%, #1A1A1A 35%, #2A2A2A 70%, #3A3A3A 100%)', borderRadius: 14, overflow: 'hidden', padding: 24, height: 420}}>
+  <RunbookAnimation />
+</div>
 
 ## What You'll Accomplish
 

--- a/learn/features/secrets-manager.mdx
+++ b/learn/features/secrets-manager.mdx
@@ -3,9 +3,11 @@ title: "Secrets Management"
 description: "Securely inject credentials into connections without exposing them to users"
 ---
 
-<Frame>
-  <img src="/images/learn/features/secrets-manager.png" alt="Secrets Management" />
-</Frame>
+import { DataFlowAnimation } from '/snippets/annimations/DataFlowAnimation.jsx';
+
+<div style={{background: 'linear-gradient(135deg, #111111 0%, #1A1A1A 35%, #2A2A2A 70%, #3A3A3A 100%)', borderRadius: 14, overflow: 'hidden', padding: 24, height: 350}}>
+  <DataFlowAnimation />
+</div>
 
 ## What You'll Accomplish
 

--- a/learn/features/session-recording.mdx
+++ b/learn/features/session-recording.mdx
@@ -3,9 +3,11 @@ title: "Session Recording"
 description: "Record and playback terminal sessions and entire databases connections."
 ---
 
-<Frame>
-  ![](/images/learn/features/session-recording.png)
-</Frame>
+import { RiskMetricsAnimation } from '/snippets/annimations/RiskMetricsAnimation.jsx';
+
+<div style={{background: 'linear-gradient(135deg, #111111 0%, #1A1A1A 35%, #2A2A2A 70%, #3A3A3A 100%)', borderRadius: 14, overflow: 'hidden', padding: 24, height: 300}}>
+  <RiskMetricsAnimation />
+</div>
 
 You can audit tracks every action made with Hoop.dev. It provides video recordings of sessions and logging.
 

--- a/setup/architecture.mdx
+++ b/setup/architecture.mdx
@@ -3,18 +3,13 @@ title: "Architecture"
 description: "Understand how Hoop's components fit together and how traffic flows through the system."
 ---
 
+import { GatewayVisualization } from '/snippets/annimations/GatewayVisualization.jsx';
+
 Hoop is a secure access gateway that sits between your users and your infrastructure. It proxies connections through a lightweight agent running inside your network — no inbound firewall rules required, no VPN needed, and nothing in your infrastructure exposed to the internet.
 
-<Frame>
-  <img
-    className="block dark:hidden"
-    src="/images/learn/Architecture_Light.png"
-  />
-  <img
-    className="hidden dark:block"
-    src="/images/learn/Architecture_Dark.png"
-  />
-</Frame>
+<div style={{height: 350, overflow: 'hidden', borderRadius: 14}}>
+  <GatewayVisualization />
+</div>
 
 ## Components
 

--- a/setup/configuration/access-control-configuration.mdx
+++ b/setup/configuration/access-control-configuration.mdx
@@ -3,9 +3,11 @@ title: "Access Control Configuration"
 description: "Configure group-based access policies for your connections"
 ---
 
-<Frame>
-  <img src="/images/learn/features/access-control-app.png" alt="Access Control Configuration" />
-</Frame>
+import { LayeredAccess } from '/snippets/annimations/layeredaccess.jsx';
+
+<div style={{height: 400, overflow: 'hidden', borderRadius: 14}}>
+  <LayeredAccess />
+</div>
 
 Access Control lets you restrict which users can see and access specific connections based on their group memberships. This page covers detailed configuration options.
 

--- a/setup/configuration/guardrails-configuration.mdx
+++ b/setup/configuration/guardrails-configuration.mdx
@@ -3,17 +3,11 @@ title: "Guardrails Configuration"
 description: "Create and manage pattern-based rules to block dangerous queries"
 ---
 
-<Frame>
-  <img
-    src="/images/clients/webapp/guardrails-light.png"
-    className="block dark:hidden"
-  />
+import { KillCommandDemo } from '/snippets/annimations/KillCommandDemo.jsx';
 
-  <img
-    src="/images/clients/webapp/guardrails-dark.png"
-    className="hidden dark:block"
-  />
-</Frame>
+<div style={{height: 380, overflow: 'hidden', borderRadius: 14}}>
+  <KillCommandDemo />
+</div>
 
 Guardrails use pattern matching to evaluate queries and block dangerous operations before they execute. This page covers configuration options and rule syntax.
 

--- a/setup/configuration/live-data-masking/get-started.mdx
+++ b/setup/configuration/live-data-masking/get-started.mdx
@@ -3,9 +3,11 @@ title: "Get Started"
 description: "Set up and know better about hoop.dev's Live Data Masking"
 ---
 
-<Frame>
-  ![](/images/ai-data-masking.png)
-</Frame>
+import { LiveDataMasking } from '/snippets/annimations/datamaskingscan.jsx';
+
+<div style={{height: 400, overflow: 'hidden', borderRadius: 14}}>
+  <LiveDataMasking />
+</div>
 
 ## Prerequisites
 

--- a/snippets/annimations/AgentRiskAnimation.jsx
+++ b/snippets/annimations/AgentRiskAnimation.jsx
@@ -1,0 +1,144 @@
+/**
+ * AgentRiskAnimation — AI agent executing commands with escalating risk
+ *
+ * Shows a terminal where an AI agent runs commands sequentially.
+ * Each command appears with a risk level badge. The risk escalates
+ * from "low" to "critical" — but nothing stops any of them.
+ * Conveys: agents execute blindly with your full credentials.
+ *
+ * Pure CSS + React state.
+ */
+
+export const AgentRiskAnimation = () => {
+  const COMMANDS = [
+    { cmd: 'SELECT * FROM users LIMIT 10;',          risk: 'low',      color: 'rgba(var(--sand-100-rgb),0.4)' },
+    { cmd: 'UPDATE config SET debug=true;',           risk: 'medium',   color: 'var(--warm-gold)' },
+    { cmd: 'kubectl scale deploy api --replicas=0',   risk: 'high',     color: 'var(--warm-gold)' },
+    { cmd: 'DELETE FROM sessions WHERE 1=1;',         risk: 'critical', color: 'var(--error)' },
+    { cmd: 'DROP TABLE customers;',                   risk: 'critical', color: 'var(--error)' },
+  ];
+
+  const CMD_DELAY = 1800;
+  const TYPING_DURATION = 1000;
+  const CYCLE_PAD = 3500;
+
+  const [cycle, setCycle]       = useState(0);
+  const [visible, setVisible]   = useState(0);
+  const [typing, setTyping]     = useState(-1);
+  const [fading, setFading]     = useState(false);
+  const timers                  = useRef([]);
+
+  function T(fn, ms) { const id = setTimeout(fn, ms); timers.current.push(id); }
+
+  useEffect(() => {
+    timers.current.forEach(clearTimeout);
+    timers.current = [];
+    setVisible(0);
+    setTyping(-1);
+    setFading(false);
+
+    COMMANDS.forEach((_, i) => {
+      const t = i * CMD_DELAY;
+      T(() => setTyping(i), t);
+      T(() => { setVisible(i + 1); setTyping(-1); }, t + TYPING_DURATION);
+    });
+
+    const totalTime = COMMANDS.length * CMD_DELAY + CYCLE_PAD;
+    // Fade out 600ms before reset
+    T(() => setFading(true), totalTime - 600);
+    T(() => setCycle((c) => c + 1), totalTime);
+    return () => timers.current.forEach(clearTimeout);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cycle]);
+
+  return (
+    <div className="ar-root" aria-hidden="true">
+      <div className={`mock-container ar-mock${fading ? ' ar-fadeout' : ''}`}>
+        <div className="mock-toolbar" style={{ justifyContent: 'space-between' }}>
+          <div style={{ display: 'flex', gap: 6 }}>
+            <div className="mock-dot" /><div className="mock-dot" /><div className="mock-dot" />
+          </div>
+          <span className="ar-title">ai-agent · prod session</span>
+          <span style={{ width: 48 }} />
+        </div>
+
+        <div className="ar-stream">
+          {COMMANDS.map((c, i) => {
+            const show = i < visible;
+            const isTyping = i === typing;
+            return (
+              <div key={i} className={`ar-line${show ? ' ar-done' : ''}${isTyping ? ' ar-typing' : ''}`}>
+                <div className="ar-cmd-row">
+                  <span className="ar-prompt">agent $</span>
+                  <span className="ar-cmd">{isTyping || show ? c.cmd : ''}</span>
+                  {isTyping && <span className="ar-cursor" />}
+                </div>
+                {show && (
+                  <div className="ar-result">
+                    <span className="ar-risk" style={{ color: c.color, borderColor: c.color }}>
+                      {c.risk}
+                    </span>
+                    <span className="ar-executed">executed</span>
+                    <span className="ar-no-review">no review</span>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="ar-footer">
+          <span className="ar-warn-dot" />
+          <span>0 commands reviewed &middot; 0 blocked</span>
+        </div>
+      </div>
+
+      <style>{`
+        .ar-root { width: 100%; }
+        .ar-mock { border-radius: 12px; overflow: hidden; transition: opacity 0.5s ease; }
+        .ar-fadeout { opacity: 0; }
+        .ar-title { font-family: var(--mono); font-size: 11px; color: rgba(var(--sand-100-rgb),0.2); }
+
+        .ar-stream { padding: 12px 16px; display: flex; flex-direction: column; gap: 6px; min-height: 220px; }
+
+        .ar-line { opacity: 0; transition: opacity 0.3s ease; }
+        .ar-line.ar-done, .ar-line.ar-typing { opacity: 1; }
+
+        .ar-cmd-row { display: flex; align-items: center; gap: 8px; }
+        .ar-prompt { font-family: var(--mono); font-size: 11px; color: rgba(var(--warm-gold-rgb),0.5); flex-shrink: 0; }
+        .ar-cmd { font-family: var(--mono); font-size: 12px; color: rgba(var(--sand-100-rgb),0.6); }
+        .ar-cursor {
+          display: inline-block; width: 6px; height: 13px;
+          background: rgba(var(--sand-100-rgb),0.5); margin-left: 1px;
+          animation: ar-blink 1s step-end infinite;
+        }
+        @keyframes ar-blink { 0%,100%{opacity:1} 50%{opacity:0} }
+
+        .ar-result {
+          display: flex; align-items: center; gap: 8px;
+          padding: 2px 0 4px 52px;
+          font-family: var(--sans); font-size: 10px;
+        }
+        .ar-risk {
+          font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em;
+          border: 1px solid; border-radius: 3px; padding: 1px 6px;
+          font-size: 9px;
+        }
+        .ar-executed { color: rgba(var(--sand-100-rgb),0.3); }
+        .ar-no-review { color: rgba(var(--sand-100-rgb),0.15); font-style: italic; }
+
+        .ar-footer {
+          display: flex; align-items: center; gap: 7px;
+          padding: 10px 16px; border-top: 1px solid rgba(var(--sand-100-rgb),0.06);
+          font-family: var(--sans); font-size: 11px; color: rgba(var(--sand-100-rgb),0.2);
+        }
+        .ar-warn-dot {
+          width: 6px; height: 6px; border-radius: 50%;
+          background: var(--error); opacity: 0.6;
+          animation: ar-wp 1.5s ease-in-out infinite;
+        }
+        @keyframes ar-wp { 0%,100%{opacity:.4} 50%{opacity:1} }
+      `}</style>
+    </div>
+  );
+}

--- a/snippets/annimations/AuditTrailDemo.jsx
+++ b/snippets/annimations/AuditTrailDemo.jsx
@@ -1,0 +1,543 @@
+export const AuditTrailDemo = () => {
+  const COLORS = {
+    espresso: "var(--gradient-dark-mid)",
+    bronzeDark: "var(--bronze-dark)",
+    bronze: "var(--bronze)",
+    warmGold: "var(--warm-gold)",
+    sand100: "var(--sand-100)",
+    sand200: "var(--sand-200)",
+    sand300: "var(--sand-300)",
+    sand400: "var(--sand-400)",
+    sand500: "var(--sand-500)",
+    nearBlack: "#111111",
+    strong: "#333333",
+    body: "#555555",
+    secondary: "#777777",
+    muted: "#999999",
+    error: "#E05A47",
+  };
+
+  const COMMANDS = [
+    {
+      prompt: "claude-agent@prod $",
+      cmd: " SELECT id, name, email, role FROM users WHERE active = true;",
+      resultType: "passed",
+      resultLabel: "passed",
+      detail: "4 fields masked",
+      detailColor: COLORS.warmGold,
+    },
+    {
+      prompt: "claude-agent@prod $",
+      cmd: " kubectl get pods -n payments",
+      resultType: "passed",
+      resultLabel: "passed",
+      detail: null,
+      detailColor: null,
+    },
+    {
+      prompt: "claude-agent@prod $",
+      cmd: " DROP TABLE customers;",
+      resultType: "blocked",
+      resultLabel: "blocked",
+      detail: "destructive operation",
+      detailColor: COLORS.error,
+    },
+    {
+      prompt: "claude-agent@prod $",
+      cmd: " kubectl set image deploy/payments api=api:v2.3.1",
+      resultType: "pending-approved",
+      pendingLabel: "pending review...",
+      approvedLabel: "approved by @sarah.chen",
+      detail: null,
+      detailColor: null,
+    },
+    {
+      prompt: "claude-agent@prod $",
+      cmd: " kubectl rollout status deploy/payments",
+      resultType: "passed",
+      resultLabel: "passed",
+      detail: null,
+      detailColor: null,
+    },
+  ];
+
+  const SESSION_META = {
+    agent: "claude-code-agent",
+    connection: "prod-us-east (Kubernetes)",
+    started: "Mar 21, 2026 · 14:23 UTC",
+    duration: "47s",
+    status: "Completed",
+    summary: "5 commands · 1 blocked · 1 approved · 4 fields masked",
+  };
+
+  /* ── Typewriter hook ── */
+  function useTypewriter(text, speed = 32, startDelay = 0, active = false) {
+    const [displayed, setDisplayed] = useState("");
+    const [done, setDone] = useState(false);
+    const timerRef = useRef(null);
+    const intervalRef = useRef(null);
+
+    useEffect(() => {
+      if (!active) {
+        if (!done) { setDisplayed(""); setDone(false); }
+        return;
+      }
+      setDisplayed(""); setDone(false);
+      let i = 0;
+      timerRef.current = setTimeout(() => {
+        intervalRef.current = setInterval(() => {
+          i++;
+          setDisplayed(text.slice(0, i));
+          if (i >= text.length) {
+            clearInterval(intervalRef.current);
+            setDone(true);
+          }
+        }, speed);
+      }, startDelay);
+      return () => {
+        clearTimeout(timerRef.current);
+        clearInterval(intervalRef.current);
+      };
+    }, [text, speed, startDelay, active]);
+
+    return { displayed, done };
+  }
+
+  /* ── Playback bar ── */
+  function PlaybackBar({ progress, elapsed, total }) {
+    return (
+      <div style={{
+        display: "flex", alignItems: "center", gap: 10,
+        padding: "10px 18px",
+        background: "rgba(0,0,0,0.25)",
+        borderTop: "1px solid rgba(var(--sand-100-rgb),0.06)",
+        fontFamily: "'JetBrains Mono', monospace",
+        fontSize: 11,
+      }}>
+        <svg width="12" height="14" viewBox="0 0 12 14" fill="none">
+          <path d="M1.5 1v12l9.5-6L1.5 1z" fill={COLORS.warmGold} opacity={0.6} />
+        </svg>
+        <span style={{ color: "rgba(var(--sand-100-rgb),0.35)", minWidth: 38 }}>{elapsed}</span>
+        <div style={{
+          flex: 1, height: 3, borderRadius: 2,
+          background: "rgba(var(--sand-100-rgb),0.08)",
+          overflow: "hidden",
+        }}>
+          <div style={{
+            width: `${progress}%`, height: "100%",
+            background: `linear-gradient(90deg, ${COLORS.warmGold}, ${COLORS.bronze})`,
+            borderRadius: 2, transition: "width 0.4s linear",
+          }} />
+        </div>
+        <span style={{ color: "rgba(var(--sand-100-rgb),0.2)", minWidth: 38, textAlign: "right" }}>{total}</span>
+      </div>
+    );
+  }
+
+  /* ── Meta sidebar ── */
+  function MetaPanel({ visible }) {
+    const rows = [
+      { label: "AGENT", value: SESSION_META.agent },
+      { label: "CONNECTION", value: SESSION_META.connection },
+      { label: "STARTED", value: SESSION_META.started },
+      { label: "DURATION", value: SESSION_META.duration },
+      { label: "STATUS", value: SESSION_META.status, badge: true },
+      { label: "SUMMARY", value: SESSION_META.summary },
+    ];
+    return (
+      <div style={{
+        width: 210, flexShrink: 0,
+        background: "rgba(0,0,0,0.18)",
+        borderLeft: "1px solid rgba(var(--sand-100-rgb),0.06)",
+        padding: "18px 16px",
+        display: "flex", flexDirection: "column", gap: 14,
+        opacity: visible ? 1 : 0,
+        transform: visible ? "translateX(0)" : "translateX(16px)",
+        transition: "opacity 0.6s ease, transform 0.6s ease",
+        fontFamily: "'DM Sans', sans-serif",
+        overflow: "hidden",
+      }}>
+        <div style={{
+          fontSize: 10, fontWeight: 600, letterSpacing: "0.1em",
+          color: COLORS.warmGold, textTransform: "uppercase",
+          paddingBottom: 6,
+          borderBottom: "1px solid rgba(var(--sand-100-rgb),0.06)",
+        }}>Session Details</div>
+        {rows.map((r, i) => (
+          <div key={i} style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+            <span style={{
+              fontSize: 9, fontWeight: 600, letterSpacing: "0.08em",
+              color: "rgba(var(--sand-100-rgb),0.25)", textTransform: "uppercase",
+            }}>{r.label}</span>
+            {r.badge ? (
+              <span style={{
+                display: "inline-block", width: "fit-content",
+                fontSize: 10, fontWeight: 600,
+                padding: "2px 8px", borderRadius: 99,
+                background: "rgba(var(--warm-gold-rgb),0.15)",
+                color: COLORS.warmGold,
+              }}>{r.value}</span>
+            ) : (
+              <span style={{ fontSize: 12, color: "rgba(var(--sand-100-rgb),0.6)", lineHeight: 1.4 }}>
+                {r.value}
+              </span>
+            )}
+          </div>
+        ))}
+        <div style={{ display: "flex", flexDirection: "column", gap: 5, marginTop: 2 }}>
+          <span style={{
+            fontSize: 9, fontWeight: 600, letterSpacing: "0.08em",
+            color: "rgba(var(--sand-100-rgb),0.25)", textTransform: "uppercase",
+          }}>TAGS</span>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
+            {["production", "kubernetes", "claude-code"].map(tag => (
+              <span key={tag} style={{
+                fontSize: 10, padding: "2px 7px", borderRadius: 4,
+                background: "rgba(var(--sand-100-rgb),0.06)",
+                color: "rgba(var(--sand-100-rgb),0.3)",
+                border: "1px solid rgba(var(--sand-100-rgb),0.08)",
+              }}>{tag}</span>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  /* ── Recording dot ── */
+  function RecordingDot({ active }) {
+    return (
+      <div style={{
+        display: "flex", alignItems: "center", gap: 6,
+        opacity: active ? 1 : 0.3, transition: "opacity 0.4s ease",
+      }}>
+        <div style={{
+          width: 7, height: 7, borderRadius: "50%",
+          background: active ? "#E05A47" : "rgba(var(--sand-100-rgb),0.2)",
+          boxShadow: active ? "0 0 8px rgba(224,90,71,0.4)" : "none",
+          animation: active ? "atdRecPulse 1.4s ease-in-out infinite" : "none",
+        }} />
+        <span style={{
+          fontSize: 10, fontWeight: 600, letterSpacing: "0.06em",
+          color: active ? "rgba(var(--sand-100-rgb),0.45)" : "rgba(var(--sand-100-rgb),0.15)",
+          textTransform: "uppercase", fontFamily: "'DM Sans', sans-serif",
+        }}>REC</span>
+      </div>
+    );
+  }
+
+  /* ── Command line with typewriter + inline result ── */
+  function CommandLine({ entry, animate, onDone, delay = 0, approved, cycle }) {
+    const [showResult, setShowResult] = useState(false);
+    const [showApproved, setShowApproved] = useState(false);
+
+    const { displayed: cmdText, done: cmdDone } = useTypewriter(
+      entry.cmd, 28, delay, animate
+    );
+
+    const resultColorMap = {
+      passed: "rgba(var(--sand-100-rgb),0.3)",
+      blocked: COLORS.error,
+      "pending-approved": COLORS.warmGold,
+    };
+
+    // Show result after typing finishes
+    useEffect(() => {
+      if (cmdDone) {
+        const t = setTimeout(() => {
+          setShowResult(true);
+          if (entry.resultType === "pending-approved") {
+            // Show pending first, then after delay flip to approved
+            const t2 = setTimeout(() => {
+              setShowApproved(true);
+              setTimeout(() => onDone?.(), 300);
+            }, 1200);
+            return () => clearTimeout(t2);
+          } else {
+            const t2 = setTimeout(() => onDone?.(), 400);
+            return () => clearTimeout(t2);
+          }
+        }, 250);
+        return () => clearTimeout(t);
+      }
+    }, [cmdDone]);
+
+    // Sync approved state from parent for re-renders
+    useEffect(() => {
+      if (approved && entry.resultType === "pending-approved") {
+        setShowApproved(true);
+      }
+    }, [approved]);
+
+    return (
+      <div style={{ marginBottom: 2 }}>
+        {/* Prompt + command */}
+        <div style={{
+          display: "flex", lineHeight: 2.0, whiteSpace: "pre",
+          background: entry.resultType === "blocked" && showResult
+            ? "rgba(224,90,71,0.05)" : "transparent",
+          borderRadius: 4,
+          paddingLeft: 2, paddingRight: 2,
+          transition: "background 0.4s ease",
+        }}>
+          <span style={{ color: COLORS.warmGold, opacity: 0.7 }}>{entry.prompt}</span>
+          <span style={{ color: COLORS.sand100, opacity: 0.85 }}>{cmdText}</span>
+          {animate && !cmdDone && (
+            <span style={{
+              display: "inline-block", width: 7, height: 15,
+              background: COLORS.warmGold, marginLeft: 1,
+              animation: "atdBlink 0.7s step-end infinite",
+              verticalAlign: "middle", marginTop: 5,
+              borderRadius: 1,
+            }} />
+          )}
+        </div>
+
+        {/* Result line */}
+        {showResult && (
+          <div style={{
+            paddingLeft: 20, lineHeight: 1.8,
+            opacity: 0,
+            animation: "atdFadeInLine 0.3s ease forwards",
+            display: "flex", alignItems: "center", gap: 8,
+          }}>
+            {entry.resultType === "passed" && (
+              <>
+                <span style={{
+                  fontSize: 12,
+                  color: resultColorMap.passed,
+                  fontFamily: "'JetBrains Mono', monospace",
+                }}>{entry.resultLabel}</span>
+                {entry.detail && (
+                  <span style={{
+                    fontSize: 10, fontWeight: 600,
+                    padding: "1px 7px", borderRadius: 3,
+                    background: "rgba(var(--warm-gold-rgb),0.12)",
+                    color: entry.detailColor,
+                    fontFamily: "'DM Sans', sans-serif",
+                  }}>{entry.detail}</span>
+                )}
+              </>
+            )}
+            {entry.resultType === "blocked" && (
+              <>
+                <span style={{
+                  fontSize: 12, fontWeight: 500,
+                  color: COLORS.error,
+                  fontFamily: "'JetBrains Mono', monospace",
+                }}>{entry.resultLabel}</span>
+                {entry.detail && (
+                  <span style={{
+                    fontSize: 10, fontWeight: 600,
+                    padding: "1px 7px", borderRadius: 3,
+                    background: "rgba(224,90,71,0.12)",
+                    color: COLORS.error,
+                    fontFamily: "'DM Sans', sans-serif",
+                    opacity: 0.7,
+                  }}>{entry.detail}</span>
+                )}
+              </>
+            )}
+            {entry.resultType === "pending-approved" && (
+              <span style={{
+                fontSize: 12,
+                color: COLORS.warmGold,
+                fontFamily: "'JetBrains Mono', monospace",
+                transition: "opacity 0.3s ease",
+              }}>
+                {showApproved ? entry.approvedLabel : entry.pendingLabel}
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  const [phase, setPhase] = useState(0);
+  const [metaVisible, setMetaVisible] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [cycle, setCycle] = useState(0);
+  const [approvedMap, setApprovedMap] = useState({});
+  const termRef = useRef(null);
+  const totalSteps = COMMANDS.length;
+
+  const handleLineDone = useCallback((index) => {
+    setPhase(p => {
+      const next = p + 1;
+      setProgress((next / totalSteps) * 100);
+      return next;
+    });
+    // Mark pending-approved entries as approved when their line finishes
+    if (COMMANDS[index] && COMMANDS[index].resultType === "pending-approved") {
+      setApprovedMap(m => ({ ...m, [index]: true }));
+    }
+  }, [totalSteps]);
+
+  useEffect(() => {
+    const t = setTimeout(() => setMetaVisible(true), 900);
+    return () => clearTimeout(t);
+  }, [cycle]);
+
+  useEffect(() => {
+    if (termRef.current) {
+      termRef.current.scrollTop = termRef.current.scrollHeight;
+    }
+  }, [phase]);
+
+  // Loop: hold 4s after complete, then reset
+  useEffect(() => {
+    if (phase >= totalSteps) {
+      const t = setTimeout(() => {
+        setPhase(0);
+        setProgress(0);
+        setMetaVisible(false);
+        setApprovedMap({});
+        setCycle(c => c + 1);
+      }, 4000);
+      return () => clearTimeout(t);
+    }
+  }, [phase, totalSteps]);
+
+  const fmtTime = (pct) => {
+    const s = Math.round((pct / 100) * 47);
+    return `0:${String(s).padStart(2, "0")}`;
+  };
+
+  return (
+    <div style={{ width: "100%", maxWidth: 860, margin: "0 auto" }}>
+      <style>{`
+        @import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&family=Sora:wght@600;700;800&display=swap');
+        @keyframes atdBlink { 0%,100%{opacity:1} 50%{opacity:0} }
+        @keyframes atdRecPulse { 0%,100%{opacity:1;transform:scale(1)} 50%{opacity:0.3;transform:scale(0.85)} }
+        @keyframes atdFadeInLine { from{opacity:0;transform:translateY(2px)} to{opacity:1;transform:translateY(0)} }
+        @keyframes atdSlideUp { from{opacity:0;transform:translateY(8px)} to{opacity:1;transform:translateY(0)} }
+      `}</style>
+
+      {/* Outer frame */}
+      <div style={{
+        background: "linear-gradient(135deg, var(--gradient-dark-start) 0%, var(--gradient-dark-mid) 35%, var(--gradient-dark-end) 70%, var(--bronze) 100%)",
+        borderRadius: 12,
+        position: "relative",
+        overflow: "hidden",
+        boxShadow: "0 4px 32px rgba(0,0,0,0.3), 0 1px 4px rgba(0,0,0,0.2)",
+      }}>
+        {/* Radial glow overlay */}
+        <div style={{
+          position: "absolute", top: "-30%", right: "-10%",
+          width: "60%", height: "160%",
+          background: "radial-gradient(ellipse at center, rgba(var(--warm-gold-rgb),0.12) 0%, transparent 70%)",
+          pointerEvents: "none", zIndex: 0,
+        }} />
+
+        <div style={{
+          position: "relative", zIndex: 1,
+          fontFamily: "'JetBrains Mono', monospace", fontSize: 13,
+        }}>
+          {/* Toolbar */}
+          <div style={{
+            display: "flex", alignItems: "center", justifyContent: "space-between",
+            padding: "11px 18px",
+            background: "rgba(0,0,0,0.2)",
+            borderBottom: "1px solid rgba(var(--sand-100-rgb),0.06)",
+          }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 7 }}>
+              <div style={{ width: 9, height: 9, borderRadius: "50%", background: "rgba(var(--sand-100-rgb),0.12)" }} />
+              <div style={{ width: 9, height: 9, borderRadius: "50%", background: "rgba(var(--sand-100-rgb),0.12)" }} />
+              <div style={{ width: 9, height: 9, borderRadius: "50%", background: "rgba(var(--sand-100-rgb),0.12)" }} />
+            </div>
+            <div style={{
+              display: "flex", alignItems: "center", gap: 8,
+              padding: "4px 14px", borderRadius: 5,
+              background: "rgba(0,0,0,0.15)",
+              border: "1px solid rgba(var(--sand-100-rgb),0.04)",
+              fontSize: 11, color: "rgba(var(--sand-100-rgb),0.25)",
+              fontFamily: "'DM Sans', sans-serif",
+            }}>
+              <svg width="10" height="10" viewBox="0 0 16 16" fill="none">
+                <rect x="2" y="7" width="12" height="2" rx="1" fill="rgba(var(--sand-100-rgb),0.15)" />
+                <rect x="7" y="2" width="2" height="12" rx="1" fill="rgba(var(--sand-100-rgb),0.15)" />
+              </svg>
+              app.hoop.dev/sessions/claude-7f3a
+            </div>
+            <RecordingDot active={phase < totalSteps} />
+          </div>
+
+          {/* Tabs */}
+          <div style={{
+            display: "flex", gap: 0,
+            background: "rgba(0,0,0,0.12)",
+            borderBottom: "1px solid rgba(var(--sand-100-rgb),0.06)",
+            fontFamily: "'DM Sans', sans-serif", fontSize: 12,
+          }}>
+            {["Commands", "Timeline", "Replay"].map((tab, i) => (
+              <div key={tab} style={{
+                padding: "9px 20px",
+                color: i === 0 ? "rgba(var(--sand-100-rgb),0.75)" : "rgba(var(--sand-100-rgb),0.2)",
+                borderBottom: i === 0 ? `2px solid ${COLORS.warmGold}` : "2px solid transparent",
+                background: i === 0 ? "rgba(var(--sand-100-rgb),0.02)" : "transparent",
+                cursor: "default",
+              }}>{tab}</div>
+            ))}
+          </div>
+
+          {/* Main content */}
+          <div style={{
+            display: "flex",
+            background: "rgba(0,0,0,0.10)",
+            minHeight: 340,
+          }}>
+            {/* Terminal area */}
+            <div
+              ref={termRef}
+              style={{
+                flex: 1, padding: "20px 22px",
+                overflowY: "auto", overflowX: "hidden",
+                maxHeight: 340, scrollbarWidth: "none",
+              }}
+            >
+              {COMMANDS.filter((_, i) => i <= phase).map((entry, i) => (
+                <CommandLine
+                  key={`${cycle}-${i}`}
+                  entry={entry}
+                  animate={phase === i}
+                  onDone={() => handleLineDone(i)}
+                  delay={i === 0 ? 700 : 200}
+                  approved={!!approvedMap[i]}
+                  cycle={cycle}
+                />
+              ))}
+
+              {/* Session complete banner */}
+              {phase >= totalSteps && (
+                <div style={{
+                  marginTop: 18, padding: "10px 14px",
+                  borderRadius: 6,
+                  background: "rgba(var(--warm-gold-rgb),0.08)",
+                  border: "1px solid rgba(var(--warm-gold-rgb),0.15)",
+                  display: "flex", alignItems: "center", gap: 8,
+                  animation: "atdSlideUp 0.5s ease forwards",
+                }}>
+                  <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+                    <circle cx="7" cy="7" r="5.5" stroke={COLORS.warmGold} strokeWidth="1" opacity={0.5} />
+                    <path d="M4.5 7l1.8 1.8L9.5 5.5" stroke={COLORS.warmGold} strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" fill="none" />
+                  </svg>
+                  <span style={{
+                    fontSize: 12, color: COLORS.warmGold, opacity: 0.8,
+                    fontFamily: "'DM Sans', sans-serif",
+                  }}>Session recorded. 5 commands, 4 fields masked.</span>
+                </div>
+              )}
+            </div>
+
+            {/* Sidebar */}
+            <MetaPanel visible={metaVisible} />
+          </div>
+
+          {/* Playback bar */}
+          <PlaybackBar progress={progress} elapsed={fmtTime(progress)} total="0:47" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/snippets/annimations/BlindSpotAnimation.jsx
+++ b/snippets/annimations/BlindSpotAnimation.jsx
@@ -1,0 +1,258 @@
+/**
+ * BlindSpotAnimation — Visualizes unprotected data flowing through a wire
+ *
+ * Used in: app/page.jsx (The Blind Spot section)
+ *
+ * Shows a live data stream with sensitive values (SSNs, emails, credit cards)
+ * flowing through undetected. A status bar shows "0 threats detected" while
+ * sensitive data streams past — conveying the blind spot visually.
+ *
+ * Phases:
+ *   1. Data packets stream left-to-right through a wire
+ *   2. Some packets briefly flash to reveal sensitive content
+ *   3. Status bar stays at "0 detected" — nothing is catching it
+ *   4. Loop
+ *
+ * Pure CSS keyframes + React state — no external animation library.
+ */
+
+export const BlindSpotAnimation = () => {
+  const STREAM_ITEMS = [
+    { id: 0, type: 'safe',      label: 'SELECT name FROM users',          delay: 0 },
+    { id: 1, type: 'sensitive',  label: '→ 123-45-6789',                   delay: 600 },
+    { id: 2, type: 'safe',      label: 'GET /api/v1/health',              delay: 1100 },
+    { id: 3, type: 'sensitive',  label: '→ alice@corp.com',                delay: 1700 },
+    { id: 4, type: 'safe',      label: 'kubectl get pods -n prod',        delay: 2200 },
+    { id: 5, type: 'sensitive',  label: '→ 4532-XXXX-XXXX-8821',          delay: 2900 },
+    { id: 6, type: 'safe',      label: 'UPDATE sessions SET token=...',   delay: 3400 },
+    { id: 7, type: 'sensitive',  label: '→ SSN: 987-65-4321',             delay: 4000 },
+  ];
+
+  const CYCLE_DURATION = 5200;
+
+  const [cycle, setCycle]           = useState(0);
+  const [visibleItems, setVisible]  = useState(new Set());
+  const [flashItems, setFlash]      = useState(new Set());
+  const timers                      = useRef([]);
+
+  function T(fn, delay) {
+    const id = setTimeout(fn, delay);
+    timers.current.push(id);
+  }
+
+  useEffect(() => {
+    timers.current.forEach(clearTimeout);
+    timers.current = [];
+    setVisible(new Set());
+    setFlash(new Set());
+
+    STREAM_ITEMS.forEach((item) => {
+      // Appear
+      T(() => setVisible((prev) => new Set([...prev, item.id])), item.delay);
+
+      // Flash sensitive items briefly
+      if (item.type === 'sensitive') {
+        T(() => setFlash((prev) => new Set([...prev, item.id])), item.delay + 200);
+        T(() => setFlash((prev) => {
+          const next = new Set(prev);
+          next.delete(item.id);
+          return next;
+        }), item.delay + 700);
+      }
+    });
+
+    // Reset cycle
+    T(() => setCycle((c) => c + 1), CYCLE_DURATION);
+
+    return () => timers.current.forEach(clearTimeout);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cycle]);
+
+  return (
+    <div className="bs-root" aria-hidden="true">
+      <div className="mock-container bs-mock">
+
+        {/* Toolbar */}
+        <div className="mock-toolbar" style={{ justifyContent: 'space-between' }}>
+          <div style={{ display: 'flex', gap: 6 }}>
+            <div className="mock-dot" />
+            <div className="mock-dot" />
+            <div className="mock-dot" />
+          </div>
+          <span className="bs-title">network traffic · live</span>
+          <span style={{ width: 48 }} />
+        </div>
+
+        {/* Stream */}
+        <div className="bs-stream">
+          {STREAM_ITEMS.map((item) => {
+            const show = visibleItems.has(item.id);
+            const flash = flashItems.has(item.id);
+            const isSensitive = item.type === 'sensitive';
+
+            return (
+              <div
+                key={item.id}
+                className={`bs-packet${show ? ' bs-visible' : ''}${flash ? ' bs-flash' : ''}${isSensitive ? ' bs-sensitive' : ''}`}
+              >
+                <span className="bs-dot-indicator" />
+                <span className="bs-packet-text">{item.label}</span>
+                {isSensitive && <span className="bs-tag">PII</span>}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Status bar — always shows 0 */}
+        <div className="bs-status">
+          <div className="bs-status-left">
+            <span className="bs-status-dot" />
+            <span>Monitoring</span>
+          </div>
+          <div className="bs-status-right">
+            <span className="bs-counter">0 threats detected</span>
+          </div>
+        </div>
+      </div>
+
+      <style>{`
+        .bs-root {
+          position: relative;
+          width: 100%;
+        }
+
+        .bs-mock {
+          border-radius: 12px;
+          overflow: hidden;
+        }
+
+        .bs-title {
+          font-family: var(--mono);
+          font-size: 11px;
+          color: rgba(var(--sand-100-rgb), 0.2);
+        }
+
+        /* Stream area */
+        .bs-stream {
+          padding: 12px 16px;
+          display: flex;
+          flex-direction: column;
+          gap: 2px;
+          min-height: 240px;
+        }
+
+        .bs-packet {
+          display: flex;
+          align-items: center;
+          gap: 10px;
+          padding: 6px 12px;
+          border-radius: 4px;
+          opacity: 0;
+          transform: translateX(-8px);
+          transition: opacity 0.3s ease, transform 0.3s ease, background 0.25s ease;
+        }
+
+        .bs-packet.bs-visible {
+          opacity: 1;
+          transform: translateX(0);
+        }
+
+        .bs-packet.bs-flash {
+          background: rgba(var(--warm-gold-rgb), 0.08);
+        }
+
+        .bs-dot-indicator {
+          width: 5px;
+          height: 5px;
+          border-radius: 50%;
+          background: rgba(var(--sand-100-rgb), 0.15);
+          flex-shrink: 0;
+        }
+
+        .bs-sensitive .bs-dot-indicator {
+          background: rgba(var(--warm-gold-rgb), 0.4);
+        }
+
+        .bs-flash .bs-dot-indicator {
+          background: var(--warm-gold);
+        }
+
+        .bs-packet-text {
+          font-family: var(--mono);
+          font-size: 12px;
+          color: rgba(var(--sand-100-rgb), 0.4);
+          white-space: nowrap;
+        }
+
+        .bs-sensitive .bs-packet-text {
+          color: rgba(var(--sand-100-rgb), 0.5);
+        }
+
+        .bs-flash .bs-packet-text {
+          color: rgba(var(--warm-gold-rgb), 0.8);
+        }
+
+        .bs-tag {
+          font-family: var(--sans);
+          font-size: 9px;
+          font-weight: 600;
+          text-transform: uppercase;
+          letter-spacing: 0.05em;
+          color: rgba(var(--warm-gold-rgb), 0.5);
+          background: rgba(var(--warm-gold-rgb), 0.06);
+          padding: 1px 6px;
+          border-radius: 3px;
+          opacity: 0;
+          transition: opacity 0.3s ease;
+        }
+
+        .bs-flash .bs-tag {
+          opacity: 1;
+        }
+
+        /* Status bar */
+        .bs-status {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          padding: 10px 16px;
+          border-top: 1px solid rgba(var(--sand-100-rgb), 0.06);
+          font-family: var(--sans);
+          font-size: 11px;
+        }
+
+        .bs-status-left {
+          display: flex;
+          align-items: center;
+          gap: 7px;
+          color: rgba(var(--sand-100-rgb), 0.25);
+        }
+
+        .bs-status-dot {
+          width: 6px;
+          height: 6px;
+          border-radius: 50%;
+          background: rgba(var(--sand-100-rgb), 0.15);
+          animation: bs-pulse 2s ease-in-out infinite;
+        }
+
+        @keyframes bs-pulse {
+          0%, 100% { opacity: 0.5; }
+          50%      { opacity: 1; }
+        }
+
+        .bs-status-right {
+          display: flex;
+          align-items: center;
+          gap: 6px;
+        }
+
+        .bs-counter {
+          font-family: var(--mono);
+          font-size: 11px;
+          color: rgba(var(--sand-100-rgb), 0.2);
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/snippets/annimations/ComplianceDashboard.jsx
+++ b/snippets/annimations/ComplianceDashboard.jsx
@@ -1,0 +1,327 @@
+/**
+ * ComplianceDashboard — Enterprise compliance posture animation
+ *
+ * Before/after visualization: compliance gaps → resolved by Hoop.
+ * Targets C-level / VP audience who think in frameworks, not code.
+ *
+ * Phase 1 (before): Low score, gaps in controls, action items
+ * Phase 2 (after):  Score rises, controls flip to passing, gaps close
+ *
+ * Fixed height: 480px. Dark theme (lives in mood-dark or dark wrapper).
+ */
+
+export const ComplianceDashboard = () => {
+  const FRAMEWORKS = ['SOC 2', 'GDPR', 'PCI DSS', 'HIPAA'];
+
+  const CONTROLS = [
+    { id: 'CC6.1', label: 'Logical Access Security', category: 'Access Control', before: true, after: true },
+    { id: 'CC6.3', label: 'Data-in-Transit Encryption', category: 'Data Protection', before: true, after: true },
+    { id: 'CC6.6', label: 'Session-Level Access Controls', category: 'Access Control', before: false, after: true },
+    { id: 'CC6.7', label: 'Data Masking & Redaction', category: 'Data Protection', before: false, after: true },
+    { id: 'CC7.2', label: 'Anomaly Detection & Monitoring', category: 'Monitoring', before: false, after: true },
+    { id: 'CC8.1', label: 'Audit Trail & Evidence', category: 'Audit Trail', before: false, after: true },
+  ];
+
+  const CATEGORIES = [
+    { label: 'Identity', before: '3/4', after: '4/4', beforePct: 75, afterPct: 100 },
+    { label: 'Audit Trail', before: '3/6', after: '6/6', beforePct: 50, afterPct: 100 },
+    { label: 'Access Control', before: '2/6', after: '5/6', beforePct: 33, afterPct: 83 },
+    { label: 'Data Protection', before: '2/6', after: '6/6', beforePct: 33, afterPct: 100 },
+    { label: 'Monitoring', before: '3/5', after: '5/5', beforePct: 60, afterPct: 100 },
+  ];
+
+  const BEFORE_SCORE = 52;
+  const AFTER_SCORE = 94;
+
+  function AnimatedScore({ target, active }) {
+    const [value, setValue] = useState(0);
+    const ref = useRef(null);
+
+    useEffect(() => {
+      if (!active) { setValue(0); return; }
+      let current = 0;
+      const step = target / 40;
+      ref.current = setInterval(() => {
+        current += step;
+        if (current >= target) {
+          current = target;
+          clearInterval(ref.current);
+        }
+        setValue(Math.round(current));
+      }, 30);
+      return () => clearInterval(ref.current);
+    }, [target, active]);
+
+    return value;
+  }
+
+  const [isAfter, setIsAfter] = useState(false);
+  const [animating, setAnimating] = useState(false);
+  const timer = useRef(null);
+  const mounted = useRef(true);
+
+  useEffect(() => {
+    mounted.current = true;
+
+    function cycle() {
+      if (!mounted.current) return;
+      // Show "before" for 4s, then flip to "after" for 5s, then reset
+      setIsAfter(false);
+      setAnimating(true);
+
+      timer.current = setTimeout(() => {
+        if (!mounted.current) return;
+        setIsAfter(true);
+
+        timer.current = setTimeout(() => {
+          if (!mounted.current) return;
+          cycle();
+        }, 5500);
+      }, 3500);
+    }
+
+    cycle();
+    return () => { mounted.current = false; clearTimeout(timer.current); };
+  }, []);
+
+  const score = isAfter ? AFTER_SCORE : BEFORE_SCORE;
+  const scoreColor = isAfter ? 'var(--success)' : 'var(--warm-gold)';
+  const circumference = 2 * Math.PI * 42;
+  const strokeDashoffset = circumference - (circumference * score) / 100;
+
+  return (
+    <div style={{
+      height: 480,
+      background: 'rgba(var(--sand-100-rgb),0.03)',
+      border: '1px solid rgba(var(--sand-100-rgb),0.06)',
+      borderRadius: 14,
+      overflow: 'hidden',
+      display: 'flex',
+      flexDirection: 'column',
+    }}>
+      {/* Header */}
+      <div style={{
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+        padding: '14px 24px',
+        borderBottom: '1px solid rgba(var(--sand-100-rgb),0.06)',
+        background: 'rgba(var(--sand-100-rgb),0.02)',
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+            <rect x="1" y="1" width="14" height="14" rx="3" stroke="rgba(var(--sand-100-rgb),0.3)" strokeWidth="1.2"/>
+            <path d="M4.5 8.5L7 11L11.5 5.5" stroke={scoreColor} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+          </svg>
+          <span style={{
+            fontFamily: 'var(--sans)', fontSize: 13, fontWeight: 600,
+            color: 'var(--sand-100)',
+          }}>
+            Compliance Report
+          </span>
+        </div>
+
+        {/* Before/After toggle */}
+        <div style={{
+          display: 'flex', alignItems: 'center',
+          background: 'rgba(var(--sand-100-rgb),0.04)',
+          borderRadius: 6, overflow: 'hidden',
+          border: '1px solid rgba(var(--sand-100-rgb),0.06)',
+        }}>
+          <span style={{
+            fontFamily: 'var(--sans)', fontSize: 10, fontWeight: 600,
+            padding: '5px 12px',
+            color: !isAfter ? 'var(--sand-100)' : 'rgba(var(--sand-100-rgb),0.3)',
+            background: !isAfter ? 'rgba(var(--sand-100-rgb),0.08)' : 'transparent',
+            transition: 'all 0.3s',
+          }}>
+            Before
+          </span>
+          <span style={{
+            fontFamily: 'var(--sans)', fontSize: 10, fontWeight: 600,
+            padding: '5px 12px',
+            color: isAfter ? 'var(--warm-gold)' : 'rgba(var(--sand-100-rgb),0.3)',
+            background: isAfter ? 'rgba(var(--warm-gold-rgb),0.08)' : 'transparent',
+            transition: 'all 0.3s',
+          }}>
+            With Hoop
+          </span>
+        </div>
+      </div>
+
+      <div style={{ flex: 1, padding: '20px 24px', display: 'flex', flexDirection: 'column', gap: 20, overflow: 'hidden' }}>
+        {/* Top row: Score ring + category cards */}
+        <div style={{ display: 'flex', gap: 20, alignItems: 'flex-start' }}>
+          {/* Score ring */}
+          <div style={{ flexShrink: 0, textAlign: 'center', width: 120 }}>
+            <div style={{ position: 'relative', width: 100, height: 100, margin: '0 auto' }}>
+              <svg width="100" height="100" viewBox="0 0 100 100" style={{ transform: 'rotate(-90deg)' }}>
+                <circle cx="50" cy="50" r="42" fill="none" stroke="rgba(var(--sand-100-rgb),0.06)" strokeWidth="6"/>
+                <circle
+                  cx="50" cy="50" r="42" fill="none"
+                  stroke={scoreColor}
+                  strokeWidth="6"
+                  strokeLinecap="round"
+                  strokeDasharray={circumference}
+                  strokeDashoffset={strokeDashoffset}
+                  style={{ transition: 'stroke-dashoffset 1.2s ease-out, stroke 0.5s' }}
+                />
+              </svg>
+              <div style={{
+                position: 'absolute', inset: 0,
+                display: 'flex', flexDirection: 'column',
+                alignItems: 'center', justifyContent: 'center',
+              }}>
+                <span style={{
+                  fontFamily: 'var(--display)', fontSize: 28, fontWeight: 800,
+                  color: 'var(--sand-100)', letterSpacing: '-0.03em',
+                  lineHeight: 1,
+                }}>
+                  <AnimatedScore target={score} active={animating} />
+                </span>
+                <span style={{
+                  fontFamily: 'var(--sans)', fontSize: 9,
+                  color: 'rgba(var(--sand-100-rgb),0.3)',
+                }}>/ 100</span>
+              </div>
+            </div>
+            <span style={{
+              fontFamily: 'var(--sans)', fontSize: 10,
+              color: isAfter ? 'rgba(var(--success-rgb),0.7)' : 'rgba(var(--warm-gold-rgb),0.7)',
+              fontWeight: 600,
+              display: 'block', marginTop: 8,
+              transition: 'color 0.5s',
+            }}>
+              {isAfter ? 'HIGH COMPLIANT' : 'GAPS DETECTED'}
+            </span>
+          </div>
+
+          {/* Category cards grid */}
+          <div style={{
+            flex: 1, display: 'grid',
+            gridTemplateColumns: 'repeat(3, 1fr)',
+            gap: 8,
+          }}>
+            {CATEGORIES.map((cat) => {
+              const val = isAfter ? cat.after : cat.before;
+              const pct = isAfter ? cat.afterPct : cat.beforePct;
+              const isFull = pct === 100;
+              return (
+                <div key={cat.label} style={{
+                  background: 'rgba(var(--sand-100-rgb),0.03)',
+                  border: '1px solid rgba(var(--sand-100-rgb),0.06)',
+                  borderRadius: 8,
+                  padding: '10px 12px',
+                }}>
+                  <span style={{
+                    fontFamily: 'var(--sans)', fontSize: 10, fontWeight: 500,
+                    color: 'rgba(var(--sand-100-rgb),0.4)',
+                    display: 'block', marginBottom: 6,
+                  }}>{cat.label}</span>
+                  <span style={{
+                    fontFamily: 'var(--display)', fontSize: 18, fontWeight: 700,
+                    color: isFull && isAfter ? 'rgba(var(--success-rgb),0.9)' : 'var(--sand-100)',
+                    transition: 'color 0.5s',
+                  }}>{val}</span>
+                  {/* Mini bar */}
+                  <div style={{
+                    height: 2, borderRadius: 1, marginTop: 8,
+                    background: 'rgba(var(--sand-100-rgb),0.06)',
+                    overflow: 'hidden',
+                  }}>
+                    <div style={{
+                      height: '100%', borderRadius: 1,
+                      width: `${pct}%`,
+                      background: isFull && isAfter ? 'var(--success)' : 'var(--warm-gold)',
+                      transition: 'width 1s ease-out, background 0.5s',
+                    }} />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Framework tabs */}
+        <div style={{ display: 'flex', gap: 0, borderBottom: '1px solid rgba(var(--sand-100-rgb),0.06)' }}>
+          {FRAMEWORKS.map((fw, i) => (
+            <span key={fw} style={{
+              fontFamily: 'var(--sans)', fontSize: 11, fontWeight: i === 0 ? 600 : 400,
+              color: i === 0 ? 'var(--sand-100)' : 'rgba(var(--sand-100-rgb),0.3)',
+              padding: '8px 16px',
+              borderBottom: i === 0 ? '2px solid var(--warm-gold)' : '2px solid transparent',
+            }}>
+              {fw}
+            </span>
+          ))}
+        </div>
+
+        {/* Controls list */}
+        <div style={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', gap: 0 }}>
+          {CONTROLS.map((ctrl, i) => {
+            const passing = isAfter ? ctrl.after : ctrl.before;
+            const wasGap = !ctrl.before && ctrl.after;
+            return (
+              <div key={ctrl.id} style={{
+                display: 'flex', alignItems: 'center', gap: 12,
+                padding: '8px 0',
+                borderBottom: i < CONTROLS.length - 1 ? '1px solid rgba(var(--sand-100-rgb),0.04)' : 'none',
+              }}>
+                {/* Status icon */}
+                <div style={{
+                  width: 20, height: 20, borderRadius: 5, flexShrink: 0,
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  background: passing
+                    ? 'rgba(var(--success-rgb),0.12)'
+                    : 'rgba(var(--error-rgb),0.10)',
+                  transition: 'background 0.5s',
+                  transitionDelay: `${i * 0.1}s`,
+                }}>
+                  {passing ? (
+                    <svg width="10" height="10" viewBox="0 0 12 12" fill="none">
+                      <path d="M2.5 6.5L5 9L9.5 3.5" stroke="var(--success)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+                    </svg>
+                  ) : (
+                    <svg width="10" height="10" viewBox="0 0 12 12" fill="none">
+                      <path d="M3 3l6 6M9 3l-6 6" stroke="rgba(var(--error-rgb),0.7)" strokeWidth="1.3" strokeLinecap="round"/>
+                    </svg>
+                  )}
+                </div>
+
+                {/* Control ID badge */}
+                <span style={{
+                  fontFamily: 'var(--mono)', fontSize: 10, fontWeight: 600,
+                  color: 'rgba(var(--sand-100-rgb),0.35)',
+                  background: 'rgba(var(--sand-100-rgb),0.04)',
+                  padding: '2px 8px', borderRadius: 4,
+                  flexShrink: 0,
+                }}>{ctrl.id}</span>
+
+                {/* Label */}
+                <span style={{
+                  fontFamily: 'var(--sans)', fontSize: 12, fontWeight: 400,
+                  color: passing ? 'rgba(var(--sand-100-rgb),0.7)' : 'rgba(var(--sand-100-rgb),0.4)',
+                  transition: 'color 0.5s',
+                  transitionDelay: `${i * 0.1}s`,
+                  flex: 1,
+                }}>{ctrl.label}</span>
+
+                {/* Category tag */}
+                <span style={{
+                  fontFamily: 'var(--sans)', fontSize: 9, fontWeight: 600,
+                  color: wasGap && isAfter ? 'rgba(var(--success-rgb),0.7)' : 'rgba(var(--sand-100-rgb),0.25)',
+                  background: wasGap && isAfter ? 'rgba(var(--success-rgb),0.08)' : 'rgba(var(--sand-100-rgb),0.04)',
+                  padding: '2px 8px', borderRadius: 99,
+                  transition: 'all 0.5s',
+                  transitionDelay: `${i * 0.1}s`,
+                  flexShrink: 0,
+                  textTransform: 'uppercase', letterSpacing: '0.04em',
+                }}>
+                  {wasGap && isAfter ? 'Resolved' : ctrl.category}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/snippets/annimations/ComplianceGapAnimation.jsx
+++ b/snippets/annimations/ComplianceGapAnimation.jsx
@@ -1,0 +1,125 @@
+/**
+ * ComplianceGapAnimation — Audit checklist with unanswered questions
+ *
+ * Shows a compliance audit checklist where questions appear one by one.
+ * Some get a green check (provable), but the critical ones get a red "?"
+ * or "NO PROOF" badge — conveying audit gaps.
+ *
+ * Pure CSS + React state.
+ */
+
+export const ComplianceGapAnimation = () => {
+  const CHECKS = [
+    { q: 'VPN access logs collected?',              status: 'pass' },
+    { q: 'Database audit logging enabled?',         status: 'pass' },
+    { q: 'Who saw data in query responses?',        status: 'fail' },
+    { q: 'What did AI agent do during access?',     status: 'fail' },
+    { q: 'PII masked when contractor queried DB?',  status: 'fail' },
+    { q: 'Session-level actions tied to identity?',  status: 'fail' },
+  ];
+
+  const ITEM_DELAY = 800;
+  const CYCLE_PAD = 2500;
+
+  const [cycle, setCycle]     = useState(0);
+  const [visible, setVisible] = useState(0);
+  const timers                = useRef([]);
+
+  function T(fn, ms) { const id = setTimeout(fn, ms); timers.current.push(id); }
+
+  useEffect(() => {
+    timers.current.forEach(clearTimeout);
+    timers.current = [];
+    setVisible(0);
+
+    CHECKS.forEach((_, i) => {
+      T(() => setVisible(i + 1), (i + 1) * ITEM_DELAY);
+    });
+
+    T(() => setCycle((c) => c + 1), CHECKS.length * ITEM_DELAY + CYCLE_PAD);
+    return () => timers.current.forEach(clearTimeout);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cycle]);
+
+  const failCount = CHECKS.filter((c) => c.status === 'fail').length;
+  const shownFails = CHECKS.slice(0, visible).filter((c) => c.status === 'fail').length;
+
+  return (
+    <div className="cg-root" aria-hidden="true">
+      <div className="mock-container cg-mock">
+        <div className="mock-toolbar" style={{ justifyContent: 'space-between' }}>
+          <div style={{ display: 'flex', gap: 6 }}>
+            <div className="mock-dot" /><div className="mock-dot" /><div className="mock-dot" />
+          </div>
+          <span className="cg-title">SOX / SOC2 · audit review</span>
+          <span style={{ width: 48 }} />
+        </div>
+
+        <div className="cg-list">
+          {CHECKS.map((c, i) => {
+            const show = i < visible;
+            const isFail = c.status === 'fail';
+            return (
+              <div key={i} className={`cg-item${show ? ' cg-vis' : ''}${isFail && show ? ' cg-fail' : ''}`}>
+                <span className={`cg-icon${isFail ? ' cg-icon-fail' : ' cg-icon-pass'}`}>
+                  {show ? (isFail ? '?' : '\u2713') : ''}
+                </span>
+                <span className="cg-question">{c.q}</span>
+                {isFail && show && <span className="cg-badge">NO PROOF</span>}
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="cg-footer">
+          <span className={`cg-status${shownFails > 0 ? ' cg-status-warn' : ''}`}>
+            {shownFails > 0
+              ? `${shownFails} of ${failCount} critical gaps found`
+              : 'Reviewing...'}
+          </span>
+        </div>
+      </div>
+
+      <style>{`
+        .cg-root { width: 100%; }
+        .cg-mock { border-radius: 12px; overflow: hidden; }
+        .cg-title { font-family: var(--mono); font-size: 11px; color: rgba(var(--sand-100-rgb),0.2); }
+
+        .cg-list { padding: 10px 16px; display: flex; flex-direction: column; gap: 2px; min-height: 210px; }
+
+        .cg-item {
+          display: flex; align-items: center; gap: 10px;
+          padding: 7px 10px; border-radius: 4px;
+          opacity: 0; transform: translateY(4px);
+          transition: opacity 0.3s ease, transform 0.3s ease, background 0.3s ease;
+        }
+        .cg-item.cg-vis { opacity: 1; transform: translateY(0); }
+        .cg-item.cg-fail { background: rgba(var(--error-rgb),0.06); }
+
+        .cg-icon {
+          width: 18px; height: 18px; border-radius: 50%;
+          display: flex; align-items: center; justify-content: center;
+          font-size: 11px; font-weight: 700; flex-shrink: 0;
+        }
+        .cg-icon-pass { background: rgba(var(--success-rgb),0.15); color: rgba(var(--success-rgb),0.8); }
+        .cg-icon-fail { background: rgba(var(--error-rgb),0.15); color: var(--error); }
+
+        .cg-question { font-family: var(--sans); font-size: 12px; color: rgba(var(--sand-100-rgb),0.5); flex: 1; }
+        .cg-fail .cg-question { color: rgba(var(--sand-100-rgb),0.65); }
+
+        .cg-badge {
+          font-family: var(--sans); font-size: 9px; font-weight: 600;
+          text-transform: uppercase; letter-spacing: 0.05em;
+          color: var(--error); background: rgba(var(--error-rgb),0.1);
+          padding: 2px 7px; border-radius: 3px; flex-shrink: 0;
+        }
+
+        .cg-footer {
+          padding: 10px 16px; border-top: 1px solid rgba(var(--sand-100-rgb),0.06);
+          font-family: var(--sans); font-size: 11px; color: rgba(var(--sand-100-rgb),0.25);
+        }
+        .cg-status-warn { color: var(--error); font-weight: 500; }
+      `}</style>
+    </div>
+  );
+}

--- a/snippets/annimations/DataFlowAnimation.jsx
+++ b/snippets/annimations/DataFlowAnimation.jsx
@@ -1,0 +1,178 @@
+/**
+ * DataFlowAnimation — Configurable sensitive-data-in-transit stream
+ *
+ * Props:
+ *   variant — 'database' | 'phi' | 'financial' | 'general'
+ *
+ * Each variant shows domain-specific sensitive data flowing through
+ * a wire unprotected. Items slide in, sensitive ones briefly flash
+ * gold to reveal PII/PHI/financial data, then fade — conveying that
+ * nothing is catching it.
+ *
+ * Pure CSS keyframes + React state.
+ */
+
+export const DataFlowAnimation = ({ variant = 'general' }) => {
+  const VARIANTS = {
+    database: {
+      title: 'postgres:prod · live queries',
+      items: [
+        { type: 'safe',      label: 'SELECT name, dept FROM employees' },
+        { type: 'sensitive',  label: '→ ssn: 123-45-6789',              tag: 'SSN' },
+        { type: 'safe',      label: 'UPDATE orders SET status=shipped' },
+        { type: 'sensitive',  label: '→ email: j.smith@acme.com',       tag: 'PII' },
+        { type: 'safe',      label: 'SELECT count(*) FROM sessions' },
+        { type: 'sensitive',  label: '→ ssn: 987-65-4321',              tag: 'SSN' },
+      ],
+    },
+    phi: {
+      title: 'ehr-db:prod · patient queries',
+      items: [
+        { type: 'safe',      label: 'SELECT patient_id, visit_date' },
+        { type: 'sensitive',  label: '→ diagnosis: Type 2 Diabetes',    tag: 'PHI' },
+        { type: 'safe',      label: 'GET /api/lab-results/4821' },
+        { type: 'sensitive',  label: '→ ssn: 321-54-9876',              tag: 'SSN' },
+        { type: 'safe',      label: 'SELECT medication FROM rx_active' },
+        { type: 'sensitive',  label: '→ mrn: MRN-00284719',             tag: 'MRN' },
+      ],
+    },
+    financial: {
+      title: 'payments-db:prod · transactions',
+      items: [
+        { type: 'safe',      label: 'SELECT tx_id, amount, status' },
+        { type: 'sensitive',  label: '→ card: 4532-8821-0093-4417',     tag: 'PCI' },
+        { type: 'safe',      label: 'GET /api/settlements/batch-429' },
+        { type: 'sensitive',  label: '→ account: 0028-4719-882',        tag: 'PII' },
+        { type: 'safe',      label: 'SELECT balance FROM accounts' },
+        { type: 'sensitive',  label: '→ routing: 021000021',            tag: 'PII' },
+      ],
+    },
+    general: {
+      title: 'network traffic · live',
+      items: [
+        { type: 'safe',      label: 'SELECT name FROM users' },
+        { type: 'sensitive',  label: '→ 123-45-6789',                   tag: 'SSN' },
+        { type: 'safe',      label: 'GET /api/v1/health' },
+        { type: 'sensitive',  label: '→ alice@corp.com',                tag: 'PII' },
+        { type: 'safe',      label: 'kubectl get pods -n prod' },
+        { type: 'sensitive',  label: '→ 4532-XXXX-XXXX-8821',          tag: 'PCI' },
+      ],
+    },
+  };
+
+  const ITEM_DELAY = 650;
+  const FLASH_DURATION = 500;
+  const CYCLE_PAD = 1200;
+
+  const config = VARIANTS[variant] || VARIANTS.general;
+  const [cycle, setCycle]          = useState(0);
+  const [visibleSet, setVisible]   = useState(new Set());
+  const [flashSet, setFlash]       = useState(new Set());
+  const timers                     = useRef([]);
+
+  function T(fn, ms) { const id = setTimeout(fn, ms); timers.current.push(id); }
+
+  useEffect(() => {
+    timers.current.forEach(clearTimeout);
+    timers.current = [];
+    setVisible(new Set());
+    setFlash(new Set());
+
+    config.items.forEach((item, i) => {
+      const t = i * ITEM_DELAY;
+      T(() => setVisible((s) => new Set([...s, i])), t);
+
+      if (item.type === 'sensitive') {
+        T(() => setFlash((s) => new Set([...s, i])), t + 180);
+        T(() => setFlash((s) => { const n = new Set(s); n.delete(i); return n; }), t + 180 + FLASH_DURATION);
+      }
+    });
+
+    T(() => setCycle((c) => c + 1), config.items.length * ITEM_DELAY + CYCLE_PAD);
+    return () => timers.current.forEach(clearTimeout);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cycle, variant]);
+
+  return (
+    <div className="df-root" aria-hidden="true">
+      <div className="mock-container df-mock">
+        {/* Toolbar */}
+        <div className="mock-toolbar" style={{ justifyContent: 'space-between' }}>
+          <div style={{ display: 'flex', gap: 6 }}>
+            <div className="mock-dot" /><div className="mock-dot" /><div className="mock-dot" />
+          </div>
+          <span className="df-title">{config.title}</span>
+          <span style={{ width: 48 }} />
+        </div>
+
+        {/* Stream */}
+        <div className="df-stream">
+          {config.items.map((item, i) => {
+            const show = visibleSet.has(i);
+            const flash = flashSet.has(i);
+            const sens = item.type === 'sensitive';
+            return (
+              <div key={i} className={`df-row${show ? ' df-vis' : ''}${flash ? ' df-flash' : ''}${sens ? ' df-sens' : ''}`}>
+                <span className="df-dot" />
+                <span className="df-text">{item.label}</span>
+                {item.tag && <span className="df-tag">{item.tag}</span>}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Footer */}
+        <div className="df-footer">
+          <span className="df-pulse" />
+          <span>No protections active</span>
+        </div>
+      </div>
+
+      <style>{`
+        .df-root { width: 100%; }
+        .df-mock { border-radius: 12px; overflow: hidden; }
+        .df-title { font-family: var(--mono); font-size: 11px; color: rgba(var(--sand-100-rgb),0.2); }
+
+        .df-stream { padding: 10px 16px; display: flex; flex-direction: column; gap: 2px; min-height: 200px; }
+
+        .df-row {
+          display: flex; align-items: center; gap: 10px;
+          padding: 5px 10px; border-radius: 4px;
+          opacity: 0; transform: translateX(-8px);
+          transition: opacity 0.3s ease, transform 0.3s ease, background 0.25s ease;
+        }
+        .df-row.df-vis { opacity: 1; transform: translateX(0); }
+        .df-row.df-flash { background: rgba(var(--warm-gold-rgb),0.08); }
+
+        .df-dot { width: 5px; height: 5px; border-radius: 50%; background: rgba(var(--sand-100-rgb),0.15); flex-shrink: 0; }
+        .df-sens .df-dot { background: rgba(var(--warm-gold-rgb),0.4); }
+        .df-flash .df-dot { background: var(--warm-gold); }
+
+        .df-text { font-family: var(--mono); font-size: 12px; color: rgba(var(--sand-100-rgb),0.4); white-space: nowrap; }
+        .df-sens .df-text { color: rgba(var(--sand-100-rgb),0.5); }
+        .df-flash .df-text { color: rgba(var(--warm-gold-rgb),0.8); }
+
+        .df-tag {
+          font-family: var(--sans); font-size: 9px; font-weight: 600;
+          text-transform: uppercase; letter-spacing: 0.05em;
+          color: rgba(var(--warm-gold-rgb),0.5); background: rgba(var(--warm-gold-rgb),0.06);
+          padding: 1px 6px; border-radius: 3px;
+          opacity: 0; transition: opacity 0.3s ease;
+        }
+        .df-flash .df-tag { opacity: 1; }
+
+        .df-footer {
+          display: flex; align-items: center; gap: 7px;
+          padding: 10px 16px; border-top: 1px solid rgba(var(--sand-100-rgb),0.06);
+          font-family: var(--sans); font-size: 11px; color: rgba(var(--sand-100-rgb),0.2);
+        }
+        .df-pulse {
+          width: 6px; height: 6px; border-radius: 50%;
+          background: rgba(var(--sand-100-rgb),0.15);
+          animation: df-p 2s ease-in-out infinite;
+        }
+        @keyframes df-p { 0%,100%{opacity:.5} 50%{opacity:1} }
+      `}</style>
+    </div>
+  );
+}

--- a/snippets/annimations/DataMaskingDemo.jsx
+++ b/snippets/annimations/DataMaskingDemo.jsx
@@ -1,0 +1,373 @@
+export const DataMaskingDemo = () => {
+  const FONTS_URL =
+    "https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;0,9..40,800&family=JetBrains+Mono:wght@400;500&family=Sora:wght@600;700;800&display=swap";
+
+  const C = {
+    espresso: "var(--gradient-dark-mid)",
+    warmGold: "var(--warm-gold)",
+    sand100: "var(--sand-100)",
+    sand300: "var(--sand-300)",
+    sand500: "var(--sand-500)",
+  };
+
+  const QUERY = "SELECT name, email, ssn, card FROM customers LIMIT 4;";
+  const TYPING_CHAR_MS = 22;
+
+  const ROWS = [
+    { raw: ["Sarah Chen", "sarah.chen@acme.io", "284-19-7653", "4532-8821"], masked: ["[PERSON]", "[EMAIL]", "[SSN]", "[PCI]"] },
+    { raw: ["Marcus Webb", "m.webb@globex.com", "531-77-0294", "4916-3350"], masked: ["[PERSON]", "[EMAIL]", "[SSN]", "[PCI]"] },
+    { raw: ["Elena Ruiz", "eruiz@initech.co", "719-42-8106", "5425-1247"], masked: ["[PERSON]", "[EMAIL]", "[SSN]", "[PCI]"] },
+    { raw: ["James Okafor", "j.okafor@stark.dev", "603-88-1542", "4111-9063"], masked: ["[PERSON]", "[EMAIL]", "[SSN]", "[PCI]"] },
+  ];
+
+  const ROW_DELAY = 800;
+  const CROSS_DURATION = 600;
+  const HOLD = 3000;
+
+  function ShieldIcon({ active, done }) {
+    return (
+      <svg width="18" height="18" viewBox="0 0 20 20" fill="none" style={{
+        animation: done ? "shieldIn 0.5s ease-out" : undefined,
+        opacity: active ? 1 : 0.3, transition: "opacity 0.4s ease",
+      }}>
+        <path d="M10 2L3 5.5V10C3 14.5 6 17.5 10 19C14 17.5 17 14.5 17 10V5.5L10 2Z"
+          fill={done ? "rgba(var(--warm-gold-rgb),0.15)" : "rgba(var(--sand-100-rgb),0.05)"}
+          stroke={done ? "var(--warm-gold)" : "rgba(var(--sand-100-rgb),0.15)"} strokeWidth="1.2" />
+        {done && (
+          <path d="M7 10.5L9 12.5L13 8" stroke="var(--warm-gold)" strokeWidth="1.5"
+            strokeLinecap="round" strokeLinejoin="round" />
+        )}
+      </svg>
+    );
+  }
+
+  const [typedLen, setTypedLen] = useState(0);
+  const [typingDone, setTypingDone] = useState(false);
+  const [rowPhases, setRowPhases] = useState(ROWS.map(() => "hidden"));
+  const [allDone, setAllDone] = useState(false);
+  const [membraneActive, setMembraneActive] = useState(false);
+  const [membraneGlow, setMembraneGlow] = useState(false);
+  const timeouts = useRef([]);
+  const frameRef = useRef(null);
+
+  const clearAll = useCallback(() => {
+    timeouts.current.forEach(clearTimeout);
+    timeouts.current = [];
+    if (frameRef.current) cancelAnimationFrame(frameRef.current);
+  }, []);
+
+  const later = useCallback((fn, ms) => {
+    const id = setTimeout(fn, ms);
+    timeouts.current.push(id);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const cycle = () => {
+      if (cancelled) return;
+      setTypedLen(0);
+      setTypingDone(false);
+      setRowPhases(ROWS.map(() => "hidden"));
+      setAllDone(false);
+      setMembraneActive(false);
+      setMembraneGlow(false);
+
+      // Phase 1: type out the SQL query
+      const typingStart = performance.now();
+      function tick(now) {
+        if (cancelled) return;
+        const elapsed = now - typingStart;
+        const chars = Math.min(Math.floor(elapsed / TYPING_CHAR_MS), QUERY.length);
+        setTypedLen(chars);
+        if (chars < QUERY.length) {
+          frameRef.current = requestAnimationFrame(tick);
+        } else {
+          setTypingDone(true);
+        }
+      }
+      frameRef.current = requestAnimationFrame(tick);
+
+      const typingTotal = QUERY.length * TYPING_CHAR_MS;
+      const baseDelay = typingTotal + 400;
+
+      // Phase 2: activate membrane after typing
+      later(() => {
+        if (cancelled) return;
+        setMembraneActive(true);
+      }, baseDelay);
+
+      // Phase 3: send rows through the membrane
+      ROWS.forEach((_, i) => {
+        const t0 = baseDelay + 300 + i * ROW_DELAY;
+
+        later(() => {
+          if (cancelled) return;
+          setRowPhases(p => { const n = [...p]; n[i] = "approaching"; return n; });
+        }, t0);
+
+        later(() => {
+          if (cancelled) return;
+          setRowPhases(p => { const n = [...p]; n[i] = "crossing"; return n; });
+          setMembraneGlow(true);
+          later(() => { if (!cancelled) setMembraneGlow(false); }, 300);
+        }, t0 + 400);
+
+        later(() => {
+          if (cancelled) return;
+          setRowPhases(p => { const n = [...p]; n[i] = "through"; return n; });
+        }, t0 + 400 + CROSS_DURATION);
+      });
+
+      const total = baseDelay + 300 + (ROWS.length - 1) * ROW_DELAY + 400 + CROSS_DURATION + 300;
+      later(() => { if (!cancelled) setAllDone(true); }, total);
+      later(() => { if (!cancelled) cycle(); }, total + HOLD);
+    };
+
+    cycle();
+    return () => { cancelled = true; clearAll(); };
+  }, [later, clearAll]);
+
+  return (
+    <>
+      <link rel="stylesheet" href={FONTS_URL} />
+      <style>{`
+        @keyframes approachSlide {
+          from { opacity: 0; transform: translateX(-30px); }
+          to { opacity: 1; transform: translateX(0); }
+        }
+        @keyframes crossFlash {
+          0% { opacity: 1; filter: blur(0); }
+          30% { opacity: 0.3; filter: blur(4px); transform: scaleY(0.8); }
+          60% { opacity: 0.6; filter: blur(2px); transform: scaleY(1.05); }
+          100% { opacity: 1; filter: blur(0); transform: scaleY(1); }
+        }
+        @keyframes throughSlide {
+          from { opacity: 0; transform: translateX(0); }
+          to { opacity: 1; transform: translateX(0); }
+        }
+        @keyframes membranePulse {
+          0%, 100% { box-shadow: 0 0 8px 0 rgba(var(--warm-gold-rgb),0.1); }
+          50% { box-shadow: 0 0 24px 4px rgba(var(--warm-gold-rgb),0.3); }
+        }
+        @keyframes membraneFlash {
+          0% { background: rgba(var(--warm-gold-rgb),0.15); }
+          100% { background: rgba(var(--warm-gold-rgb),0.06); }
+        }
+        @keyframes shieldIn {
+          0% { opacity:0; transform:scale(0.6); }
+          60% { opacity:1; transform:scale(1.08); }
+          100% { opacity:1; transform:scale(1); }
+        }
+        @keyframes cursorBlink {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0; }
+        }
+      `}</style>
+
+      <div style={{
+        background: "linear-gradient(135deg, var(--gradient-dark-start) 0%, var(--gradient-dark-mid) 35%, var(--gradient-dark-end) 70%, var(--bronze) 100%)",
+        borderRadius: 14, padding: "28px 28px 24px",
+        fontFamily: "'DM Sans', system-ui, sans-serif",
+        position: "relative", overflow: "hidden", maxWidth: 760, margin: "0 auto",
+        height: 420,
+      }}>
+        {/* Radial glow */}
+        <div style={{
+          position: "absolute", top: "-30%", right: "-10%", width: "60%", height: "160%",
+          background: "radial-gradient(ellipse at center, rgba(var(--warm-gold-rgb),0.12) 0%, transparent 70%)",
+          pointerEvents: "none",
+        }} />
+
+        {/* Header */}
+        <div style={{
+          display: "flex", alignItems: "center", gap: 10,
+          marginBottom: 16, position: "relative", zIndex: 1,
+        }}>
+          <ShieldIcon done={allDone} active={membraneActive} />
+          <span style={{
+            fontFamily: "'Sora', sans-serif", fontSize: 14, fontWeight: 600,
+            color: C.sand100, letterSpacing: "-0.01em",
+          }}>Claude Code Gateway</span>
+          <span style={{
+            fontFamily: "'DM Sans', sans-serif", fontSize: 10, fontWeight: 600,
+            textTransform: "uppercase", letterSpacing: "0.06em",
+            color: allDone ? C.warmGold : "rgba(var(--sand-100-rgb),0.18)",
+            background: allDone ? "rgba(var(--warm-gold-rgb),0.10)" : "rgba(var(--sand-100-rgb),0.04)",
+            padding: "2px 8px", borderRadius: 99, transition: "all 0.3s ease",
+          }}>{allDone ? "Protected" : membraneActive ? "Active" : "Ready"}</span>
+        </div>
+
+        {/* SQL query typing area */}
+        <div style={{
+          background: "rgba(var(--sand-100-rgb),0.03)",
+          border: "1px solid rgba(var(--sand-100-rgb),0.06)",
+          borderRadius: 8, padding: "8px 12px", marginBottom: 14,
+          position: "relative", zIndex: 1,
+          display: "flex", alignItems: "center", gap: 8,
+          minHeight: 34,
+        }}>
+          <span style={{
+            fontFamily: "'JetBrains Mono', monospace", fontSize: 11, fontWeight: 500,
+            color: C.warmGold, opacity: 0.7, flexShrink: 0,
+          }}>claude $</span>
+          <span style={{
+            fontFamily: "'JetBrains Mono', monospace", fontSize: 11,
+            color: "rgba(var(--sand-100-rgb),0.75)", whiteSpace: "nowrap", overflow: "hidden",
+          }}>
+            {QUERY.slice(0, typedLen)}
+            {!typingDone && (
+              <span style={{
+                color: C.warmGold, fontWeight: 600,
+                animation: "cursorBlink 0.6s step-end infinite",
+              }}>|</span>
+            )}
+          </span>
+        </div>
+
+        {/* Three-zone layout: Raw | Membrane | Masked */}
+        <div style={{
+          display: "grid", gridTemplateColumns: "1fr 48px 1fr",
+          gap: 0, position: "relative", zIndex: 1, minHeight: 220,
+        }}>
+          {/* Left: raw data zone */}
+          <div style={{ position: "relative" }}>
+            <div style={{
+              fontFamily: "'JetBrains Mono', monospace", fontSize: 9, fontWeight: 500,
+              color: "rgba(var(--sand-100-rgb),0.20)", textTransform: "uppercase",
+              letterSpacing: "0.1em", marginBottom: 10, paddingLeft: 2,
+            }}>Claude Code query</div>
+
+            <div style={{
+              background: "rgba(var(--sand-100-rgb),0.03)", border: "1px solid rgba(var(--sand-100-rgb),0.06)",
+              borderRadius: 8, overflow: "hidden",
+            }}>
+              {ROWS.map((row, i) => {
+                const phase = rowPhases[i];
+                const show = phase === "approaching" || phase === "crossing";
+                return (
+                  <div key={i} style={{
+                    padding: "7px 12px",
+                    borderBottom: i < ROWS.length - 1 ? "1px solid rgba(var(--sand-100-rgb),0.04)" : "none",
+                    opacity: show ? 1 : phase === "through" ? 0.15 : 0,
+                    transform: show ? "translateX(0)" : "translateX(-10px)",
+                    transition: phase === "through" ? "opacity 0.4s ease" : "opacity 0.3s ease, transform 0.3s ease",
+                    animation: phase === "crossing" ? "crossFlash 0.6s ease-out" : undefined,
+                    minHeight: 34, display: "flex", flexDirection: "column", justifyContent: "center", gap: 1,
+                  }}>
+                    <div style={{
+                      fontFamily: "'JetBrains Mono', monospace", fontSize: 11,
+                      color: "rgba(var(--sand-100-rgb),0.50)", whiteSpace: "nowrap", overflow: "hidden",
+                      textOverflow: "ellipsis",
+                    }}>{row.raw[0]} , {row.raw[1]}</div>
+                    <div style={{
+                      fontFamily: "'JetBrains Mono', monospace", fontSize: 10,
+                      color: "rgba(var(--sand-100-rgb),0.30)", whiteSpace: "nowrap",
+                    }}>{row.raw[2]} , {row.raw[3]}</div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Center: membrane barrier */}
+          <div style={{
+            display: "flex", alignItems: "center", justifyContent: "center",
+            position: "relative",
+          }}>
+            <div style={{
+              width: 3, height: "calc(100% - 20px)", marginTop: 20,
+              background: membraneActive
+                ? `linear-gradient(180deg, transparent 0%, ${C.warmGold} 20%, ${C.warmGold} 80%, transparent 100%)`
+                : "rgba(var(--sand-100-rgb),0.08)",
+              borderRadius: 2, position: "relative",
+              transition: "background 0.6s ease",
+              animation: membraneGlow ? "membranePulse 0.4s ease-out" : undefined,
+              boxShadow: membraneActive ? "0 0 12px 2px rgba(var(--warm-gold-rgb),0.15)" : "none",
+            }}>
+              {/* Shield icon on membrane */}
+              <div style={{
+                position: "absolute", top: "50%", left: "50%",
+                transform: "translate(-50%, -50%)",
+                width: 28, height: 28, borderRadius: "50%",
+                background: "rgba(var(--espresso-rgb),0.95)",
+                border: `1.5px solid ${membraneActive ? C.warmGold : "rgba(var(--sand-100-rgb),0.12)"}`,
+                display: "flex", alignItems: "center", justifyContent: "center",
+                transition: "border-color 0.4s ease",
+                zIndex: 5,
+              }}>
+                <svg width="14" height="14" viewBox="0 0 20 20" fill="none">
+                  <path d="M10 2L3 5.5V10C3 14.5 6 17.5 10 19C14 17.5 17 14.5 17 10V5.5L10 2Z"
+                    fill={membraneActive ? "rgba(var(--warm-gold-rgb),0.2)" : "rgba(var(--sand-100-rgb),0.05)"}
+                    stroke={membraneActive ? C.warmGold : "rgba(var(--sand-100-rgb),0.15)"} strokeWidth="1.2" />
+                </svg>
+              </div>
+            </div>
+          </div>
+
+          {/* Right: masked data zone */}
+          <div style={{ position: "relative" }}>
+            <div style={{
+              fontFamily: "'JetBrains Mono', monospace", fontSize: 9, fontWeight: 500,
+              color: "rgba(var(--sand-100-rgb),0.20)", textTransform: "uppercase",
+              letterSpacing: "0.1em", marginBottom: 10, paddingLeft: 2,
+            }}>Delivered to Claude</div>
+
+            <div style={{
+              background: "rgba(var(--sand-100-rgb),0.03)", border: "1px solid rgba(var(--sand-100-rgb),0.06)",
+              borderRadius: 8, overflow: "hidden",
+            }}>
+              {ROWS.map((row, i) => {
+                const phase = rowPhases[i];
+                const show = phase === "through";
+                return (
+                  <div key={i} style={{
+                    padding: "7px 12px",
+                    borderBottom: i < ROWS.length - 1 ? "1px solid rgba(var(--sand-100-rgb),0.04)" : "none",
+                    opacity: show ? 1 : 0,
+                    transform: show ? "translateX(0)" : "translateX(10px)",
+                    transition: "opacity 0.4s ease, transform 0.4s ease",
+                    minHeight: 34, display: "flex", flexDirection: "column", justifyContent: "center", gap: 1,
+                  }}>
+                    <div style={{ display: "flex", gap: 8 }}>
+                      {row.masked.slice(0, 2).map((m, j) => (
+                        <span key={j} style={{
+                          fontFamily: "'JetBrains Mono', monospace", fontSize: 11,
+                          fontWeight: 600, color: C.warmGold,
+                        }}>{m}</span>
+                      ))}
+                    </div>
+                    <div style={{ display: "flex", gap: 8 }}>
+                      {row.masked.slice(2).map((m, j) => (
+                        <span key={j} style={{
+                          fontFamily: "'JetBrains Mono', monospace", fontSize: 10,
+                          fontWeight: 600, color: C.warmGold, opacity: 0.7,
+                        }}>{m}</span>
+                      ))}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+
+        {/* Bottom tags */}
+        <div style={{
+          display: "flex", gap: 8, marginTop: 14, position: "relative", zIndex: 1,
+          opacity: allDone ? 1 : 0, transform: allDone ? "translateY(0)" : "translateY(4px)",
+          transition: "opacity 0.5s ease, transform 0.5s ease", height: 20,
+        }}>
+          {["Zero-config proxy", "GDPR", "PCI-DSS", "Real-time"].map((tag) => (
+            <span key={tag} style={{
+              fontFamily: "'DM Sans', sans-serif", fontSize: 10, fontWeight: 600,
+              textTransform: "uppercase", color: "rgba(var(--sand-100-rgb),0.25)",
+              background: "rgba(var(--sand-100-rgb),0.04)", padding: "2px 8px",
+              borderRadius: 99, letterSpacing: "0.04em",
+            }}>{tag}</span>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/snippets/annimations/GatewayVisualization.jsx
+++ b/snippets/annimations/GatewayVisualization.jsx
@@ -1,0 +1,312 @@
+/**
+ * GatewayVisualization — About page hero animation
+ *
+ * Data streams flow through the gateway, one lane at a time.
+ * Raw data enters left, crosses the gateway line, exits masked on the right.
+ * Larger text, higher contrast, slower pace — designed to be read.
+ *
+ * Fixed height: 420px.
+ */
+
+export const GatewayVisualization = () => {
+  const STREAMS = [
+    { protocol: 'PostgreSQL', raw: 'sarah.chen@acme.io', masked: '[EMAIL]' },
+    { protocol: 'kubectl', raw: 'delete deploy/prod', masked: '\u26D4 blocked', blocked: true },
+    { protocol: 'MySQL', raw: 'SSN 284-19-7653', masked: '[REDACTED]' },
+    { protocol: 'SSH', raw: 'cat /etc/shadow', masked: '\u2713 logged' },
+    { protocol: 'gRPC', raw: 'card 4532-7891', masked: '[PCI]' },
+  ];
+
+  const PHASE_TIMING = {
+    enter: 0,
+    travel: 900,
+    cross: 1800,
+    exit: 2600,
+    fade: 3400,
+  };
+  const CYCLE_MS = 4200;
+  const STAGGER = 600;
+
+  function Lane({ stream, index, cycle }) {
+    const [phase, setPhase] = useState('idle');
+
+    useEffect(() => {
+      const base = index * STAGGER;
+      setPhase('idle');
+
+      const timers = [
+        setTimeout(() => setPhase('enter'), base + PHASE_TIMING.enter),
+        setTimeout(() => setPhase('travel'), base + PHASE_TIMING.travel),
+        setTimeout(() => setPhase('cross'), base + PHASE_TIMING.cross),
+        setTimeout(() => setPhase('exit'), base + PHASE_TIMING.exit),
+        setTimeout(() => setPhase('fade'), base + PHASE_TIMING.fade),
+      ];
+      return () => timers.forEach(clearTimeout);
+    }, [cycle, index]);
+
+    const showRaw = phase === 'enter' || phase === 'travel';
+    const showFlash = phase === 'cross';
+    const showMasked = phase === 'exit' || phase === 'fade';
+
+    // Raw packet position
+    const rawLeft = phase === 'enter' ? '2%' : '32%';
+    // Masked packet position
+    const maskedLeft = phase === 'exit' ? '56%' : '82%';
+
+    return (
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        height: 52,
+        position: 'relative',
+      }}>
+        {/* Protocol label */}
+        <div style={{
+          width: 88,
+          flexShrink: 0,
+          fontFamily: 'var(--mono)',
+          fontSize: 12,
+          fontWeight: 500,
+          color: phase !== 'idle' ? 'rgba(var(--sand-100-rgb),0.55)' : 'rgba(var(--sand-100-rgb),0.2)',
+          textAlign: 'right',
+          paddingRight: 20,
+          transition: 'color 0.4s',
+        }}>
+          {stream.protocol}
+        </div>
+
+        {/* Wire */}
+        <div style={{
+          flex: 1,
+          height: 1,
+          background: 'rgba(var(--sand-100-rgb),0.06)',
+          position: 'relative',
+        }}>
+          {/* Active wire glow */}
+          {phase !== 'idle' && phase !== 'fade' && (
+            <div style={{
+              position: 'absolute',
+              top: 0, left: 0, right: 0, height: 1,
+              background: 'rgba(var(--warm-gold-rgb),0.15)',
+              transition: 'opacity 0.4s',
+            }} />
+          )}
+
+          {/* Raw packet */}
+          {showRaw && (
+            <div style={{
+              position: 'absolute',
+              top: -15,
+              left: rawLeft,
+              transition: 'left 0.9s cubic-bezier(0.25, 0.1, 0.25, 1), opacity 0.3s',
+              opacity: phase === 'travel' ? 1 : 0.7,
+            }}>
+              <span style={{
+                fontFamily: 'var(--mono)',
+                fontSize: 13,
+                fontWeight: 500,
+                color: 'rgba(var(--sand-100-rgb),0.8)',
+                whiteSpace: 'nowrap',
+                background: 'rgba(var(--sand-100-rgb),0.06)',
+                padding: '5px 14px',
+                borderRadius: 6,
+                border: '1px solid rgba(var(--sand-100-rgb),0.10)',
+                display: 'inline-block',
+              }}>
+                {stream.raw}
+              </span>
+            </div>
+          )}
+
+          {/* Gateway flash */}
+          {showFlash && (
+            <div style={{
+              position: 'absolute',
+              top: -20,
+              left: '50%',
+              transform: 'translateX(-50%)',
+              width: 40,
+              height: 40,
+              borderRadius: '50%',
+              background: stream.blocked
+                ? 'rgba(var(--error-rgb),0.2)'
+                : 'rgba(var(--warm-gold-rgb),0.15)',
+              animation: 'gw-pulse 0.7s ease-out forwards',
+            }} />
+          )}
+
+          {/* Masked packet */}
+          {showMasked && (
+            <div style={{
+              position: 'absolute',
+              top: -15,
+              left: maskedLeft,
+              transition: 'left 0.8s cubic-bezier(0.25, 0.1, 0.25, 1), opacity 0.5s',
+              opacity: phase === 'fade' ? 0 : 1,
+            }}>
+              <span style={{
+                fontFamily: 'var(--mono)',
+                fontSize: 13,
+                fontWeight: 700,
+                color: stream.blocked ? 'rgba(var(--error-rgb),0.9)' : 'var(--warm-gold)',
+                whiteSpace: 'nowrap',
+                background: stream.blocked
+                  ? 'rgba(var(--error-rgb),0.10)'
+                  : 'rgba(var(--warm-gold-rgb),0.10)',
+                padding: '5px 14px',
+                borderRadius: 6,
+                border: stream.blocked
+                  ? '1px solid rgba(var(--error-rgb),0.20)'
+                  : '1px solid rgba(var(--warm-gold-rgb),0.18)',
+                display: 'inline-block',
+              }}>
+                {stream.masked}
+              </span>
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  const [cycle, setCycle] = useState(0);
+  const mounted = useRef(true);
+
+  useEffect(() => {
+    mounted.current = true;
+    const interval = setInterval(() => {
+      if (mounted.current) setCycle(c => c + 1);
+    }, CYCLE_MS);
+    return () => { mounted.current = false; clearInterval(interval); };
+  }, []);
+
+  return (
+    <div style={{ height: 420, position: 'relative', overflow: 'hidden' }}>
+      {/* Dot grid */}
+      <div style={{
+        position: 'absolute', inset: 0,
+        backgroundImage: 'radial-gradient(rgba(var(--sand-100-rgb),0.05) 1px, transparent 1px)',
+        backgroundSize: '28px 28px',
+        pointerEvents: 'none',
+      }} />
+
+      {/* Gateway center line */}
+      <div style={{
+        position: 'absolute',
+        top: 32, bottom: 32,
+        left: '50%',
+        width: 1,
+        background: 'linear-gradient(180deg, transparent 0%, rgba(var(--warm-gold-rgb),0.3) 20%, rgba(var(--warm-gold-rgb),0.3) 80%, transparent 100%)',
+        transform: 'translateX(-50%)',
+      }} />
+
+      {/* Header row */}
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        padding: '0 0 0 88px',
+        height: 44,
+        position: 'relative',
+      }}>
+        {/* Left label */}
+        <div style={{
+          position: 'absolute', left: 108, top: 14,
+          fontFamily: 'var(--sans)', fontSize: 11, fontWeight: 600,
+          textTransform: 'uppercase', letterSpacing: '0.08em',
+          color: 'rgba(var(--sand-100-rgb),0.25)',
+        }}>
+          Raw
+        </div>
+
+        {/* Gateway badge */}
+        <div style={{
+          position: 'absolute',
+          left: '50%', top: 8,
+          transform: 'translateX(-50%)',
+          display: 'flex', alignItems: 'center', gap: 8,
+          background: 'rgba(var(--warm-gold-rgb),0.08)',
+          border: '1px solid rgba(var(--warm-gold-rgb),0.15)',
+          padding: '5px 14px',
+          borderRadius: 99,
+        }}>
+          <div style={{
+            width: 7, height: 7, borderRadius: '50%',
+            background: 'var(--warm-gold)',
+            boxShadow: '0 0 10px rgba(var(--warm-gold-rgb),0.5)',
+            animation: 'gw-breathe 2s ease-in-out infinite',
+          }} />
+          <span style={{
+            fontFamily: 'var(--mono)', fontSize: 11, fontWeight: 600,
+            color: 'var(--warm-gold)',
+            textTransform: 'uppercase', letterSpacing: '0.08em',
+          }}>
+            Gateway
+          </span>
+        </div>
+
+        {/* Right label */}
+        <div style={{
+          position: 'absolute', right: 16, top: 14,
+          fontFamily: 'var(--sans)', fontSize: 11, fontWeight: 600,
+          textTransform: 'uppercase', letterSpacing: '0.08em',
+          color: 'rgba(var(--sand-100-rgb),0.25)',
+        }}>
+          Protected
+        </div>
+      </div>
+
+      {/* Lanes */}
+      <div style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+        paddingTop: 12,
+      }}>
+        {STREAMS.map((s, i) => (
+          <Lane key={`${s.protocol}-${cycle}`} stream={s} index={i} cycle={cycle} />
+        ))}
+      </div>
+
+      {/* Bottom stats */}
+      <div style={{
+        position: 'absolute',
+        bottom: 16, left: 88, right: 0,
+        display: 'flex',
+        justifyContent: 'center',
+        gap: 40,
+        borderTop: '1px solid rgba(var(--sand-100-rgb),0.06)',
+        paddingTop: 14,
+        marginRight: 16,
+      }}>
+        {[
+          { n: '5', label: 'protocols' },
+          { n: '<5ms', label: 'added latency' },
+          { n: '100%', label: 'inspected' },
+        ].map(s => (
+          <div key={s.label} style={{ display: 'flex', alignItems: 'baseline', gap: 7 }}>
+            <span style={{
+              fontFamily: 'var(--display)', fontSize: 18, fontWeight: 700,
+              color: 'rgba(var(--sand-100-rgb),0.55)',
+              letterSpacing: '-0.02em',
+            }}>{s.n}</span>
+            <span style={{
+              fontFamily: 'var(--sans)', fontSize: 11,
+              color: 'rgba(var(--sand-100-rgb),0.25)',
+            }}>{s.label}</span>
+          </div>
+        ))}
+      </div>
+
+      <style>{`
+        @keyframes gw-pulse {
+          0% { transform: translateX(-50%) scale(0.5); opacity: 1; }
+          100% { transform: translateX(-50%) scale(2.5); opacity: 0; }
+        }
+        @keyframes gw-breathe {
+          0%, 100% { opacity: 0.6; transform: scale(1); }
+          50% { opacity: 1; transform: scale(1.4); }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/snippets/annimations/HeroAnimation.jsx
+++ b/snippets/annimations/HeroAnimation.jsx
@@ -1,0 +1,292 @@
+/**
+ * HeroAnimation — Hero section animated visual
+ *
+ * Used in: app/page.jsx (Home hero, right column)
+ *
+ * Shows a live postgres session:
+ *   1. Query types out character by character
+ *   2. Data rows fade in staggered
+ *   3. Sensitive columns flash warm-gold (var(--warm-gold))
+ *   4. Masking applied — SSN + email replaced, badge slides in
+ *   5. Resets and loops
+ *
+ * Pure CSS keyframes + React state — no external animation library.
+ * All colors from Styleguide §2 — rgba transparency system (§4.5).
+ */
+
+export const HeroAnimation = () => {
+  const QUERY = 'SELECT * FROM customers LIMIT 4;';
+
+  const ROWS = [
+    { id: 1001, name: 'J. Smith',     ssn: '123-45-6789', email: 'jsmith@acme.com'     },
+    { id: 1002, name: 'M. Rodriguez', ssn: '234-56-7890', email: 'mrodriguez@acme.com'  },
+    { id: 1003, name: 'A. Chen',      ssn: '345-67-8901', email: 'achen@acme.com'       },
+    { id: 1004, name: 'S. Patel',     ssn: '456-78-9012', email: 'spatel@acme.com'      },
+  ];
+
+  const [cycle, setCycle]               = useState(0);
+  const [typedLen, setTypedLen]         = useState(0);
+  const [visibleRows, setVisibleRows]   = useState(0);
+  // phase: 'typing' | 'flashing' | 'masked' | 'resetting'
+  const [phase, setPhase]               = useState('typing');
+  const timers                          = useRef([]);
+
+  function T(fn, delay) {
+    const id = setTimeout(fn, delay);
+    timers.current.push(id);
+  }
+
+  useEffect(() => {
+    timers.current.forEach(clearTimeout);
+    timers.current = [];
+
+    setTypedLen(0);
+    setVisibleRows(0);
+    setPhase('typing');
+
+    let t = 0;
+
+    // 1. Type query
+    for (let i = 1; i <= QUERY.length; i++) {
+      t += 38;
+      const ci = i;
+      T(() => setTypedLen(ci), t);
+    }
+
+    // 2. Short pause, then reveal rows one by one
+    t += 350;
+    for (let r = 1; r <= ROWS.length; r++) {
+      const cr = r;
+      T(() => setVisibleRows(cr), t);
+      t += 95;
+    }
+
+    // 3. Wait, then flash sensitive columns
+    t += 900;
+    T(() => setPhase('flashing'), t);
+
+    // 4. Apply masking
+    t += 480;
+    T(() => setPhase('masked'), t);
+
+    // 5. Hold, then reset
+    t += 3200;
+    T(() => setPhase('resetting'), t);
+
+    t += 550;
+    T(() => setCycle(c => c + 1), t);
+
+    return () => timers.current.forEach(clearTimeout);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cycle]);
+
+  const isMasked    = phase === 'masked';
+  const isFlashing  = phase === 'flashing';
+  const isResetting = phase === 'resetting';
+  const showRows    = phase !== 'typing' && phase !== 'resetting';
+
+  return (
+    <div className="ha-root" aria-hidden="true">
+      <div className={`mock-container ha-mock${isResetting ? ' ha-fadeout' : ''}`}>
+
+        {/* Toolbar */}
+        <div className="mock-toolbar" style={{ justifyContent: 'space-between' }}>
+          <div style={{ display: 'flex', gap: 6 }}>
+            <div className="mock-dot" />
+            <div className="mock-dot" />
+            <div className="mock-dot" />
+          </div>
+          <span className="ha-wintitle">hoop — postgres:prod</span>
+          <span style={{ width: 48 }} />
+        </div>
+
+        {/* Query bar */}
+        <div className="ha-querybar">
+          <span className="ha-prompt">psql&gt;&nbsp;</span>
+          <span className="ha-querytext">{QUERY.slice(0, typedLen)}</span>
+          {!isMasked && !isResetting && <span className="ha-cursor" />}
+        </div>
+
+        {/* Results table */}
+        <div className="ha-tablewrap">
+          <table className="ha-table">
+            <thead>
+              <tr>
+                <th className="ha-th">id</th>
+                <th className="ha-th">name</th>
+                <th className="ha-th">ssn</th>
+                <th className="ha-th">email</th>
+              </tr>
+            </thead>
+            <tbody>
+              {ROWS.map((row, i) => (
+                <tr
+                  key={row.id}
+                  className="ha-tr"
+                  style={{
+                    opacity: showRows && i < visibleRows ? 1 : 0,
+                    transition: 'opacity 0.2s ease',
+                  }}
+                >
+                  <td className="ha-td ha-dim">{row.id}</td>
+                  <td className="ha-td ha-bright">{row.name}</td>
+                  <td className={`ha-td ha-sensitive${isFlashing ? ' ha-flash' : ''}${isMasked ? ' ha-masked' : ''}`}>
+                    {isMasked ? `***-**-${row.ssn.slice(-4)}` : row.ssn}
+                  </td>
+                  <td className={`ha-td ha-sensitive${isFlashing ? ' ha-flash' : ''}${isMasked ? ' ha-masked' : ''}`}>
+                    {isMasked ? '****@****.com' : row.email}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Masking notice badge */}
+        <div className={`ha-notice${isMasked ? ' ha-notice-visible' : ''}`}>
+          <span className="ha-notice-dot" />
+          <span>2 columns masked &middot; SSN &middot; email</span>
+        </div>
+
+      </div>
+
+      <style>{`
+        .ha-root {
+          position: relative;
+          width: 100%;
+          max-width: 540px;
+        }
+
+        .ha-mock {
+          border-radius: 12px;
+          overflow: hidden;
+          transition: opacity 0.4s ease;
+        }
+
+        .ha-fadeout {
+          opacity: 0;
+        }
+
+        .ha-wintitle {
+          font-family: var(--mono);
+          font-size: 11px;
+          color: rgba(var(--sand-100-rgb), 0.2);
+        }
+
+        /* Query bar */
+        .ha-querybar {
+          display: flex;
+          align-items: center;
+          padding: 9px 16px;
+          background: rgba(var(--sand-100-rgb), 0.03);
+          border-top: 1px solid rgba(var(--sand-100-rgb), 0.06);
+          border-bottom: 1px solid rgba(var(--sand-100-rgb), 0.06);
+          min-height: 38px;
+        }
+
+        .ha-prompt {
+          font-family: var(--mono);
+          font-size: 12px;
+          color: rgba(var(--warm-gold-rgb), 0.7);
+          flex-shrink: 0;
+        }
+
+        .ha-querytext {
+          font-family: var(--mono);
+          font-size: 12px;
+          color: rgba(var(--sand-100-rgb), 0.7);
+        }
+
+        .ha-cursor {
+          display: inline-block;
+          width: 6px;
+          height: 13px;
+          background: rgba(var(--sand-100-rgb), 0.5);
+          margin-left: 1px;
+          vertical-align: middle;
+          animation: ha-blink 1s step-end infinite;
+        }
+
+        @keyframes ha-blink {
+          0%, 100% { opacity: 1; }
+          50%       { opacity: 0; }
+        }
+
+        /* Table */
+        .ha-tablewrap {
+          overflow-x: auto;
+          padding-bottom: 4px;
+        }
+
+        .ha-table {
+          width: 100%;
+          border-collapse: collapse;
+          font-family: var(--mono);
+          font-size: 12px;
+        }
+
+        .ha-th {
+          text-align: left;
+          padding: 7px 16px;
+          color: rgba(var(--sand-100-rgb), 0.25);
+          font-size: 10px;
+          font-weight: 500;
+          text-transform: uppercase;
+          letter-spacing: 0.06em;
+          border-bottom: 1px solid rgba(var(--sand-100-rgb), 0.04);
+        }
+
+        .ha-tr:not(:last-child) td {
+          border-bottom: 1px solid rgba(var(--sand-100-rgb), 0.04);
+        }
+
+        .ha-td {
+          padding: 7px 16px;
+          transition: color 0.25s ease, background 0.25s ease;
+        }
+
+        .ha-dim       { color: rgba(var(--sand-100-rgb), 0.3);  }
+        .ha-bright    { color: rgba(var(--sand-100-rgb), 0.6);  }
+        .ha-sensitive { color: rgba(var(--sand-100-rgb), 0.5);  }
+
+        .ha-flash {
+          color: var(--warm-gold) !important;
+          background: rgba(var(--warm-gold-rgb), 0.1);
+        }
+
+        .ha-masked {
+          color: var(--warm-gold) !important;
+          font-weight: 600;
+        }
+
+        /* Masking notice */
+        .ha-notice {
+          display: flex;
+          align-items: center;
+          gap: 7px;
+          padding: 8px 16px;
+          border-top: 1px solid rgba(var(--sand-100-rgb), 0.06);
+          font-family: var(--sans);
+          font-size: 11px;
+          color: rgba(var(--warm-gold-rgb), 0.75);
+          opacity: 0;
+          transform: translateY(4px);
+          transition: opacity 0.3s ease, transform 0.3s ease;
+        }
+
+        .ha-notice-visible {
+          opacity: 1;
+          transform: translateY(0);
+        }
+
+        .ha-notice-dot {
+          width: 6px;
+          height: 6px;
+          border-radius: 50%;
+          background: var(--warm-gold);
+          flex-shrink: 0;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/snippets/annimations/JDBCProxy.jsx
+++ b/snippets/annimations/JDBCProxy.jsx
@@ -1,0 +1,443 @@
+/**
+ * JDBCProxy — Animated horizontal flow diagram showing how agents/apps
+ * connect through Hoop Gateway by simply changing the connection string.
+ *
+ * 3 stages: Sources (left) → Gateway (center) → Database (right)
+ * Animated dots flow left-to-right, changing color at the gateway.
+ */
+
+export const JDBCProxy = () => {
+  const SOURCES = [
+    {
+      name: 'Claude Code',
+      icon: 'agent',
+      accent: 'var(--warm-gold)',
+    },
+    {
+      name: 'ETL Pipeline',
+      icon: 'gear',
+      accent: 'rgba(var(--sand-100-rgb),0.5)',
+    },
+    {
+      name: 'DBeaver',
+      icon: 'database',
+      accent: 'rgba(var(--sand-100-rgb),0.5)',
+    },
+  ];
+
+  const CONN_STRING = 'jdbc:postgresql://gateway.hoop.dev:5432/prod';
+
+  const CONTROLS = [
+    { label: 'Mask PII' },
+    { label: 'Log session' },
+    { label: 'Apply guardrails' },
+  ];
+
+  const MESSAGES = [
+    'No SDK required. Just change the connection string.',
+    'Same JDBC driver. Same ORM. Same code.',
+    "The agent doesn't know Hoop exists.",
+  ];
+
+  /* ---- icons ---- */
+  function AgentIcon({ color }) {
+    return (
+      <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+        <circle cx="8" cy="5" r="3" stroke={color} strokeWidth="1.2" />
+        <path d="M3 14c0-2.76 2.24-5 5-5s5 2.24 5 5" stroke={color} strokeWidth="1.2" strokeLinecap="round" />
+      </svg>
+    );
+  }
+
+  function GearIcon({ color }) {
+    return (
+      <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+        <circle cx="8" cy="8" r="2.5" stroke={color} strokeWidth="1.2" />
+        <path d="M8 1.5v2M8 12.5v2M1.5 8h2M12.5 8h2M3.4 3.4l1.4 1.4M11.2 11.2l1.4 1.4M3.4 12.6l1.4-1.4M11.2 4.8l1.4-1.4" stroke={color} strokeWidth="1" strokeLinecap="round" />
+      </svg>
+    );
+  }
+
+  function DbIcon({ color }) {
+    return (
+      <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+        <ellipse cx="8" cy="4" rx="5" ry="2" stroke={color} strokeWidth="1.2" />
+        <path d="M3 4v8c0 1.1 2.24 2 5 2s5-.9 5-2V4" stroke={color} strokeWidth="1.2" />
+        <path d="M3 8c0 1.1 2.24 2 5 2s5-.9 5-2" stroke={color} strokeWidth="1.2" />
+      </svg>
+    );
+  }
+
+  function ShieldIcon({ color }) {
+    return (
+      <svg width="22" height="22" viewBox="0 0 20 20" fill="none">
+        <path d="M10 2L3 5.5V10C3 14.5 6 17.5 10 19C14 17.5 17 14.5 17 10V5.5L10 2Z"
+          fill="rgba(var(--warm-gold-rgb),0.10)" stroke={color} strokeWidth="1.2" />
+        <path d="M7 10l2 2 4-4" stroke={color} strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    );
+  }
+
+  function SourceIcon({ type, color }) {
+    if (type === 'agent') return <AgentIcon color={color} />;
+    if (type === 'gear') return <GearIcon color={color} />;
+    return <DbIcon color={color} />;
+  }
+
+  const [activeSource, setActiveSource] = useState(-1);
+  const [dotPhase, setDotPhase] = useState('idle'); // idle | toGateway | atGateway | toDb | done
+  const [activeControls, setActiveControls] = useState(-1);
+  const [messageIdx, setMessageIdx] = useState(0);
+  const [cycle, setCycle] = useState(0);
+  const timers = useRef([]);
+
+  function T(fn, ms) {
+    const id = setTimeout(fn, ms);
+    timers.current.push(id);
+  }
+
+  useEffect(() => {
+    timers.current.forEach(clearTimeout);
+    timers.current = [];
+
+    const srcIdx = cycle % SOURCES.length;
+
+    setActiveSource(srcIdx);
+    setDotPhase('idle');
+    setActiveControls(-1);
+
+    // Dot starts moving to gateway
+    T(() => setDotPhase('toGateway'), 200);
+
+    // Dot arrives at gateway
+    T(() => setDotPhase('atGateway'), 900);
+
+    // Controls light up sequentially
+    T(() => setActiveControls(0), 1000);
+    T(() => setActiveControls(1), 1300);
+    T(() => setActiveControls(2), 1600);
+
+    // Dot continues to database (now gold)
+    T(() => setDotPhase('toDb'), 1900);
+
+    // Dot arrives
+    T(() => setDotPhase('done'), 2500);
+
+    // Cycle message
+    T(() => setMessageIdx((m) => (m + 1) % MESSAGES.length), 2200);
+
+    // Next cycle
+    T(() => setCycle((c) => c + 1), 3400);
+
+    return () => timers.current.forEach(clearTimeout);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cycle]);
+
+  const gatewayActive = dotPhase === 'atGateway' || activeControls >= 0;
+
+  return (
+    <div className="jdbc-root" aria-hidden="true">
+      <div className="jdbc-flow">
+        {/* ---- Stage 1: Sources ---- */}
+        <div className="jdbc-sources">
+          {SOURCES.map((src, i) => {
+            const active = i === activeSource;
+            return (
+              <div key={src.name} className={`jdbc-card${active ? ' jdbc-card--active' : ''}`}>
+                <div className="jdbc-card-header">
+                  <SourceIcon
+                    type={src.icon}
+                    color={active ? (src.icon === 'agent' ? 'var(--warm-gold)' : 'rgba(var(--sand-100-rgb),0.6)') : 'rgba(var(--sand-100-rgb),0.2)'}
+                  />
+                  <span className="jdbc-card-name" style={{
+                    color: active ? 'var(--sand-100)' : 'rgba(var(--sand-100-rgb),0.35)',
+                  }}>{src.name}</span>
+                </div>
+                <div className="jdbc-card-conn" style={{
+                  color: active ? 'rgba(var(--warm-gold-rgb),0.6)' : 'rgba(var(--sand-100-rgb),0.12)',
+                }}>{CONN_STRING}</div>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* ---- Flow line: Source → Gateway ---- */}
+        <div className="jdbc-line-container">
+          <div className={`jdbc-line${gatewayActive || dotPhase === 'toGateway' ? ' jdbc-line--active' : ''}`} />
+          {(dotPhase === 'toGateway') && (
+            <div className="jdbc-dot jdbc-dot--white jdbc-dot--move-right" />
+          )}
+        </div>
+
+        {/* ---- Stage 2: Gateway ---- */}
+        <div className={`jdbc-gateway${gatewayActive ? ' jdbc-gateway--active' : ''}`}>
+          <ShieldIcon color={gatewayActive ? 'var(--warm-gold)' : 'rgba(var(--sand-100-rgb),0.25)'} />
+          <span className="jdbc-gateway-label" style={{
+            color: gatewayActive ? 'var(--warm-gold)' : 'rgba(var(--sand-100-rgb),0.3)',
+          }}>Hoop Gateway</span>
+
+          <div className="jdbc-controls">
+            {CONTROLS.map((ctrl, i) => {
+              const on = i <= activeControls;
+              return (
+                <div key={ctrl.label} className={`jdbc-ctrl${on ? ' jdbc-ctrl--on' : ''}`}>
+                  <svg width="10" height="10" viewBox="0 0 16 16" fill="none" style={{ flexShrink: 0 }}>
+                    <path d="M3 8.5L6.5 12L13 4"
+                      stroke={on ? 'var(--warm-gold)' : 'rgba(var(--sand-100-rgb),0.15)'}
+                      strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                  <span>{ctrl.label}</span>
+                </div>
+              );
+            })}
+          </div>
+
+          <span className="jdbc-latency" style={{
+            opacity: gatewayActive ? 1 : 0.3,
+          }}>{'< 5ms added latency'}</span>
+        </div>
+
+        {/* ---- Flow line: Gateway → Database ---- */}
+        <div className="jdbc-line-container">
+          <div className={`jdbc-line${dotPhase === 'toDb' || dotPhase === 'done' ? ' jdbc-line--active' : ''}`} />
+          {(dotPhase === 'toDb') && (
+            <div className="jdbc-dot jdbc-dot--gold jdbc-dot--move-right" />
+          )}
+        </div>
+
+        {/* ---- Stage 3: Database ---- */}
+        <div className={`jdbc-dest${dotPhase === 'done' ? ' jdbc-dest--active' : ''}`}>
+          <DbIcon color={dotPhase === 'done' ? 'var(--warm-gold)' : 'rgba(var(--sand-100-rgb),0.25)'} />
+          <span className="jdbc-dest-name" style={{
+            color: dotPhase === 'done' ? 'var(--sand-100)' : 'rgba(var(--sand-100-rgb),0.35)',
+          }}>PostgreSQL</span>
+          <span className="jdbc-dest-host">prod-db-cluster.internal:5432</span>
+        </div>
+      </div>
+
+      {/* ---- Callout message ---- */}
+      <div className="jdbc-message" key={messageIdx}>
+        {MESSAGES[messageIdx]}
+      </div>
+
+      <style>{`
+        .jdbc-root {
+          width: 100%;
+          max-width: 650px;
+          margin: 0 auto;
+          font-family: 'DM Sans', system-ui, sans-serif;
+        }
+
+        .jdbc-flow {
+          display: flex;
+          align-items: center;
+          gap: 0;
+          width: 100%;
+        }
+
+        /* ---- Sources ---- */
+        .jdbc-sources {
+          display: flex;
+          flex-direction: column;
+          gap: 6px;
+          flex-shrink: 0;
+          width: 180px;
+        }
+
+        .jdbc-card {
+          padding: 8px 10px;
+          border-radius: 8px;
+          background: rgba(var(--sand-100-rgb),0.04);
+          border: 1px solid rgba(var(--sand-100-rgb),0.08);
+          transition: all 0.4s ease;
+        }
+        .jdbc-card--active {
+          background: rgba(var(--warm-gold-rgb),0.06);
+          border-color: rgba(var(--warm-gold-rgb),0.18);
+        }
+
+        .jdbc-card-header {
+          display: flex;
+          align-items: center;
+          gap: 7px;
+          margin-bottom: 4px;
+        }
+
+        .jdbc-card-name {
+          font-family: 'DM Sans', sans-serif;
+          font-size: 12px;
+          font-weight: 600;
+          transition: color 0.4s ease;
+        }
+
+        .jdbc-card-conn {
+          font-family: 'JetBrains Mono', monospace;
+          font-size: 8px;
+          line-height: 1.3;
+          word-break: break-all;
+          transition: color 0.4s ease;
+        }
+
+        /* ---- Flow lines ---- */
+        .jdbc-line-container {
+          flex: 1;
+          min-width: 32px;
+          height: 2px;
+          position: relative;
+          display: flex;
+          align-items: center;
+        }
+
+        .jdbc-line {
+          width: 100%;
+          height: 1px;
+          background: rgba(var(--sand-100-rgb),0.08);
+          transition: background 0.4s ease;
+        }
+        .jdbc-line--active {
+          background: rgba(var(--warm-gold-rgb),0.3);
+        }
+
+        .jdbc-dot {
+          position: absolute;
+          width: 6px;
+          height: 6px;
+          border-radius: 50%;
+          top: 50%;
+          transform: translateY(-50%);
+          filter: blur(0px);
+        }
+        .jdbc-dot--white {
+          background: var(--sand-100);
+          box-shadow: 0 0 6px rgba(var(--sand-100-rgb),0.5);
+        }
+        .jdbc-dot--gold {
+          background: var(--warm-gold);
+          box-shadow: 0 0 8px rgba(var(--warm-gold-rgb),0.6);
+        }
+        .jdbc-dot--move-right {
+          animation: jdbc-travel 0.7s ease-in-out forwards;
+        }
+
+        @keyframes jdbc-travel {
+          0% { left: 0%; }
+          100% { left: calc(100% - 6px); }
+        }
+
+        /* ---- Gateway ---- */
+        .jdbc-gateway {
+          flex-shrink: 0;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          gap: 6px;
+          padding: 14px 16px;
+          border-radius: 10px;
+          background: rgba(var(--sand-100-rgb),0.04);
+          border: 1px solid rgba(var(--sand-100-rgb),0.08);
+          transition: all 0.4s ease;
+          min-width: 130px;
+        }
+        .jdbc-gateway--active {
+          background: rgba(var(--warm-gold-rgb),0.06);
+          border-color: rgba(var(--warm-gold-rgb),0.3);
+          box-shadow: 0 0 20px rgba(var(--warm-gold-rgb),0.08);
+        }
+
+        .jdbc-gateway-label {
+          font-family: 'Sora', sans-serif;
+          font-size: 11px;
+          font-weight: 600;
+          transition: color 0.4s ease;
+        }
+
+        .jdbc-controls {
+          display: flex;
+          flex-direction: column;
+          gap: 3px;
+          width: 100%;
+          margin-top: 4px;
+        }
+
+        .jdbc-ctrl {
+          display: flex;
+          align-items: center;
+          gap: 6px;
+          opacity: 0.3;
+          transition: opacity 0.3s ease;
+        }
+        .jdbc-ctrl--on {
+          opacity: 1;
+        }
+        .jdbc-ctrl span {
+          font-family: 'JetBrains Mono', monospace;
+          font-size: 9px;
+          color: rgba(var(--sand-100-rgb),0.5);
+        }
+        .jdbc-ctrl--on span {
+          color: rgba(var(--sand-100-rgb),0.75);
+        }
+
+        .jdbc-latency {
+          font-family: 'JetBrains Mono', monospace;
+          font-size: 9px;
+          color: rgba(var(--sand-100-rgb),0.2);
+          margin-top: 4px;
+          transition: opacity 0.4s ease;
+        }
+
+        /* ---- Destination ---- */
+        .jdbc-dest {
+          flex-shrink: 0;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          gap: 4px;
+          padding: 14px 12px;
+          border-radius: 10px;
+          background: rgba(var(--sand-100-rgb),0.02);
+          border: 1px solid rgba(var(--sand-100-rgb),0.06);
+          transition: all 0.4s ease;
+          min-width: 100px;
+        }
+        .jdbc-dest--active {
+          border-color: rgba(var(--warm-gold-rgb),0.15);
+        }
+
+        .jdbc-dest-name {
+          font-family: 'DM Sans', sans-serif;
+          font-size: 12px;
+          font-weight: 600;
+          transition: color 0.4s ease;
+        }
+
+        .jdbc-dest-host {
+          font-family: 'JetBrains Mono', monospace;
+          font-size: 8px;
+          color: rgba(var(--sand-100-rgb),0.2);
+          text-align: center;
+          word-break: break-all;
+        }
+
+        /* ---- Message callout ---- */
+        .jdbc-message {
+          text-align: center;
+          margin-top: 20px;
+          padding-top: 14px;
+          border-top: 1px solid rgba(var(--sand-100-rgb),0.06);
+          font-family: 'DM Sans', sans-serif;
+          font-size: 12px;
+          font-weight: 500;
+          color: rgba(var(--sand-100-rgb),0.4);
+          font-style: italic;
+          animation: jdbc-fade-in 0.5s ease;
+        }
+
+        @keyframes jdbc-fade-in {
+          0% { opacity: 0; transform: translateY(4px); }
+          100% { opacity: 1; transform: translateY(0); }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/snippets/annimations/KillCommandDemo.jsx
+++ b/snippets/annimations/KillCommandDemo.jsx
@@ -1,0 +1,366 @@
+export const KillCommandDemo = () => {
+  const COMMANDS = [
+    { cmd: "SELECT count(*) FROM orders;", blocked: false, rule: null, type: "SELECT" },
+    { cmd: "kubectl get pods -n payments", blocked: false, rule: null, type: "READ" },
+    { cmd: "DROP TABLE customers;", blocked: true, rule: "Destructive DDL blocked", type: "DROP" },
+    { cmd: "DELETE FROM users WHERE 1=1;", blocked: true, rule: "Missing WHERE clause", type: "DELETE" },
+    { cmd: "rm -rf /var/data/prod", blocked: true, rule: "Destructive exec blocked", type: "EXEC" },
+  ];
+
+  const animationStyles = `
+    @keyframes slideIn {
+      from { opacity: 0; transform: translateX(-40px); }
+      to { opacity: 1; transform: translateX(0); }
+    }
+    @keyframes pulseShield {
+      0%, 100% { transform: scale(1); filter: drop-shadow(0 0 0px rgba(var(--bronze-rgb),0)); }
+      50% { transform: scale(1.08); filter: drop-shadow(0 0 12px rgba(var(--bronze-rgb),0.4)); }
+    }
+    @keyframes pulseShieldBlock {
+      0% { transform: scale(1); filter: drop-shadow(0 0 0px rgba(180,60,60,0)); }
+      30% { transform: scale(1.15); filter: drop-shadow(0 0 16px rgba(180,60,60,0.5)); }
+      100% { transform: scale(1); filter: drop-shadow(0 0 0px rgba(180,60,60,0)); }
+    }
+    @keyframes resultSlide {
+      from { opacity: 0; transform: translateY(8px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+    @keyframes fadeInUp {
+      from { opacity: 0; transform: translateY(12px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+    @keyframes scanLine {
+      0% { top: 0%; opacity: 0; }
+      10% { opacity: 1; }
+      90% { opacity: 1; }
+      100% { top: 100%; opacity: 0; }
+    }
+  `;
+
+  const ShieldIcon = ({ state, size = 56 }) => {
+    const color = state === "block" ? "#B43C3C" : state === "pass" ? "#4A7C59" : "var(--bronze)";
+    const anim = state === "block" ? "pulseShieldBlock 0.5s ease-out" : state === "pass" ? "pulseShield 0.6s ease-out" : "none";
+    return (
+      <svg width={size} height={size} viewBox="0 0 48 48" style={{ animation: anim }}>
+        <path
+          d="M24 4L6 12v12c0 11.1 7.7 21.5 18 24 10.3-2.5 18-12.9 18-24V12L24 4z"
+          fill="none"
+          stroke={color}
+          strokeWidth="2.5"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M24 8L10 14.5v9.5c0 9.2 6.4 17.8 14 20 7.6-2.2 14-10.8 14-20v-9.5L24 8z"
+          fill={color}
+          fillOpacity="0.08"
+        />
+        {state === "block" && (
+          <g stroke="#B43C3C" strokeWidth="3" strokeLinecap="round">
+            <line x1="18" y1="18" x2="30" y2="30" />
+            <line x1="30" y1="18" x2="18" y2="30" />
+          </g>
+        )}
+        {state === "pass" && (
+          <polyline
+            points="16,24 22,30 32,18"
+            fill="none"
+            stroke="#4A7C59"
+            strokeWidth="3"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        )}
+        {state === "idle" && (
+          <g>
+            <rect x="19" y="15" width="10" height="3" rx="1.5" fill="var(--bronze)" fillOpacity="0.5" />
+            <rect x="17" y="21" width="14" height="3" rx="1.5" fill="var(--bronze)" fillOpacity="0.35" />
+            <rect x="19" y="27" width="10" height="3" rx="1.5" fill="var(--bronze)" fillOpacity="0.2" />
+          </g>
+        )}
+      </svg>
+    );
+  };
+
+  const CommandTag = ({ type }) => {
+    const colors = {
+      SELECT: { bg: "rgba(var(--bronze-rgb),0.08)", text: "var(--bronze)" },
+      READ: { bg: "rgba(var(--bronze-rgb),0.08)", text: "var(--bronze)" },
+      DELETE: { bg: "rgba(180,60,60,0.08)", text: "#B43C3C" },
+      DROP: { bg: "rgba(180,60,60,0.08)", text: "#B43C3C" },
+      EXEC: { bg: "rgba(180,60,60,0.08)", text: "#B43C3C" },
+    };
+    const c = colors[type] || colors.SELECT;
+    return (
+      <span style={{
+        fontFamily: "'JetBrains Mono', monospace",
+        fontSize: 10,
+        fontWeight: 500,
+        color: c.text,
+        background: c.bg,
+        padding: "2px 8px",
+        borderRadius: 4,
+        letterSpacing: "0.04em",
+        textTransform: "uppercase",
+        whiteSpace: "nowrap",
+      }}>{type}</span>
+    );
+  };
+
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const [phase, setPhase] = useState("idle"); // idle | scanning | result
+  const [results, setResults] = useState([]);
+  const [stats, setStats] = useState({ blocked: 0, allowed: 0 });
+  const timerRef = useRef(null);
+  const indexRef = useRef(0);
+
+  const processNext = useCallback(() => {
+    const idx = indexRef.current % COMMANDS.length;
+    const q = COMMANDS[idx];
+    indexRef.current += 1;
+
+    setActiveIndex(idx);
+    setPhase("scanning");
+
+    timerRef.current = setTimeout(() => {
+      setPhase("result");
+      setResults(prev => {
+        const next = [{ ...q, ts: Date.now() }, ...prev];
+        return next.slice(0, 6);
+      });
+      setStats(prev => ({
+        blocked: prev.blocked + (q.blocked ? 1 : 0),
+        allowed: prev.allowed + (q.blocked ? 0 : 1),
+      }));
+
+      timerRef.current = setTimeout(() => {
+        setPhase("idle");
+        timerRef.current = setTimeout(() => {
+          processNext();
+        }, 600);
+      }, 1400);
+    }, 900);
+  }, []);
+
+  useEffect(() => {
+    timerRef.current = setTimeout(() => processNext(), 800);
+    return () => clearTimeout(timerRef.current);
+  }, []);
+
+  const currentCommand = activeIndex >= 0 ? COMMANDS[activeIndex] : null;
+  const shieldState = phase === "result" && currentCommand
+    ? (currentCommand.blocked ? "block" : "pass")
+    : phase === "scanning" ? "idle" : "idle";
+
+  return (
+    <div style={{
+      fontFamily: "'DM Sans', system-ui, sans-serif",
+      borderRadius: 12,
+      padding: "20px 24px 16px",
+      position: "relative",
+      overflow: "hidden",
+      width: "100%",
+      color: "var(--sand-100)",
+    }}>
+      <style>{animationStyles}</style>
+
+      {/* Radial glow */}
+      <div style={{
+        position: "absolute", top: "-30%", right: "-10%", width: "60%", height: "160%",
+        background: "radial-gradient(ellipse at center, rgba(var(--warm-gold-rgb),0.12) 0%, transparent 70%)",
+        pointerEvents: "none",
+      }} />
+
+      {/* Main animation area */}
+      <div style={{
+        display: "grid",
+        gridTemplateColumns: "1fr auto 1fr",
+        gap: 24,
+        alignItems: "start",
+        position: "relative",
+        height: 320,
+      }}>
+        {/* Left: incoming command */}
+        <div style={{
+          background: "rgba(var(--sand-100-rgb),0.04)",
+          border: "1px solid rgba(var(--sand-100-rgb),0.08)",
+          borderRadius: 10,
+          padding: 20,
+          height: 300,
+          overflow: "hidden",
+        }}>
+          <div style={{
+            fontSize: 10, fontWeight: 600, color: "rgba(var(--sand-100-rgb),0.25)",
+            textTransform: "uppercase", letterSpacing: "0.08em", marginBottom: 14,
+          }}>Incoming Command</div>
+
+          {currentCommand && phase !== "idle" ? (
+            <div key={indexRef.current} style={{ animation: "slideIn 0.35s ease-out" }}>
+              <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 10 }}>
+                <CommandTag type={currentCommand.type} />
+                <span style={{ fontSize: 11, color: "rgba(var(--sand-100-rgb),0.3)" }}>
+                  via CLI
+                </span>
+              </div>
+              <div style={{
+                fontFamily: "'JetBrains Mono', monospace",
+                fontSize: 13, lineHeight: 1.7,
+                color: "var(--sand-300)",
+                background: "rgba(var(--sand-100-rgb),0.03)",
+                padding: "14px 16px",
+                borderRadius: 8,
+                border: "1px solid rgba(var(--sand-100-rgb),0.06)",
+                wordBreak: "break-all",
+                position: "relative",
+                overflow: "hidden",
+              }}>
+                {currentCommand.cmd}
+                {phase === "scanning" && (
+                  <div style={{
+                    position: "absolute",
+                    left: 0, width: "100%", height: 2,
+                    background: "linear-gradient(90deg, transparent, var(--warm-gold), transparent)",
+                    animation: "scanLine 0.8s ease-in-out",
+                  }} />
+                )}
+              </div>
+
+              {phase === "scanning" && (
+                <div style={{
+                  marginTop: 14, fontSize: 12, color: "var(--warm-gold)",
+                  display: "flex", alignItems: "center", gap: 6,
+                  animation: "fadeInUp 0.3s ease-out",
+                }}>
+                  <span style={{
+                    width: 6, height: 6, borderRadius: "50%",
+                    background: "var(--warm-gold)",
+                    display: "inline-block",
+                    animation: "pulseShield 1s ease-in-out infinite",
+                  }} />
+                  Evaluating rules...
+                </div>
+              )}
+
+              {phase === "result" && (
+                <div style={{
+                  marginTop: 14,
+                  animation: "fadeInUp 0.3s ease-out",
+                  display: "flex", alignItems: "center", gap: 8,
+                }}>
+                  <span style={{
+                    width: 8, height: 8, borderRadius: "50%",
+                    background: currentCommand.blocked ? "#B43C3C" : "#4A7C59",
+                    display: "inline-block",
+                  }} />
+                  <span style={{
+                    fontSize: 12, fontWeight: 500,
+                    color: currentCommand.blocked ? "#D4726A" : "#7CB88A",
+                  }}>
+                    {currentCommand.blocked ? "Blocked" : "Allowed"}
+                  </span>
+                  {currentCommand.rule && (
+                    <span style={{ fontSize: 11, color: "rgba(var(--sand-100-rgb),0.3)" }}>
+                      {currentCommand.rule}
+                    </span>
+                  )}
+                </div>
+              )}
+            </div>
+          ) : (
+            <div style={{
+              color: "rgba(var(--sand-100-rgb),0.15)",
+              fontSize: 13, fontStyle: "italic",
+              paddingTop: 20,
+            }}>Waiting for next command...</div>
+          )}
+        </div>
+
+        {/* Center: shield */}
+        <div style={{
+          display: "flex", flexDirection: "column",
+          alignItems: "center", justifyContent: "center",
+          paddingTop: 40, gap: 12, minWidth: 72,
+        }}>
+          <ShieldIcon state={shieldState} size={56} />
+          <div style={{
+            fontSize: 10, fontWeight: 600, color: "rgba(var(--sand-100-rgb),0.2)",
+            textTransform: "uppercase", letterSpacing: "0.08em",
+            textAlign: "center",
+          }}>
+            {phase === "scanning" ? "Checking..." :
+             phase === "result" ? (currentCommand?.blocked ? "Denied" : "Clear") :
+             "Ready"}
+          </div>
+        </div>
+
+        {/* Right: decision log */}
+        <div style={{
+          background: "rgba(var(--sand-100-rgb),0.04)",
+          border: "1px solid rgba(var(--sand-100-rgb),0.08)",
+          borderRadius: 10,
+          padding: 20,
+          height: 300,
+          overflow: "hidden",
+        }}>
+          <div style={{
+            fontSize: 10, fontWeight: 600, color: "rgba(var(--sand-100-rgb),0.25)",
+            textTransform: "uppercase", letterSpacing: "0.08em", marginBottom: 14,
+          }}>Decision Log</div>
+
+          <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+            {results.length === 0 && (
+              <div style={{ color: "rgba(var(--sand-100-rgb),0.15)", fontSize: 12, fontStyle: "italic" }}>
+                No decisions yet
+              </div>
+            )}
+            {results.map((r, i) => (
+              <div key={r.ts} style={{
+                display: "flex", alignItems: "center", gap: 8,
+                padding: "8px 10px",
+                background: i === 0 ? "rgba(var(--sand-100-rgb),0.03)" : "transparent",
+                borderRadius: 6,
+                border: i === 0 ? "1px solid rgba(var(--sand-100-rgb),0.06)" : "1px solid transparent",
+                animation: i === 0 ? "resultSlide 0.3s ease-out" : "none",
+                opacity: 1 - (i * 0.12),
+              }}>
+                <span style={{
+                  width: 6, height: 6, borderRadius: "50%", flexShrink: 0,
+                  background: r.blocked ? "#B43C3C" : "#4A7C59",
+                }} />
+                <span style={{
+                  fontFamily: "'JetBrains Mono', monospace",
+                  fontSize: 11, color: "rgba(var(--sand-100-rgb),0.5)",
+                  overflow: "hidden", textOverflow: "ellipsis",
+                  whiteSpace: "nowrap", flex: 1,
+                }}>
+                  {r.cmd.length > 32 ? r.cmd.slice(0, 32) + "..." : r.cmd}
+                </span>
+                <span style={{
+                  fontSize: 10, fontWeight: 500, flexShrink: 0,
+                  color: r.blocked ? "#D4726A" : "#7CB88A",
+                }}>{r.blocked ? "BLOCKED" : "OK"}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Status bar */}
+      <div style={{
+        display: "flex", alignItems: "center", gap: 20,
+        marginTop: 16, paddingTop: 12,
+        borderTop: "1px solid rgba(var(--sand-100-rgb),0.06)",
+        position: "relative",
+      }}>
+        <span style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: 11, color: "rgba(var(--sand-100-rgb),0.25)" }}>
+          {stats.blocked} blocked
+        </span>
+        <span style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: 11, color: "rgba(var(--sand-100-rgb),0.25)" }}>
+          {stats.allowed} allowed
+        </span>
+        <span style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: 11, color: "var(--warm-gold)" }}>
+          &lt;5ms latency
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/snippets/annimations/KubernetesNativeMasking.jsx
+++ b/snippets/annimations/KubernetesNativeMasking.jsx
@@ -1,0 +1,629 @@
+export const KubernetesNativeMasking = () => {
+  const FONT_URL =
+    "https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700&family=JetBrains+Mono:wght@400;500&family=Sora:wght@600;700;800&display=swap";
+
+  const C = {
+    sand100: "var(--sand-100)",
+    sand300: "var(--sand-300)",
+    sand500: "var(--sand-500)",
+    warmGold: "var(--warm-gold)",
+    blocked: "var(--error)",
+    info: "rgba(var(--sand-100-rgb),0.45)",
+    warn: "var(--warm-gold)",
+    error: "var(--error)",
+    dim: "rgba(var(--sand-100-rgb),0.3)",
+    green: "#4A7C59",
+    blue: "#5B8CB8",
+  };
+
+  const animationStyles = `
+    @keyframes typeCursor {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0; }
+    }
+    @keyframes shieldFlash {
+      0% { opacity: 0; transform: scale(0.8); }
+      30% { opacity: 1; transform: scale(1.1); }
+      100% { opacity: 0; transform: scale(1.3); }
+    }
+    @keyframes fadeInLine {
+      from { opacity: 0; transform: translateY(4px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+    @keyframes pulseBlock {
+      0%, 100% { box-shadow: 0 0 0 0 rgba(199,107,74,0); }
+      50% { box-shadow: 0 0 20px 4px rgba(199,107,74,0.25); }
+    }
+    @keyframes streamDot {
+      0% { opacity: 0.3; }
+      50% { opacity: 1; }
+      100% { opacity: 0.3; }
+    }
+  `;
+
+  const LOG_LINES = [
+    {
+      time: "2026-03-22 14:22:01",
+      level: "INFO",
+      parts: [
+        { text: "User authenticated: ", masked: false },
+        { text: "[EMAIL]", masked: true },
+        { text: " from ", masked: false },
+        { text: "[IP]", masked: true },
+      ],
+    },
+    {
+      time: "2026-03-22 14:22:03",
+      level: "INFO",
+      parts: [
+        { text: "Query executed: SELECT * FROM users WHERE id=", masked: false },
+        { text: "[REDACTED]", masked: true },
+      ],
+    },
+    {
+      time: "2026-03-22 14:22:05",
+      level: "WARN",
+      parts: [
+        { text: "Rate limit: ", masked: false },
+        { text: "[EMAIL]", masked: true },
+        { text: " exceeded 100 req/min", masked: false },
+      ],
+    },
+    {
+      time: "2026-03-22 14:22:08",
+      level: "INFO",
+      parts: [
+        { text: "Payment: card=", masked: false },
+        { text: "[PCI]", masked: true },
+        { text: " amount=$1,250.00 user=", masked: false },
+        { text: "[EMAIL]", masked: true },
+      ],
+    },
+    {
+      time: "2026-03-22 14:22:11",
+      level: "ERROR",
+      parts: [
+        { text: "Auth failed: ", masked: false },
+        { text: "[EMAIL]", masked: true },
+        { text: " invalid token from ", masked: false },
+        { text: "[IP]", masked: true },
+      ],
+    },
+  ];
+
+  const KUBECTL_SEQUENCE = [
+    {
+      command: "kubectl logs api-server-7d9f8b -n production --tail=3",
+      output: [
+        { text: `[2026-03-22 14:22:05] WARN  Rate limit: `, parts: [{ text: "[EMAIL]", masked: true }], suffix: " exceeded 100 req/min" },
+        { text: `[2026-03-22 14:22:08] INFO  Payment: card=`, parts: [{ text: "[PCI]", masked: true }], suffix: ` amount=$1,250.00 user=`, parts2: [{ text: "[EMAIL]", masked: true }] },
+        { text: `[2026-03-22 14:22:11] ERROR Auth failed: `, parts: [{ text: "[EMAIL]", masked: true }], suffix: ` invalid token from `, parts2: [{ text: "[IP]", masked: true }] },
+      ],
+      blocked: false,
+    },
+    {
+      command: "kubectl exec -it api-server-7d9f8b -- cat /tmp/debug.log",
+      output: [
+        { text: `session_token=`, parts: [{ text: "[REDACTED]", masked: true }], suffix: ` user_email=`, parts2: [{ text: "[EMAIL]", masked: true }] },
+        { text: `db_password=`, parts: [{ text: "[REDACTED]", masked: true }], suffix: ` host=10.0.`, parts2: [{ text: "[IP]", masked: true }] },
+        { text: `api_key=`, parts: [{ text: "[REDACTED]", masked: true }], suffix: ` card=`, parts2: [{ text: "[PCI]", masked: true }] },
+      ],
+      blocked: false,
+    },
+    {
+      command: "kubectl delete namespace production",
+      output: [],
+      blocked: true,
+      blockMessage: "hoop | BLOCKED: destructive operation (delete namespace) requires approval",
+    },
+  ];
+
+  const K8sIcon = ({ size = 14 }) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none">
+      <path
+        d="M16 2L4 9v14l12 7 12-7V9L16 2z"
+        stroke="#5B8CB8"
+        strokeWidth="1.5"
+        fill="rgba(91,140,184,0.1)"
+        strokeLinejoin="round"
+      />
+      <circle cx="16" cy="16" r="3" stroke="#5B8CB8" strokeWidth="1.2" fill="none" />
+      <g stroke="#5B8CB8" strokeWidth="1" opacity="0.6">
+        <line x1="16" y1="13" x2="16" y2="6" />
+        <line x1="16" y1="19" x2="16" y2="26" />
+        <line x1="13.4" y1="14.5" x2="7.5" y2="11" />
+        <line x1="18.6" y1="17.5" x2="24.5" y2="21" />
+        <line x1="18.6" y1="14.5" x2="24.5" y2="11" />
+        <line x1="13.4" y1="17.5" x2="7.5" y2="21" />
+      </g>
+    </svg>
+  );
+
+  const ShieldIcon = ({ active, size = 16 }) => (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none"
+      style={active ? { animation: "shieldFlash 0.6s ease-out" } : undefined}
+    >
+      <path
+        d="M12 2L4 6v6c0 5.55 3.84 10.74 8 12 4.16-1.26 8-6.45 8-12V6L12 2z"
+        fill={active ? "rgba(199,107,74,0.2)" : "none"}
+        stroke={active ? C.blocked : C.sand500}
+        strokeWidth="1.5"
+        strokeLinejoin="round"
+      />
+      {active && (
+        <>
+          <line x1="8" y1="8" x2="16" y2="16" stroke={C.blocked} strokeWidth="2" strokeLinecap="round" />
+          <line x1="16" y1="8" x2="8" y2="16" stroke={C.blocked} strokeWidth="2" strokeLinecap="round" />
+        </>
+      )}
+    </svg>
+  );
+
+  function levelColor(level) {
+    if (level === "WARN") return C.warn;
+    if (level === "ERROR") return C.error;
+    return C.info;
+  }
+
+  function LogLine({ line, style }) {
+    return (
+      <div style={{
+        fontFamily: "'JetBrains Mono', monospace",
+        fontSize: 10,
+        lineHeight: "18px",
+        whiteSpace: "nowrap",
+        animation: "fadeInLine 0.3s ease-out",
+        ...style,
+      }}>
+        <span style={{ color: C.dim }}>[{line.time}] </span>
+        <span style={{ color: levelColor(line.level), fontWeight: 500 }}>
+          {line.level.padEnd(5)}
+        </span>
+        <span style={{ color: "rgba(var(--sand-100-rgb),0.55)" }}> </span>
+        {line.parts.map((p, i) =>
+          p.masked ? (
+            <span key={i} style={{ color: C.warmGold, fontWeight: 700 }}>{p.text}</span>
+          ) : (
+            <span key={i} style={{ color: "rgba(var(--sand-100-rgb),0.55)" }}>{p.text}</span>
+          )
+        )}
+      </div>
+    );
+  }
+
+  function KubectlOutputLine({ item }) {
+    return (
+      <div style={{
+        fontFamily: "'JetBrains Mono', monospace",
+        fontSize: 10,
+        lineHeight: "17px",
+        whiteSpace: "nowrap",
+        animation: "fadeInLine 0.25s ease-out",
+      }}>
+        <span style={{ color: "rgba(var(--sand-100-rgb),0.5)" }}>{item.text}</span>
+        {item.parts?.map((p, i) => (
+          <span key={i} style={{ color: C.warmGold, fontWeight: 700 }}>{p.text}</span>
+        ))}
+        {item.suffix && <span style={{ color: "rgba(var(--sand-100-rgb),0.5)" }}>{item.suffix}</span>}
+        {item.parts2?.map((p, i) => (
+          <span key={`b${i}`} style={{ color: C.warmGold, fontWeight: 700 }}>{p.text}</span>
+        ))}
+      </div>
+    );
+  }
+
+  const [lensLogs, setLensLogs] = useState([]);
+  const [kubectlState, setKubectlState] = useState({ cmdIdx: -1, typed: "", output: [], showBlock: false, cursorVisible: true });
+  const [shieldActive, setShieldActive] = useState(false);
+  const [fadingOut, setFadingOut] = useState(false);
+  const timeouts = useRef([]);
+  const cycleRef = useRef(null);
+
+  const clearAll = useCallback(() => {
+    timeouts.current.forEach(clearTimeout);
+    timeouts.current = [];
+  }, []);
+
+  const later = useCallback((fn, ms) => {
+    const id = setTimeout(fn, ms);
+    timeouts.current.push(id);
+    return id;
+  }, []);
+
+  // Left panel: streaming log lines
+  useEffect(() => {
+    let cancelled = false;
+    let idx = 0;
+
+    const streamLog = () => {
+      if (cancelled) return;
+      setLensLogs(prev => {
+        const next = [...prev, LOG_LINES[idx % LOG_LINES.length]];
+        // keep last 5 lines visible
+        return next.slice(-5);
+      });
+      idx++;
+    };
+
+    const startStream = () => {
+      if (cancelled) return;
+      setLensLogs([]);
+      idx = 0;
+      // Stream lines every 1.2s
+      const streamLine = (i) => {
+        if (cancelled || i >= LOG_LINES.length) return;
+        later(() => {
+          streamLog();
+          streamLine(i + 1);
+        }, 1200);
+      };
+      streamLine(0);
+    };
+
+    // Initial stream starts immediately
+    later(startStream, 300);
+
+    return () => { cancelled = true; clearAll(); };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Right panel: sequential kubectl commands
+  useEffect(() => {
+    let cancelled = false;
+
+    const typeCommand = (cmd, onDone) => {
+      let i = 0;
+      const typeChar = () => {
+        if (cancelled) return;
+        i++;
+        setKubectlState(prev => ({ ...prev, typed: cmd.slice(0, i), cursorVisible: true }));
+        if (i < cmd.length) {
+          later(typeChar, 30 + Math.random() * 25);
+        } else {
+          later(onDone, 400);
+        }
+      };
+      later(typeChar, 200);
+    };
+
+    const runSequence = () => {
+      if (cancelled) return;
+      setKubectlState({ cmdIdx: -1, typed: "", output: [], showBlock: false, cursorVisible: true });
+      setShieldActive(false);
+      setFadingOut(false);
+
+      let totalDelay = 800; // initial delay
+
+      KUBECTL_SEQUENCE.forEach((step, sIdx) => {
+        const startDelay = totalDelay;
+
+        // Start typing command
+        later(() => {
+          if (cancelled) return;
+          setKubectlState(prev => ({ ...prev, cmdIdx: sIdx, typed: "", output: [], showBlock: false }));
+          typeCommand(step.command, () => {
+            if (cancelled) return;
+            // Show output
+            if (step.blocked) {
+              later(() => {
+                if (cancelled) return;
+                setKubectlState(prev => ({ ...prev, showBlock: true, cursorVisible: false }));
+                setShieldActive(true);
+                later(() => setShieldActive(false), 800);
+              }, 300);
+            } else {
+              // Show output lines one by one
+              step.output.forEach((_, oIdx) => {
+                later(() => {
+                  if (cancelled) return;
+                  setKubectlState(prev => ({
+                    ...prev,
+                    output: step.output.slice(0, oIdx + 1),
+                  }));
+                }, 200 + oIdx * 150);
+              });
+            }
+          });
+        }, startDelay);
+
+        // Calculate time for this step
+        const typingTime = step.command.length * 42 + 400;
+        const outputTime = step.blocked ? 1200 : step.output.length * 150 + 600;
+        totalDelay += typingTime + outputTime + 1000; // gap between commands
+      });
+
+      // Hold, fade, restart
+      later(() => {
+        if (cancelled) return;
+        setFadingOut(true);
+        later(() => {
+          if (cancelled) return;
+          setLensLogs([]);
+          setKubectlState({ cmdIdx: -1, typed: "", output: [], showBlock: false, cursorVisible: true });
+          later(runSequence, 500);
+        }, 800);
+      }, totalDelay + 3000);
+    };
+
+    cycleRef.current = runSequence;
+    later(runSequence, 100);
+
+    return () => { cancelled = true; clearAll(); };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const panelBg = "rgba(var(--sand-100-rgb),0.04)";
+  const panelBorder = "rgba(var(--sand-100-rgb),0.08)";
+  const chromeBg = "rgba(var(--sand-100-rgb),0.06)";
+
+  const maskedCount = lensLogs.reduce((acc, l) => acc + l.parts.filter(p => p.masked).length, 0);
+
+  return (
+    <div style={{
+      maxWidth: 700,
+      width: "100%",
+      margin: "0 auto",
+      fontFamily: "'DM Sans', sans-serif",
+      opacity: fadingOut ? 0 : 1,
+      transition: "opacity 0.8s ease",
+    }}>
+      <style>{animationStyles}</style>
+      <link rel="stylesheet" href={FONT_URL} />
+
+      <div style={{
+        display: "grid",
+        gridTemplateColumns: "1fr 1fr",
+        gap: 12,
+        height: 380,
+        overflow: "hidden",
+      }}>
+        {/* Left Panel: Lens-style pod log viewer */}
+        <div style={{
+          background: panelBg,
+          border: `1px solid ${panelBorder}`,
+          borderRadius: 10,
+          overflow: "hidden",
+          display: "flex",
+          flexDirection: "column",
+        }}>
+          {/* Lens chrome */}
+          <div style={{
+            background: chromeBg,
+            borderBottom: `1px solid ${panelBorder}`,
+            padding: "7px 10px",
+            display: "flex",
+            alignItems: "center",
+            gap: 6,
+          }}>
+            <K8sIcon size={13} />
+            <span style={{
+              fontFamily: "'DM Sans', sans-serif",
+              fontSize: 10,
+              fontWeight: 600,
+              color: "rgba(var(--sand-100-rgb),0.7)",
+              letterSpacing: 0.3,
+            }}>Lens</span>
+            <div style={{ flex: 1 }} />
+            <div style={{ display: "flex", gap: 4 }}>
+              <div style={{ width: 7, height: 7, borderRadius: "50%", background: "rgba(var(--sand-100-rgb),0.12)" }} />
+              <div style={{ width: 7, height: 7, borderRadius: "50%", background: "rgba(var(--sand-100-rgb),0.12)" }} />
+              <div style={{ width: 7, height: 7, borderRadius: "50%", background: "rgba(var(--sand-100-rgb),0.12)" }} />
+            </div>
+          </div>
+
+          {/* Tab bar */}
+          <div style={{
+            padding: "4px 10px",
+            borderBottom: `1px solid ${panelBorder}`,
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+          }}>
+            <div style={{
+              fontFamily: "'JetBrains Mono', monospace",
+              fontSize: 9,
+              color: C.blue,
+              fontWeight: 500,
+              padding: "2px 6px",
+              background: "rgba(91,140,184,0.08)",
+              borderRadius: 4,
+              borderBottom: `1.5px solid ${C.blue}`,
+            }}>
+              Pod Logs &middot; api-server-7d9f8b
+            </div>
+          </div>
+
+          {/* Header bar */}
+          <div style={{
+            padding: "5px 10px",
+            borderBottom: `1px solid ${panelBorder}`,
+            display: "flex",
+            alignItems: "center",
+            gap: 6,
+            flexWrap: "wrap",
+          }}>
+            <span style={{
+              fontFamily: "'JetBrains Mono', monospace",
+              fontSize: 9,
+              color: "rgba(var(--sand-100-rgb),0.4)",
+              background: "rgba(var(--sand-100-rgb),0.04)",
+              padding: "1px 5px",
+              borderRadius: 3,
+              border: "1px solid rgba(var(--sand-100-rgb),0.06)",
+            }}>production</span>
+            <span style={{
+              fontFamily: "'JetBrains Mono', monospace",
+              fontSize: 9,
+              color: "rgba(var(--sand-100-rgb),0.35)",
+            }}>api-server-7d9f8b</span>
+            <div style={{ flex: 1 }} />
+            <span style={{
+              fontFamily: "'JetBrains Mono', monospace",
+              fontSize: 8,
+              color: C.green,
+              fontWeight: 600,
+              display: "flex",
+              alignItems: "center",
+              gap: 3,
+            }}>
+              <span style={{
+                width: 5, height: 5, borderRadius: "50%",
+                background: C.green,
+                animation: "streamDot 1.5s ease-in-out infinite",
+              }} />
+              Streaming
+            </span>
+          </div>
+
+          {/* Log lines */}
+          <div style={{
+            padding: "6px 8px",
+            flex: 1,
+            minHeight: 120,
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "flex-end",
+            overflow: "hidden",
+          }}>
+            {lensLogs.map((line, i) => (
+              <LogLine key={`${line.time}-${i}`} line={line} />
+            ))}
+          </div>
+
+          {/* Status bar */}
+          <div style={{
+            padding: "4px 10px",
+            borderTop: `1px solid ${panelBorder}`,
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+          }}>
+            <span style={{
+              fontFamily: "'JetBrains Mono', monospace",
+              fontSize: 8,
+              color: "rgba(var(--sand-100-rgb),0.3)",
+            }}>
+              {lensLogs.length} events &middot; {maskedCount} fields masked &middot; via hoop gateway
+            </span>
+          </div>
+        </div>
+
+        {/* Right Panel: kubectl terminal */}
+        <div style={{
+          background: panelBg,
+          border: `1px solid ${panelBorder}`,
+          borderRadius: 10,
+          overflow: "hidden",
+          display: "flex",
+          flexDirection: "column",
+        }}>
+          {/* Terminal chrome */}
+          <div style={{
+            background: chromeBg,
+            borderBottom: `1px solid ${panelBorder}`,
+            padding: "7px 10px",
+            display: "flex",
+            alignItems: "center",
+            gap: 6,
+          }}>
+            <span style={{
+              fontFamily: "'DM Sans', sans-serif",
+              fontSize: 10,
+              fontWeight: 600,
+              color: "rgba(var(--sand-100-rgb),0.7)",
+              letterSpacing: 0.3,
+            }}>Terminal &mdash; kubectl</span>
+            <div style={{ flex: 1 }} />
+            <div style={{ display: "flex", gap: 4 }}>
+              <div style={{ width: 7, height: 7, borderRadius: "50%", background: "rgba(var(--sand-100-rgb),0.12)" }} />
+              <div style={{ width: 7, height: 7, borderRadius: "50%", background: "rgba(var(--sand-100-rgb),0.12)" }} />
+              <div style={{ width: 7, height: 7, borderRadius: "50%", background: "rgba(var(--sand-100-rgb),0.12)" }} />
+            </div>
+          </div>
+
+          {/* Terminal content */}
+          <div style={{
+            padding: "8px 10px",
+            flex: 1,
+            minHeight: 160,
+            fontFamily: "'JetBrains Mono', monospace",
+            fontSize: 10,
+            lineHeight: "17px",
+            overflow: "hidden",
+          }}>
+            {KUBECTL_SEQUENCE.map((step, sIdx) => {
+              if (sIdx > kubectlState.cmdIdx) return null;
+              const isCurrent = sIdx === kubectlState.cmdIdx;
+              const prevComplete = sIdx < kubectlState.cmdIdx;
+
+              return (
+                <div key={sIdx} style={{ marginBottom: 8 }}>
+                  {/* Command line */}
+                  <div style={{ whiteSpace: "nowrap" }}>
+                    <span style={{ color: C.green, fontWeight: 500 }}>$ </span>
+                    <span style={{ color: "rgba(var(--sand-100-rgb),0.75)" }}>
+                      {isCurrent ? kubectlState.typed : step.command}
+                    </span>
+                    {isCurrent && kubectlState.cursorVisible && !prevComplete && kubectlState.typed.length < step.command.length && (
+                      <span style={{
+                        display: "inline-block",
+                        width: 6,
+                        height: 13,
+                        background: "rgba(var(--sand-100-rgb),0.6)",
+                        marginLeft: 1,
+                        verticalAlign: "text-bottom",
+                        animation: "typeCursor 0.8s step-end infinite",
+                      }} />
+                    )}
+                  </div>
+
+                  {/* Output */}
+                  {(prevComplete ? step.output : kubectlState.output).map((item, oIdx) => (
+                    <KubectlOutputLine key={oIdx} item={item} />
+                  ))}
+
+                  {/* Block message */}
+                  {step.blocked && (isCurrent ? kubectlState.showBlock : prevComplete) && (
+                    <div style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 6,
+                      marginTop: 3,
+                      padding: "4px 8px",
+                      borderRadius: 5,
+                      background: "rgba(199,107,74,0.08)",
+                      border: "1px solid rgba(199,107,74,0.15)",
+                      animation: isCurrent ? "pulseBlock 1s ease-out" : "none",
+                    }}>
+                      <ShieldIcon active={shieldActive} size={14} />
+                      <span style={{
+                        color: C.blocked,
+                        fontWeight: 600,
+                        fontSize: 9,
+                      }}>
+                        {step.blockMessage}
+                      </span>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+
+            {/* Cursor when idle */}
+            {kubectlState.cmdIdx === -1 && (
+              <div>
+                <span style={{ color: C.green, fontWeight: 500 }}>$ </span>
+                <span style={{
+                  display: "inline-block",
+                  width: 6,
+                  height: 13,
+                  background: "rgba(var(--sand-100-rgb),0.6)",
+                  verticalAlign: "text-bottom",
+                  animation: "typeCursor 0.8s step-end infinite",
+                }} />
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/snippets/annimations/NativeClientMasking.jsx
+++ b/snippets/annimations/NativeClientMasking.jsx
@@ -1,0 +1,461 @@
+export const NativeClientMasking = () => {
+  const C = {
+    warmGold: "var(--warm-gold)",
+    sand100: "var(--sand-100)",
+    sand300: "var(--sand-300)",
+    sand500: "var(--sand-500)",
+    rawFlash: "rgba(var(--sand-100-rgb),0.4)",
+  };
+
+  /* ── Panel data ────────────────────────────────────────────── */
+
+  const DBEAVER_COLS = ["name", "email", "ssn", "phone"];
+  const DBEAVER_ROWS = [
+    { raw: ["Sarah Chen", "sarah.chen@acme.io", "284-19-7653", "+1 415-892-3041"], masked: ["[PERSON]", "[EMAIL]", "[SSN]", "[PHONE]"] },
+    { raw: ["Marcus Webb", "m.webb@globex.com", "531-77-0294", "+1 212-555-8817"], masked: ["[PERSON]", "[EMAIL]", "[SSN]", "[PHONE]"] },
+    { raw: ["Elena Ruiz", "eruiz@initech.co", "719-42-8106", "+44 20-7946-0958"], masked: ["[PERSON]", "[EMAIL]", "[SSN]", "[PHONE]"] },
+    { raw: ["James Okafor", "j.okafor@stark.dev", "603-88-1542", "+1 650-331-7720"], masked: ["[PERSON]", "[EMAIL]", "[SSN]", "[PHONE]"] },
+  ];
+
+  const PSQL_ROWS = [
+    { raw: ["Sarah Chen", "sarah.chen@acme.io", "284-19-7653"], masked: ["[PERSON]", "[EMAIL]", "[SSN]"] },
+    { raw: ["Marcus Webb", "m.webb@globex.com", "531-77-0294"], masked: ["[PERSON]", "[EMAIL]", "[SSN]"] },
+    { raw: ["Elena Ruiz", "eruiz@initech.co", "719-42-8106"], masked: ["[PERSON]", "[EMAIL]", "[SSN]"] },
+  ];
+
+  const LENS_LINES = [
+    { prefix: "[INFO] User login: ", raw: "sarah@acme.io", masked: "[EMAIL]", suffix: " from ", raw2: "192.168.1.42", masked2: "[IP]", suffixEnd: "" },
+    { prefix: "[INFO] Payment processed: card ", raw: "4532-XXXX-XXXX-7821", masked: "[PCI]", suffix: " amount $142.50", raw2: null, masked2: null, suffixEnd: "" },
+    { prefix: "[WARN] Failed auth: ", raw: "m.webb@globex.com", masked: "[EMAIL]", suffix: " \u00b7 ", raw2: "10.0.3.88", masked2: "[IP]", suffixEnd: "" },
+  ];
+
+  const SSH_ROWS = [
+    { raw: ["Sarah Chen", "sarah.chen@acme.io", "284-19-7653"], masked: ["[PERSON]", "[EMAIL]", "[SSN]"] },
+    { raw: ["Marcus Webb", "m.webb@globex.com", "531-77-0294"], masked: ["[PERSON]", "[EMAIL]", "[SSN]"] },
+    { raw: ["Elena Ruiz", "eruiz@initech.co", "719-42-8106"], masked: ["[PERSON]", "[EMAIL]", "[SSN]"] },
+  ];
+
+  /* ── Timing constants ──────────────────────────────────────── */
+
+  const PANEL_STAGGER = 800;
+  const ROW_STAGGER = 400;
+  const RAW_FLASH_MS = 200;
+  const HOLD_MS = 3000;
+  const FADE_MS = 600;
+
+  /* ── Shared styles ─────────────────────────────────────────── */
+
+  const mono = "var(--mono, 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace)";
+
+  const panelBase = {
+    background: "rgba(var(--sand-100-rgb),0.04)",
+    border: "1px solid rgba(var(--sand-100-rgb),0.08)",
+    borderRadius: 10,
+    overflow: "hidden",
+    display: "flex",
+    flexDirection: "column",
+    height: 180,
+  };
+
+  const maskedStyle = {
+    color: C.warmGold,
+    fontWeight: 600,
+    fontFamily: mono,
+  };
+
+  const rawStyle = {
+    color: C.rawFlash,
+    fontFamily: mono,
+  };
+
+  const chromeBase = {
+    display: "flex",
+    alignItems: "center",
+    gap: 6,
+    padding: "6px 10px",
+    fontSize: 10,
+    fontWeight: 600,
+    letterSpacing: "0.02em",
+    borderBottom: "1px solid rgba(var(--sand-100-rgb),0.06)",
+  };
+
+  const statusBar = {
+    padding: "4px 10px",
+    fontSize: 9,
+    color: C.sand500,
+    borderTop: "1px solid rgba(var(--sand-100-rgb),0.06)",
+    fontFamily: mono,
+    marginTop: "auto",
+  };
+
+  /* ── Utility: cell renderer ────────────────────────────────── */
+
+  function MaskedCell({ raw, masked, isMasked, visible }) {
+    return (
+      <span
+        style={{
+          ...(isMasked ? maskedStyle : rawStyle),
+          opacity: visible ? 1 : 0,
+          transition: "opacity 0.2s ease, color 0.15s ease",
+          fontSize: 10,
+        }}
+      >
+        {isMasked ? masked : raw}
+      </span>
+    );
+  }
+
+  /* ── Panel: DBeaver ────────────────────────────────────────── */
+
+  function DBeaver({ rowStates }) {
+    return (
+      <div style={panelBase}>
+        <div style={{ ...chromeBase, background: "rgba(30,80,30,0.15)" }}>
+          <span style={{ color: "#5BA55B", fontSize: 12 }}>&#9672;</span>
+          <span style={{ color: C.sand100 }}>DBeaver</span>
+          <span style={{ color: C.sand500, marginLeft: "auto", fontWeight: 400 }}>customers @ prod-db</span>
+        </div>
+        <div style={{ padding: "8px 10px", flex: 1, overflow: "hidden" }}>
+          {/* Header row */}
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1.3fr 1fr 1.2fr", gap: 4, marginBottom: 4, borderBottom: "1px solid rgba(var(--sand-100-rgb),0.08)", paddingBottom: 4 }}>
+            {DBEAVER_COLS.map(col => (
+              <span key={col} style={{ fontSize: 9, color: C.sand500, fontFamily: mono, fontWeight: 600, textTransform: "uppercase" }}>{col}</span>
+            ))}
+          </div>
+          {/* Data rows */}
+          {DBEAVER_ROWS.map((row, ri) => {
+            const st = rowStates[ri] || { visible: false, masked: false };
+            return (
+              <div
+                key={ri}
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "1fr 1.3fr 1fr 1.2fr",
+                  gap: 4,
+                  padding: "2px 0",
+                  opacity: st.visible ? 1 : 0,
+                  transform: st.visible ? "translateX(0)" : "translateX(-8px)",
+                  transition: "opacity 0.3s ease, transform 0.3s ease",
+                }}
+              >
+                {row.raw.map((cell, ci) => (
+                  <MaskedCell key={ci} raw={cell} masked={row.masked[ci]} isMasked={st.masked} visible={st.visible} />
+                ))}
+              </div>
+            );
+          })}
+        </div>
+        <div style={statusBar}>4 rows returned &middot; masked by hoop gateway</div>
+      </div>
+    );
+  }
+
+  /* ── Panel: psql ───────────────────────────────────────────── */
+
+  function Psql({ rowStates }) {
+    const pad = (s, n) => s.padEnd(n);
+    const cols = ["name", "email", "ssn"];
+    const widths = [12, 20, 12];
+    const sep = widths.map(w => "-".repeat(w)).join("-+-");
+    const header = cols.map((c, i) => pad(c, widths[i])).join(" | ");
+
+    return (
+      <div style={panelBase}>
+        <div style={{ ...chromeBase, background: "rgba(var(--sand-100-rgb),0.03)" }}>
+          <span style={{ color: C.sand500, fontSize: 11 }}>&#9608;</span>
+          <span style={{ color: C.sand100 }}>Terminal</span>
+          <span style={{ color: C.sand500, fontWeight: 400 }}>&mdash; psql</span>
+        </div>
+        <div style={{ padding: "8px 10px", flex: 1, fontFamily: mono, fontSize: 10, lineHeight: 1.7, color: C.sand300, overflow: "hidden" }}>
+          <div><span style={{ color: C.sand500 }}>prod-db=&gt;</span> SELECT name, email, ssn FROM customers LIMIT 3;</div>
+          <div style={{ color: C.sand500, marginTop: 4 }}> {header}</div>
+          <div style={{ color: "rgba(var(--sand-100-rgb),0.12)" }}>{sep}</div>
+          {PSQL_ROWS.map((row, ri) => {
+            const st = rowStates[ri] || { visible: false, masked: false };
+            const vals = st.masked ? row.masked : row.raw;
+            const line = vals.map((v, ci) => pad(v, widths[ci])).join(" | ");
+            return (
+              <div
+                key={ri}
+                style={{
+                  opacity: st.visible ? 1 : 0,
+                  transform: st.visible ? "translateX(0)" : "translateX(-8px)",
+                  transition: "opacity 0.3s ease, transform 0.3s ease",
+                  color: st.masked ? C.warmGold : C.rawFlash,
+                  fontWeight: st.masked ? 600 : 400,
+                }}
+              >
+                {" "}{line}
+              </div>
+            );
+          })}
+          <div style={{ color: C.sand500, marginTop: 4 }}>(3 rows) &middot; masking: active</div>
+        </div>
+      </div>
+    );
+  }
+
+  /* ── Panel: Lens / K8s ─────────────────────────────────────── */
+
+  function Lens({ rowStates }) {
+    return (
+      <div style={panelBase}>
+        <div style={{ ...chromeBase, background: "rgba(50,100,200,0.12)" }}>
+          <span style={{ color: "#6B9FE8", fontSize: 11 }}>&#9781;</span>
+          <span style={{ color: C.sand100 }}>Lens</span>
+          <span style={{ color: C.sand500, fontWeight: 400 }}>&mdash; Pod Logs</span>
+        </div>
+        <div style={{ padding: "8px 10px", flex: 1, fontFamily: mono, fontSize: 10, lineHeight: 1.8, overflow: "hidden" }}>
+          {LENS_LINES.map((line, ri) => {
+            const st = rowStates[ri] || { visible: false, masked: false };
+            return (
+              <div
+                key={ri}
+                style={{
+                  opacity: st.visible ? 1 : 0,
+                  transform: st.visible ? "translateX(0)" : "translateX(-8px)",
+                  transition: "opacity 0.3s ease, transform 0.3s ease",
+                  color: C.sand300,
+                  whiteSpace: "nowrap",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                }}
+              >
+                <span style={{ color: C.sand500 }}>{line.prefix}</span>
+                <span style={st.masked ? maskedStyle : { ...rawStyle }}>{st.masked ? line.masked : line.raw}</span>
+                <span style={{ color: C.sand500 }}>{line.suffix}</span>
+                {line.raw2 && (
+                  <>
+                    <span style={st.masked ? maskedStyle : { ...rawStyle }}>{st.masked ? line.masked2 : line.raw2}</span>
+                    <span style={{ color: C.sand500 }}>{line.suffixEnd}</span>
+                  </>
+                )}
+              </div>
+            );
+          })}
+        </div>
+        <div style={statusBar}>streaming &middot; 3 fields masked</div>
+      </div>
+    );
+  }
+
+  /* ── Panel: SSH ────────────────────────────────────────────── */
+
+  function Ssh({ rowStates }) {
+    return (
+      <div style={panelBase}>
+        <div style={{ ...chromeBase, background: "rgba(var(--sand-100-rgb),0.03)" }}>
+          <span style={{ color: C.sand500, fontSize: 11 }}>&#9608;</span>
+          <span style={{ color: C.sand100 }}>Terminal</span>
+          <span style={{ color: C.sand500, fontWeight: 400 }}>&mdash; ssh prod-server</span>
+        </div>
+        <div style={{ padding: "8px 10px", flex: 1, fontFamily: mono, fontSize: 10, lineHeight: 1.7, color: C.sand300, overflow: "hidden" }}>
+          <div><span style={{ color: C.sand500 }}>$</span> cat /var/log/app/users.csv</div>
+          <div style={{ color: C.sand500, marginTop: 4 }}>id,name,email,ssn</div>
+          {SSH_ROWS.map((row, ri) => {
+            const st = rowStates[ri] || { visible: false, masked: false };
+            const vals = st.masked ? row.masked : row.raw;
+            return (
+              <div
+                key={ri}
+                style={{
+                  opacity: st.visible ? 1 : 0,
+                  transform: st.visible ? "translateX(0)" : "translateX(-8px)",
+                  transition: "opacity 0.3s ease, transform 0.3s ease",
+                  color: st.masked ? C.warmGold : C.rawFlash,
+                  fontWeight: st.masked ? 600 : 400,
+                }}
+              >
+                <span style={{ color: C.sand500 }}>{ri + 1},</span>{vals.join(",")}
+              </div>
+            );
+          })}
+          <div style={{ color: C.sand500, marginTop: 4 }}>file output &middot; 9 fields masked</div>
+        </div>
+      </div>
+    );
+  }
+
+  /* ── Gateway indicator (center) ────────────────────────────── */
+
+  function GatewayBadge({ pulsing }) {
+    return (
+      <div
+        style={{
+          position: "absolute",
+          top: "50%",
+          left: "50%",
+          transform: "translate(-50%, -50%)",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          gap: 2,
+          zIndex: 10,
+          pointerEvents: "none",
+        }}
+      >
+        <div
+          style={{
+            width: 32,
+            height: 32,
+            borderRadius: "50%",
+            background: pulsing ? "rgba(var(--warm-gold-rgb),0.2)" : "rgba(var(--warm-gold-rgb),0.08)",
+            border: `1.5px solid ${pulsing ? "rgba(var(--warm-gold-rgb),0.6)" : "rgba(var(--warm-gold-rgb),0.2)"}`,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            transition: "all 0.3s ease",
+            boxShadow: pulsing ? "0 0 16px rgba(var(--warm-gold-rgb),0.25)" : "none",
+          }}
+        >
+          <svg width="14" height="16" viewBox="0 0 14 16" fill="none">
+            <path
+              d="M7 0.5L0.5 3.5V7.5C0.5 11.5 3.3 15.1 7 15.5C10.7 15.1 13.5 11.5 13.5 7.5V3.5L7 0.5Z"
+              fill={pulsing ? "rgba(var(--warm-gold-rgb),0.3)" : "rgba(var(--warm-gold-rgb),0.1)"}
+              stroke={C.warmGold}
+              strokeWidth="1"
+              strokeLinejoin="round"
+              style={{ transition: "fill 0.3s ease" }}
+            />
+          </svg>
+        </div>
+        <span
+          style={{
+            fontSize: 8,
+            fontWeight: 700,
+            color: pulsing ? C.warmGold : C.sand500,
+            letterSpacing: "0.08em",
+            textTransform: "uppercase",
+            fontFamily: mono,
+            transition: "color 0.3s ease",
+          }}
+        >
+          hoop
+        </span>
+      </div>
+    );
+  }
+
+  /* ── Main component ────────────────────────────────────────── */
+
+  const PANEL_ROW_COUNTS = [4, 3, 3, 3]; // DBeaver, psql, Lens, SSH
+
+  // rowStates[panelIdx][rowIdx] = { visible, masked }
+  const [panelRows, setPanelRows] = useState(
+    PANEL_ROW_COUNTS.map(n => Array.from({ length: n }, () => ({ visible: false, masked: false })))
+  );
+  const [gatewayPulsing, setGatewayPulsing] = useState(false);
+  const [fadeOut, setFadeOut] = useState(false);
+  const timeouts = useRef([]);
+
+  const clearAll = useCallback(() => {
+    timeouts.current.forEach(clearTimeout);
+    timeouts.current = [];
+  }, []);
+
+  const later = useCallback((fn, ms) => {
+    const id = setTimeout(fn, ms);
+    timeouts.current.push(id);
+  }, []);
+
+  const setRow = useCallback((pi, ri, patch) => {
+    setPanelRows(prev => {
+      const next = prev.map(p => p.map(r => ({ ...r })));
+      Object.assign(next[pi][ri], patch);
+      return next;
+    });
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const cycle = () => {
+      if (cancelled) return;
+
+      // Reset
+      setPanelRows(PANEL_ROW_COUNTS.map(n => Array.from({ length: n }, () => ({ visible: false, masked: false }))));
+      setGatewayPulsing(false);
+      setFadeOut(false);
+
+      let t = 200; // initial delay
+
+      // For each panel, staggered
+      PANEL_ROW_COUNTS.forEach((rowCount, pi) => {
+        const panelStart = t + pi * PANEL_STAGGER;
+
+        for (let ri = 0; ri < rowCount; ri++) {
+          const rowStart = panelStart + ri * ROW_STAGGER;
+
+          // Show row (raw flash)
+          later(() => {
+            if (cancelled) return;
+            setRow(pi, ri, { visible: true, masked: false });
+            setGatewayPulsing(true);
+          }, rowStart);
+
+          // Flip to masked
+          later(() => {
+            if (cancelled) return;
+            setRow(pi, ri, { masked: true });
+          }, rowStart + RAW_FLASH_MS);
+
+          // Stop gateway pulse after last row of last panel
+          if (pi === PANEL_ROW_COUNTS.length - 1 && ri === rowCount - 1) {
+            later(() => {
+              if (cancelled) return;
+              setGatewayPulsing(false);
+            }, rowStart + RAW_FLASH_MS + 200);
+          }
+        }
+      });
+
+      // Total animation time
+      const lastPanel = PANEL_ROW_COUNTS.length - 1;
+      const lastRowCount = PANEL_ROW_COUNTS[lastPanel];
+      const totalFill = t + lastPanel * PANEL_STAGGER + (lastRowCount - 1) * ROW_STAGGER + RAW_FLASH_MS + 200;
+
+      // Hold
+      later(() => {
+        if (cancelled) return;
+        setFadeOut(true);
+      }, totalFill + HOLD_MS);
+
+      // Restart cycle
+      later(() => {
+        if (cancelled) return;
+        cycle();
+      }, totalFill + HOLD_MS + FADE_MS + 200);
+    };
+
+    cycle();
+
+    return () => {
+      cancelled = true;
+      clearAll();
+    };
+  }, [later, clearAll, setRow]);
+
+  return (
+    <div
+      style={{
+        maxWidth: 700,
+        width: "100%",
+        margin: "0 auto",
+      }}
+    >
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr 1fr",
+          gridTemplateRows: "180px 180px",
+          gap: 12,
+        }}
+      >
+        <DBeaver rowStates={panelRows[0]} />
+        <Psql rowStates={panelRows[1]} />
+        <Lens rowStates={panelRows[2]} />
+        <Ssh rowStates={panelRows[3]} />
+      </div>
+    </div>
+  );
+}

--- a/snippets/annimations/ObservabilityAnimation.jsx
+++ b/snippets/annimations/ObservabilityAnimation.jsx
@@ -1,0 +1,129 @@
+/**
+ * ObservabilityAnimation — Agent session log with live scoring
+ *
+ * Shows a session log where agent actions appear one by one.
+ * Each gets a risk score and status tag (logged/blocked/approved).
+ * Conveys: every agent action is recorded, scored, reviewable.
+ *
+ * Pure CSS + React state.
+ */
+
+export const ObservabilityAnimation = () => {
+  const ACTIONS = [
+    { action: 'SELECT * FROM users',          score: 'low',     status: 'logged',    color: 'rgba(var(--success-rgb),0.7)' },
+    { action: 'kubectl get pods -n prod',     score: 'low',     status: 'logged',    color: 'rgba(var(--success-rgb),0.7)' },
+    { action: 'UPDATE config SET rate=500',   score: 'medium',  status: 'approved',  color: 'var(--warm-gold)' },
+    { action: 'DELETE FROM cache WHERE 1=1',  score: 'high',    status: 'approved',  color: 'var(--warm-gold)' },
+    { action: 'DROP TABLE temp_exports',      score: 'critical',status: 'blocked',   color: 'var(--error)' },
+  ];
+
+  const ITEM_DELAY = 900;
+  const CYCLE_PAD = 2500;
+
+  const [cycle, setCycle]     = useState(0);
+  const [visible, setVisible] = useState(0);
+  const timers                = useRef([]);
+
+  function T(fn, ms) { const id = setTimeout(fn, ms); timers.current.push(id); }
+
+  useEffect(() => {
+    timers.current.forEach(clearTimeout);
+    timers.current = [];
+    setVisible(0);
+
+    ACTIONS.forEach((_, i) => {
+      T(() => setVisible(i + 1), (i + 1) * ITEM_DELAY);
+    });
+
+    T(() => setCycle((c) => c + 1), ACTIONS.length * ITEM_DELAY + CYCLE_PAD);
+    return () => timers.current.forEach(clearTimeout);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cycle]);
+
+  const logged = ACTIONS.slice(0, visible).length;
+  const blocked = ACTIONS.slice(0, visible).filter((a) => a.status === 'blocked').length;
+
+  return (
+    <div className="ob-root" aria-hidden="true">
+      <div className="mock-container ob-mock">
+        <div className="mock-toolbar" style={{ justifyContent: 'space-between' }}>
+          <div style={{ display: 'flex', gap: 6 }}>
+            <div className="mock-dot" /><div className="mock-dot" /><div className="mock-dot" />
+          </div>
+          <span className="ob-title">agent session · sess_01jkx7r2nb4f</span>
+          <span style={{ width: 48 }} />
+        </div>
+
+        {/* Header row */}
+        <div className="ob-header">
+          <span className="ob-col-action">Action</span>
+          <span className="ob-col-risk">Risk</span>
+          <span className="ob-col-status">Status</span>
+        </div>
+
+        <div className="ob-list">
+          {ACTIONS.map((a, i) => {
+            const show = i < visible;
+            return (
+              <div key={i} className={`ob-row${show ? ' ob-vis' : ''}`}>
+                <span className="ob-action">{a.action}</span>
+                <span className="ob-risk" style={{ color: a.color }}>{show ? a.score : ''}</span>
+                <span className={`ob-status ob-status-${a.status}`}>{show ? a.status : ''}</span>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="ob-footer">
+          <span className="ob-footer-dot" />
+          <span>{logged} actions logged &middot; {blocked} blocked</span>
+        </div>
+      </div>
+
+      <style>{`
+        .ob-root { width: 100%; }
+        .ob-mock { border-radius: 12px; overflow: hidden; }
+        .ob-title { font-family: var(--mono); font-size: 11px; color: rgba(var(--sand-100-rgb),0.2); }
+
+        .ob-header {
+          display: grid; grid-template-columns: 1fr 70px 80px; gap: 8px;
+          padding: 8px 16px; border-bottom: 1px solid rgba(var(--sand-100-rgb),0.06);
+          font-family: var(--sans); font-size: 10px; font-weight: 500;
+          text-transform: uppercase; letter-spacing: 0.06em;
+          color: rgba(var(--sand-100-rgb),0.25);
+        }
+
+        .ob-list { padding: 4px 16px; min-height: 180px; }
+
+        .ob-row {
+          display: grid; grid-template-columns: 1fr 70px 80px; gap: 8px;
+          padding: 7px 0; border-bottom: 1px solid rgba(var(--sand-100-rgb),0.04);
+          opacity: 0; transform: translateY(4px);
+          transition: opacity 0.3s ease, transform 0.3s ease;
+        }
+        .ob-row.ob-vis { opacity: 1; transform: translateY(0); }
+
+        .ob-action { font-family: var(--mono); font-size: 11px; color: rgba(var(--sand-100-rgb),0.5); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+        .ob-risk { font-family: var(--sans); font-size: 10px; font-weight: 600; text-transform: uppercase; }
+
+        .ob-status {
+          font-family: var(--sans); font-size: 10px; font-weight: 500;
+        }
+        .ob-status-logged { color: rgba(var(--sand-100-rgb),0.3); }
+        .ob-status-approved { color: var(--warm-gold); }
+        .ob-status-blocked { color: var(--error); }
+
+        .ob-footer {
+          display: flex; align-items: center; gap: 7px;
+          padding: 10px 16px; border-top: 1px solid rgba(var(--sand-100-rgb),0.06);
+          font-family: var(--sans); font-size: 11px; color: rgba(var(--sand-100-rgb),0.25);
+        }
+        .ob-footer-dot {
+          width: 6px; height: 6px; border-radius: 50%; background: var(--warm-gold);
+          animation: ob-p 2s ease-in-out infinite;
+        }
+        @keyframes ob-p { 0%,100%{opacity:.5} 50%{opacity:1} }
+      `}</style>
+    </div>
+  );
+}

--- a/snippets/annimations/OpenSourceFlow.jsx
+++ b/snippets/annimations/OpenSourceFlow.jsx
@@ -1,0 +1,342 @@
+/**
+ * OpenSourceFlow — Animated visualization of the open-source gateway architecture
+ *
+ * Shows the protocol flow through the open-source gateway:
+ *   1. Protocols arrive (Postgres, MySQL, SSH, K8s, HTTP)
+ *   2. Pass through the open-source gateway (inspectable, auditable)
+ *   3. Controls apply (mask, block, approve, log)
+ *   4. Traffic exits to infrastructure
+ *
+ * Dark background, warm gold accents. Designed for README and landing page.
+ */
+
+export const OpenSourceFlow = () => {
+  const PROTOCOLS = [
+    { name: 'PostgreSQL', icon: 'db' },
+    { name: 'MySQL', icon: 'db' },
+    { name: 'SSH', icon: 'term' },
+    { name: 'Kubernetes', icon: 'k8s' },
+    { name: 'HTTP/gRPC', icon: 'http' },
+  ];
+
+  const CONTROLS = [
+    { label: 'Mask PII', color: 'var(--warm-gold)' },
+    { label: 'Block DDL', color: 'var(--error)' },
+    { label: 'Approve', color: 'var(--warm-gold)' },
+    { label: 'Record', color: 'rgba(var(--sand-100-rgb),0.5)' },
+    { label: 'Analyze', color: 'var(--warm-gold)' },
+  ];
+
+  const CONTRIBUTORS = [
+    { initials: 'JC', delay: 0 },
+    { initials: 'MR', delay: 200 },
+    { initials: 'AK', delay: 400 },
+    { initials: 'SP', delay: 600 },
+    { initials: 'LW', delay: 800 },
+    { initials: '+', delay: 1000 },
+  ];
+
+  function useGitHubStats() {
+    const [stats, setStats] = useState({ stars: 619, forks: 40 });
+
+    useEffect(() => {
+      const KEY = 'hoop_gh_stats';
+      const TTL = 1000 * 60 * 30;
+      try {
+        const c = sessionStorage.getItem(KEY);
+        if (c) { const d = JSON.parse(c); if (Date.now() - d.ts < TTL) { setStats({ stars: d.stars, forks: d.forks }); return; } }
+      } catch {}
+      fetch('https://api.github.com/repos/hoophq/hoop')
+        .then(r => r.ok ? r.json() : null)
+        .then(data => {
+          if (data?.stargazers_count) {
+            const s = { stars: data.stargazers_count, forks: data.forks_count || 40 };
+            setStats(s);
+            try { sessionStorage.setItem(KEY, JSON.stringify({ ...s, ts: Date.now() })); } catch {}
+          }
+        })
+        .catch(() => {});
+    }, []);
+
+    return stats;
+  }
+
+  const [activeProtocol, setActiveProtocol] = useState(0);
+  const [activeControl, setActiveControl] = useState(-1);
+  const [gatewayPulse, setGatewayPulse] = useState(false);
+  const [showContribs, setShowContribs] = useState(false);
+  const timers = useRef([]);
+  const gh = useGitHubStats();
+
+  function T(fn, ms) { const id = setTimeout(fn, ms); timers.current.push(id); }
+
+  useEffect(() => {
+    let cancelled = false;
+    let cycle = 0;
+
+    function run() {
+      if (cancelled) return;
+      timers.current.forEach(clearTimeout);
+      timers.current = [];
+
+      const p = cycle % PROTOCOLS.length;
+      setActiveProtocol(p);
+      setActiveControl(-1);
+      setGatewayPulse(false);
+      setShowContribs(false);
+
+      // Protocol highlights
+      T(() => { if (!cancelled) setGatewayPulse(true); }, 600);
+
+      // Controls light up staggered
+      CONTROLS.forEach((_, i) => {
+        T(() => { if (!cancelled) setActiveControl(i); }, 1000 + i * 400);
+      });
+
+      // Show contributors
+      T(() => { if (!cancelled) setShowContribs(true); }, 2800);
+
+      // Reset
+      T(() => {
+        if (!cancelled) {
+          cycle++;
+          run();
+        }
+      }, 4500);
+    }
+
+    run();
+    return () => { cancelled = true; timers.current.forEach(clearTimeout); };
+  }, []);
+
+  return (
+    <div style={{
+      background: 'linear-gradient(135deg, var(--gradient-dark-start) 0%, var(--gradient-dark-mid) 35%, var(--gradient-dark-end) 70%, var(--bronze) 100%)',
+      borderRadius: 14, padding: '32px 28px 24px', position: 'relative', overflow: 'hidden',
+      height: 440,
+      fontFamily: "'DM Sans', system-ui, sans-serif",
+    }}>
+      {/* Glow */}
+      <div style={{
+        position: 'absolute', top: '-30%', right: '-10%', width: '60%', height: '160%',
+        background: 'radial-gradient(ellipse at center, rgba(var(--warm-gold-rgb),0.10) 0%, transparent 70%)',
+        pointerEvents: 'none',
+      }}/>
+
+      {/* Header */}
+      <div style={{
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+        marginBottom: 24, position: 'relative', zIndex: 1,
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" style={{ color: 'var(--warm-gold)' }}>
+            <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" fill="currentColor"/>
+          </svg>
+          <span style={{ fontFamily: "'Sora', sans-serif", fontSize: 14, fontWeight: 600, color: 'var(--sand-100)' }}>
+            Open Source Gateway
+          </span>
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <svg width="12" height="12" viewBox="0 0 16 16" fill="var(--warm-gold)">
+            <path d="M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25z"/>
+          </svg>
+          <span style={{
+            fontFamily: "'Sora', sans-serif", fontSize: 13, fontWeight: 700,
+            color: 'var(--warm-gold)',
+          }}>{gh.stars < 1000 ? '1K' : gh.stars < 2500 ? '2.5K' : gh.stars < 5000 ? '5K' : '10K'}</span>
+          <span style={{
+            fontSize: 10, fontWeight: 500, color: 'rgba(var(--sand-100-rgb),0.25)',
+          }}>stars goal</span>
+        </div>
+      </div>
+
+      {/* 3-column flow: Protocols → Gateway → Controls */}
+      <div style={{
+        display: 'grid', gridTemplateColumns: '1fr auto 1fr',
+        gap: 16, alignItems: 'center', position: 'relative', zIndex: 1, minHeight: 200,
+      }}>
+        {/* Left: Protocols */}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <span style={{
+            fontFamily: "'JetBrains Mono', monospace", fontSize: 9, fontWeight: 500,
+            color: 'rgba(var(--sand-100-rgb),0.20)', textTransform: 'uppercase', letterSpacing: '0.1em',
+            marginBottom: 6, paddingLeft: 2,
+          }}>Wire protocols</span>
+          {PROTOCOLS.map((p, i) => (
+            <div key={p.name} style={{
+              display: 'flex', alignItems: 'center', gap: 10,
+              padding: '8px 12px', borderRadius: 6,
+              background: i === activeProtocol ? 'rgba(var(--warm-gold-rgb),0.08)' : 'rgba(var(--sand-100-rgb),0.03)',
+              border: `1px solid ${i === activeProtocol ? 'rgba(var(--warm-gold-rgb),0.20)' : 'rgba(var(--sand-100-rgb),0.06)'}`,
+              transition: 'all 0.4s ease',
+            }}>
+              <div style={{
+                width: 6, height: 6, borderRadius: '50%',
+                background: i === activeProtocol ? 'var(--warm-gold)' : 'rgba(var(--sand-100-rgb),0.15)',
+                transition: 'all 0.4s ease',
+              }}/>
+              <span style={{
+                fontFamily: "'JetBrains Mono', monospace", fontSize: 12,
+                color: i === activeProtocol ? 'var(--sand-100)' : 'rgba(var(--sand-100-rgb),0.35)',
+                fontWeight: i === activeProtocol ? 500 : 400,
+                transition: 'all 0.4s ease',
+              }}>{p.name}</span>
+            </div>
+          ))}
+        </div>
+
+        {/* Center: Gateway */}
+        <div style={{
+          display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 12,
+        }}>
+          {/* Arrows in */}
+          <div style={{
+            width: 1, height: 24,
+            background: gatewayPulse
+              ? 'linear-gradient(to bottom, transparent, var(--warm-gold))'
+              : 'rgba(var(--sand-100-rgb),0.08)',
+            transition: 'background 0.4s ease',
+          }}/>
+
+          {/* Gateway box */}
+          <div style={{
+            width: 80, height: 80, borderRadius: 14,
+            background: gatewayPulse ? 'rgba(var(--warm-gold-rgb),0.10)' : 'rgba(var(--sand-100-rgb),0.04)',
+            border: `1.5px solid ${gatewayPulse ? 'var(--warm-gold)' : 'rgba(var(--sand-100-rgb),0.10)'}`,
+            display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 4,
+            transition: 'all 0.4s ease',
+            boxShadow: gatewayPulse ? '0 0 24px rgba(var(--warm-gold-rgb),0.15)' : 'none',
+          }}>
+            <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+              <path d="M10 2L3 5.5V10C3 14.5 6 17.5 10 19C14 17.5 17 14.5 17 10V5.5L10 2Z"
+                fill={gatewayPulse ? 'rgba(var(--warm-gold-rgb),0.20)' : 'rgba(var(--sand-100-rgb),0.05)'}
+                stroke={gatewayPulse ? 'var(--warm-gold)' : 'rgba(var(--sand-100-rgb),0.20)'} strokeWidth="1.2"/>
+            </svg>
+            <span style={{
+              fontFamily: "'JetBrains Mono', monospace", fontSize: 8, fontWeight: 600,
+              color: gatewayPulse ? 'var(--warm-gold)' : 'rgba(var(--sand-100-rgb),0.25)',
+              textTransform: 'uppercase', letterSpacing: '0.08em',
+              transition: 'color 0.4s ease',
+            }}>Gateway</span>
+          </div>
+
+          {/* Arrows out */}
+          <div style={{
+            width: 1, height: 24,
+            background: gatewayPulse
+              ? 'linear-gradient(to bottom, var(--warm-gold), transparent)'
+              : 'rgba(var(--sand-100-rgb),0.08)',
+            transition: 'background 0.4s ease',
+          }}/>
+        </div>
+
+        {/* Right: Controls */}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <span style={{
+            fontFamily: "'JetBrains Mono', monospace", fontSize: 9, fontWeight: 500,
+            color: 'rgba(var(--sand-100-rgb),0.20)', textTransform: 'uppercase', letterSpacing: '0.1em',
+            marginBottom: 6, paddingLeft: 2,
+          }}>Active controls</span>
+          {CONTROLS.map((c, i) => {
+            const active = i <= activeControl;
+            return (
+              <div key={c.label} style={{
+                display: 'flex', alignItems: 'center', gap: 10,
+                padding: '8px 12px', borderRadius: 6,
+                background: active ? 'rgba(var(--sand-100-rgb),0.04)' : 'transparent',
+                border: `1px solid ${active ? 'rgba(var(--sand-100-rgb),0.08)' : 'transparent'}`,
+                transition: 'all 0.35s ease',
+                opacity: active ? 1 : 0.25,
+              }}>
+                <div style={{
+                  width: 16, height: 16, borderRadius: 3,
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  background: active ? 'rgba(var(--warm-gold-rgb),0.12)' : 'rgba(var(--sand-100-rgb),0.04)',
+                  transition: 'all 0.35s ease',
+                }}>
+                  {active && (
+                    <svg width="9" height="9" viewBox="0 0 16 16" fill="none">
+                      <path d="M3 8.5L6.5 12L13 4" stroke={c.color} strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"/>
+                    </svg>
+                  )}
+                </div>
+                <span style={{
+                  fontFamily: "'DM Sans', sans-serif", fontSize: 12, fontWeight: 500,
+                  color: active ? 'var(--sand-100)' : 'rgba(var(--sand-100-rgb),0.30)',
+                  transition: 'all 0.35s ease',
+                }}>{c.label}</span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Bottom: Contributors + stats */}
+      <div style={{
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+        marginTop: 20, paddingTop: 16,
+        borderTop: '1px solid rgba(var(--sand-100-rgb),0.06)',
+        position: 'relative', zIndex: 1,
+        opacity: showContribs ? 1 : 0,
+        transform: showContribs ? 'translateY(0)' : 'translateY(6px)',
+        transition: 'opacity 0.5s ease, transform 0.5s ease',
+      }}>
+        {/* Contributors */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+          <span style={{
+            fontFamily: "'DM Sans', sans-serif", fontSize: 10, fontWeight: 500,
+            color: 'rgba(var(--sand-100-rgb),0.25)', marginRight: 4,
+          }}>Contributors</span>
+          <div style={{ display: 'flex' }}>
+            {CONTRIBUTORS.map((c, i) => (
+              <div key={i} style={{
+                width: 24, height: 24, borderRadius: '50%',
+                background: c.initials === '+' ? 'rgba(var(--sand-100-rgb),0.06)' : 'rgba(var(--warm-gold-rgb),0.12)',
+                border: '2px solid rgba(var(--espresso-rgb),0.9)',
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                fontSize: 9, fontWeight: 600,
+                color: c.initials === '+' ? 'rgba(var(--sand-100-rgb),0.30)' : 'var(--warm-gold)',
+                marginLeft: i === 0 ? 0 : -6,
+                zIndex: CONTRIBUTORS.length - i,
+              }}>{c.initials}</div>
+            ))}
+          </div>
+        </div>
+
+        {/* Stats with goals */}
+        <div style={{ display: 'flex', gap: 20, alignItems: 'center' }}>
+          {/* Stars progress */}
+          {(() => {
+            const goal = gh.stars < 1000 ? 1000 : gh.stars < 2500 ? 2500 : gh.stars < 5000 ? 5000 : 10000;
+            const goalLabel = goal >= 1000 ? `${goal / 1000}K` : goal;
+            const pct = Math.min((gh.stars / goal) * 100, 100);
+            return (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 4, minWidth: 90 }}>
+                <div style={{ display: 'flex', alignItems: 'baseline', gap: 4 }}>
+                  <span style={{ fontFamily: "'Sora', sans-serif", fontSize: 14, fontWeight: 700, color: 'var(--sand-100)' }}>{gh.stars.toLocaleString()}</span>
+                  <span style={{ fontFamily: "'DM Sans', sans-serif", fontSize: 9, color: 'rgba(var(--sand-100-rgb),0.20)' }}>/ {goalLabel} goal</span>
+                </div>
+                <div style={{ height: 3, background: 'rgba(var(--sand-100-rgb),0.06)', borderRadius: 2, overflow: 'hidden' }}>
+                  <div style={{ width: `${pct}%`, height: '100%', background: 'var(--warm-gold)', borderRadius: 2, opacity: 0.7 }}/>
+                </div>
+                <span style={{ fontFamily: "'DM Sans', sans-serif", fontSize: 9, color: 'rgba(var(--sand-100-rgb),0.20)' }}>Stars</span>
+              </div>
+            );
+          })()}
+
+          {/* Forks */}
+          <div style={{ textAlign: 'right' }}>
+            <div style={{ fontFamily: "'Sora', sans-serif", fontSize: 14, fontWeight: 700, color: 'var(--sand-100)' }}>{gh.forks}</div>
+            <div style={{ fontFamily: "'DM Sans', sans-serif", fontSize: 9, color: 'rgba(var(--sand-100-rgb),0.20)' }}>Forks</div>
+          </div>
+
+          {/* License */}
+          <div style={{ textAlign: 'right' }}>
+            <div style={{ fontFamily: "'Sora', sans-serif", fontSize: 14, fontWeight: 700, color: 'var(--warm-gold)' }}>MIT</div>
+            <div style={{ fontFamily: "'DM Sans', sans-serif", fontSize: 9, color: 'rgba(var(--sand-100-rgb),0.20)' }}>License</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/snippets/annimations/OrgImpactDashboard.jsx
+++ b/snippets/annimations/OrgImpactDashboard.jsx
@@ -1,0 +1,322 @@
+/**
+ * OrgImpactDashboard — Executive-level org impact metrics
+ *
+ * Shows what Hoop delivers at scale: PII fields masked, commands blocked,
+ * sessions audited, risk reduction. Animated counters + trend bars.
+ *
+ * Targets VP/C-level audience. No code, no terminals — just business outcomes.
+ *
+ * Fixed height: 480px. Dark theme.
+ */
+
+export const OrgImpactDashboard = () => {
+  const METRICS = [
+    { label: 'PII Fields Masked', value: 47293, unit: '', prefix: '', color: 'var(--warm-gold)' },
+    { label: 'Destructive Commands Blocked', value: 842, unit: '', prefix: '', color: 'rgba(var(--error-rgb),0.85)' },
+    { label: 'Sessions Audited', value: 12847, unit: '', prefix: '', color: 'var(--sand-100)' },
+    { label: 'Compliance Score', value: 94, unit: '%', prefix: '', color: 'var(--success)' },
+  ];
+
+  const RISK_CATEGORIES = [
+    { label: 'PII Exposure', before: 87, after: 3 },
+    { label: 'Unaudited Sessions', before: 64, after: 0 },
+    { label: 'Ungoverned AI Access', before: 92, after: 8 },
+    { label: 'Compliance Gaps', before: 48, after: 6 },
+  ];
+
+  const TIMELINE = [
+    { month: 'Sep', value: 12 },
+    { month: 'Oct', value: 28 },
+    { month: 'Nov', value: 51 },
+    { month: 'Dec', value: 67 },
+    { month: 'Jan', value: 79 },
+    { month: 'Feb', value: 88 },
+    { month: 'Mar', value: 94 },
+  ];
+
+  function AnimatedCounter({ target, active, duration = 1500 }) {
+    const [value, setValue] = useState(0);
+    const ref = useRef(null);
+    const start = useRef(0);
+
+    useEffect(() => {
+      if (!active) { setValue(0); return; }
+      start.current = performance.now();
+
+      function tick(now) {
+        const elapsed = now - start.current;
+        const progress = Math.min(elapsed / duration, 1);
+        // Ease out cubic
+        const eased = 1 - Math.pow(1 - progress, 3);
+        setValue(Math.round(eased * target));
+        if (progress < 1) ref.current = requestAnimationFrame(tick);
+      }
+
+      ref.current = requestAnimationFrame(tick);
+      return () => cancelAnimationFrame(ref.current);
+    }, [target, active, duration]);
+
+    return value.toLocaleString();
+  }
+
+  const [active, setActive] = useState(false);
+  const [showRisk, setShowRisk] = useState(false);
+  const mounted = useRef(true);
+  const timer = useRef(null);
+
+  useEffect(() => {
+    mounted.current = true;
+
+    function cycle() {
+      if (!mounted.current) return;
+      setActive(false);
+      setShowRisk(false);
+
+      timer.current = setTimeout(() => {
+        if (!mounted.current) return;
+        setActive(true);
+
+        timer.current = setTimeout(() => {
+          if (!mounted.current) return;
+          setShowRisk(true);
+
+          timer.current = setTimeout(() => {
+            if (mounted.current) cycle();
+          }, 5000);
+        }, 2000);
+      }, 600);
+    }
+
+    cycle();
+    return () => { mounted.current = false; clearTimeout(timer.current); };
+  }, []);
+
+  const maxTimeline = Math.max(...TIMELINE.map(t => t.value));
+
+  return (
+    <div style={{
+      height: 480,
+      background: 'rgba(var(--sand-100-rgb),0.03)',
+      border: '1px solid rgba(var(--sand-100-rgb),0.06)',
+      borderRadius: 14,
+      overflow: 'hidden',
+      display: 'flex',
+      flexDirection: 'column',
+    }}>
+      {/* Header */}
+      <div style={{
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+        padding: '14px 24px',
+        borderBottom: '1px solid rgba(var(--sand-100-rgb),0.06)',
+        background: 'rgba(var(--sand-100-rgb),0.02)',
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+            <rect x="1" y="7" width="3" height="8" rx="1" fill="rgba(var(--sand-100-rgb),0.2)"/>
+            <rect x="6.5" y="4" width="3" height="11" rx="1" fill="rgba(var(--sand-100-rgb),0.3)"/>
+            <rect x="12" y="1" width="3" height="14" rx="1" fill="rgba(var(--sand-100-rgb),0.4)"/>
+          </svg>
+          <span style={{
+            fontFamily: 'var(--sans)', fontSize: 13, fontWeight: 600,
+            color: 'var(--sand-100)',
+          }}>
+            Organizational Impact
+          </span>
+        </div>
+        <span style={{
+          fontFamily: 'var(--mono)', fontSize: 10, fontWeight: 500,
+          color: 'rgba(var(--sand-100-rgb),0.3)',
+          background: 'rgba(var(--sand-100-rgb),0.04)',
+          padding: '4px 10px', borderRadius: 4,
+        }}>
+          Last 30 days
+        </span>
+      </div>
+
+      <div style={{ flex: 1, padding: '20px 24px', display: 'flex', flexDirection: 'column', gap: 20, overflow: 'hidden' }}>
+        {/* Big metric cards */}
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 10 }}>
+          {METRICS.map((m, i) => (
+            <div key={m.label} style={{
+              background: 'rgba(var(--sand-100-rgb),0.03)',
+              border: '1px solid rgba(var(--sand-100-rgb),0.06)',
+              borderRadius: 8,
+              padding: '14px 14px 12px',
+            }}>
+              <span style={{
+                fontFamily: 'var(--display)', fontSize: 22, fontWeight: 800,
+                color: m.color,
+                letterSpacing: '-0.02em',
+                display: 'block',
+                lineHeight: 1.1,
+                transition: 'opacity 0.5s',
+                transitionDelay: `${i * 0.15}s`,
+                opacity: active ? 1 : 0.2,
+              }}>
+                {m.prefix}<AnimatedCounter target={m.value} active={active} duration={1500 + i * 200} />{m.unit}
+              </span>
+              <span style={{
+                fontFamily: 'var(--sans)', fontSize: 10, fontWeight: 500,
+                color: 'rgba(var(--sand-100-rgb),0.35)',
+                display: 'block', marginTop: 6,
+                lineHeight: 1.3,
+              }}>
+                {m.label}
+              </span>
+            </div>
+          ))}
+        </div>
+
+        {/* Two columns: Risk reduction + Timeline */}
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16, flex: 1 }}>
+          {/* Risk reduction bars */}
+          <div style={{
+            background: 'rgba(var(--sand-100-rgb),0.03)',
+            border: '1px solid rgba(var(--sand-100-rgb),0.06)',
+            borderRadius: 8,
+            padding: '16px 16px 12px',
+          }}>
+            <span style={{
+              fontFamily: 'var(--sans)', fontSize: 11, fontWeight: 600,
+              color: 'rgba(var(--sand-100-rgb),0.4)',
+              textTransform: 'uppercase', letterSpacing: '0.06em',
+              display: 'block', marginBottom: 14,
+            }}>
+              Risk Reduction
+            </span>
+
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+              {RISK_CATEGORIES.map((cat, i) => {
+                const val = showRisk ? cat.after : cat.before;
+                const isReduced = showRisk && cat.after < 10;
+                return (
+                  <div key={cat.label}>
+                    <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 4 }}>
+                      <span style={{
+                        fontFamily: 'var(--sans)', fontSize: 11,
+                        color: 'rgba(var(--sand-100-rgb),0.55)',
+                      }}>{cat.label}</span>
+                      <span style={{
+                        fontFamily: 'var(--mono)', fontSize: 11, fontWeight: 600,
+                        color: isReduced ? 'var(--success)' : 'rgba(var(--sand-100-rgb),0.6)',
+                        transition: 'color 0.5s',
+                        transitionDelay: `${i * 0.15}s`,
+                      }}>{val}%</span>
+                    </div>
+                    <div style={{
+                      height: 4, borderRadius: 2,
+                      background: 'rgba(var(--sand-100-rgb),0.06)',
+                      overflow: 'hidden',
+                    }}>
+                      <div style={{
+                        height: '100%', borderRadius: 2,
+                        width: `${val}%`,
+                        background: isReduced
+                          ? 'var(--success)'
+                          : val > 70 ? 'rgba(var(--error-rgb),0.7)' : 'var(--warm-gold)',
+                        transition: 'width 1s ease-out, background 0.5s',
+                        transitionDelay: `${i * 0.15}s`,
+                      }} />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Compliance timeline */}
+          <div style={{
+            background: 'rgba(var(--sand-100-rgb),0.03)',
+            border: '1px solid rgba(var(--sand-100-rgb),0.06)',
+            borderRadius: 8,
+            padding: '16px 16px 12px',
+            display: 'flex',
+            flexDirection: 'column',
+          }}>
+            <span style={{
+              fontFamily: 'var(--sans)', fontSize: 11, fontWeight: 600,
+              color: 'rgba(var(--sand-100-rgb),0.4)',
+              textTransform: 'uppercase', letterSpacing: '0.06em',
+              display: 'block', marginBottom: 14,
+            }}>
+              Compliance Trend
+            </span>
+
+            <div style={{
+              flex: 1, display: 'flex',
+              alignItems: 'flex-end', justifyContent: 'space-between',
+              gap: 6,
+              paddingBottom: 20,
+              position: 'relative',
+            }}>
+              {/* Target line */}
+              <div style={{
+                position: 'absolute',
+                left: 0, right: 0,
+                bottom: `${(90 / maxTimeline) * 100 * 0.7 + 20}px`,
+                height: 1,
+                borderTop: '1px dashed rgba(var(--success-rgb),0.2)',
+              }}>
+                <span style={{
+                  position: 'absolute', right: 0, top: -14,
+                  fontFamily: 'var(--mono)', fontSize: 9,
+                  color: 'rgba(var(--success-rgb),0.4)',
+                }}>90% target</span>
+              </div>
+
+              {TIMELINE.map((t, i) => {
+                const heightPct = (t.value / maxTimeline) * 70;
+                const meetsTarget = t.value >= 90;
+                return (
+                  <div key={t.month} style={{
+                    flex: 1,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    gap: 4,
+                  }}>
+                    <div style={{
+                      width: '100%',
+                      maxWidth: 28,
+                      height: `${heightPct}%`,
+                      minHeight: 8,
+                      borderRadius: 4,
+                      background: active
+                        ? (meetsTarget ? 'var(--success)' : 'var(--warm-gold)')
+                        : 'rgba(var(--sand-100-rgb),0.06)',
+                      transition: 'height 1s ease-out, background 0.5s',
+                      transitionDelay: `${i * 0.1}s`,
+                      opacity: active ? (0.4 + (i / TIMELINE.length) * 0.6) : 0.3,
+                    }} />
+                    <span style={{
+                      fontFamily: 'var(--mono)', fontSize: 9,
+                      color: 'rgba(var(--sand-100-rgb),0.25)',
+                      position: 'absolute',
+                      bottom: 4,
+                    }}>
+                      {t.month}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+
+            {/* Month labels row */}
+            <div style={{
+              display: 'flex', justifyContent: 'space-between',
+              paddingTop: 4,
+              borderTop: '1px solid rgba(var(--sand-100-rgb),0.04)',
+            }}>
+              {TIMELINE.map(t => (
+                <span key={t.month} style={{
+                  fontFamily: 'var(--mono)', fontSize: 9, flex: 1, textAlign: 'center',
+                  color: 'rgba(var(--sand-100-rgb),0.25)',
+                }}>{t.month}</span>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/snippets/annimations/PatternBreachAnimation.jsx
+++ b/snippets/annimations/PatternBreachAnimation.jsx
@@ -1,0 +1,148 @@
+/**
+ * PatternBreachAnimation — Benign queries forming a data extraction pattern
+ *
+ * Shows individual queries appearing one by one — each looks harmless.
+ * After all appear, a "pattern detected" overlay connects them,
+ * revealing the extraction. Conveys: static rules miss behavioral patterns.
+ *
+ * Pure CSS + React state.
+ */
+
+export const PatternBreachAnimation = () => {
+  const QUERIES = [
+    { cmd: 'SELECT name FROM customers LIMIT 100 OFFSET 0;',     time: '3:01:12' },
+    { cmd: 'SELECT name FROM customers LIMIT 100 OFFSET 100;',   time: '3:01:14' },
+    { cmd: 'SELECT name FROM customers LIMIT 100 OFFSET 200;',   time: '3:01:15' },
+    { cmd: 'SELECT email FROM customers LIMIT 100 OFFSET 0;',    time: '3:01:17' },
+    { cmd: 'SELECT ssn FROM customers LIMIT 100 OFFSET 0;',      time: '3:01:18' },
+  ];
+
+  const QUERY_DELAY = 700;
+  const PATTERN_DELAY = 1200;
+  const CYCLE_PAD = 2800;
+
+  const [cycle, setCycle]       = useState(0);
+  const [visible, setVisible]   = useState(0);
+  const [detected, setDetected] = useState(false);
+  const timers                  = useRef([]);
+
+  function T(fn, ms) { const id = setTimeout(fn, ms); timers.current.push(id); }
+
+  useEffect(() => {
+    timers.current.forEach(clearTimeout);
+    timers.current = [];
+    setVisible(0);
+    setDetected(false);
+
+    QUERIES.forEach((_, i) => {
+      T(() => setVisible(i + 1), (i + 1) * QUERY_DELAY);
+    });
+
+    const patternTime = QUERIES.length * QUERY_DELAY + PATTERN_DELAY;
+    T(() => setDetected(true), patternTime);
+    T(() => setCycle((c) => c + 1), patternTime + CYCLE_PAD);
+
+    return () => timers.current.forEach(clearTimeout);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cycle]);
+
+  return (
+    <div className="pb-root" aria-hidden="true">
+      <div className="mock-container pb-mock">
+        <div className="mock-toolbar" style={{ justifyContent: 'space-between' }}>
+          <div style={{ display: 'flex', gap: 6 }}>
+            <div className="mock-dot" /><div className="mock-dot" /><div className="mock-dot" />
+          </div>
+          <span className="pb-title">session monitor · alice@corp.com</span>
+          <span style={{ width: 48 }} />
+        </div>
+
+        <div className="pb-stream">
+          {QUERIES.map((q, i) => {
+            const show = i < visible;
+            return (
+              <div key={i} className={`pb-row${show ? ' pb-vis' : ''}${detected ? ' pb-flagged' : ''}`}>
+                <span className="pb-time">{q.time}</span>
+                <span className="pb-cmd">{q.cmd}</span>
+                {show && !detected && <span className="pb-ok">\u2713 pass</span>}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Pattern detected overlay */}
+        <div className={`pb-alert${detected ? ' pb-alert-vis' : ''}`}>
+          <span className="pb-alert-icon">!</span>
+          <div className="pb-alert-text">
+            <strong>Extraction pattern detected</strong>
+            <span>5 sequential queries · full table scan · 3 sensitive columns</span>
+          </div>
+        </div>
+
+        <div className="pb-footer">
+          <span className={`pb-status-dot${detected ? ' pb-status-warn' : ''}`} />
+          <span>{detected ? 'Behavioral anomaly flagged' : 'Static rules: all queries passed'}</span>
+        </div>
+      </div>
+
+      <style>{`
+        .pb-root { width: 100%; }
+        .pb-mock { border-radius: 12px; overflow: hidden; position: relative; }
+        .pb-title { font-family: var(--mono); font-size: 11px; color: rgba(var(--sand-100-rgb),0.2); }
+
+        .pb-stream { padding: 10px 16px; display: flex; flex-direction: column; gap: 2px; min-height: 180px; }
+
+        .pb-row {
+          display: flex; align-items: center; gap: 10px;
+          padding: 5px 8px; border-radius: 4px;
+          opacity: 0; transform: translateX(-6px);
+          transition: opacity 0.3s ease, transform 0.3s ease, background 0.4s ease, border-color 0.4s ease;
+          border: 1px solid transparent;
+        }
+        .pb-row.pb-vis { opacity: 1; transform: translateX(0); }
+        .pb-row.pb-flagged {
+          border-color: rgba(var(--warm-gold-rgb),0.2);
+          background: rgba(var(--warm-gold-rgb),0.04);
+        }
+
+        .pb-time { font-family: var(--mono); font-size: 10px; color: rgba(var(--sand-100-rgb),0.2); flex-shrink: 0; }
+        .pb-cmd { font-family: var(--mono); font-size: 11px; color: rgba(var(--sand-100-rgb),0.5); flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+        .pb-ok { font-family: var(--sans); font-size: 9px; color: rgba(var(--success-rgb),0.5); flex-shrink: 0; }
+
+        .pb-alert {
+          margin: 0 16px 10px;
+          display: flex; align-items: flex-start; gap: 10px;
+          padding: 10px 14px; border-radius: 6px;
+          background: rgba(var(--warm-gold-rgb),0.08);
+          border: 1px solid rgba(var(--warm-gold-rgb),0.15);
+          opacity: 0; transform: translateY(4px);
+          transition: opacity 0.4s ease, transform 0.4s ease;
+        }
+        .pb-alert-vis { opacity: 1; transform: translateY(0); }
+
+        .pb-alert-icon {
+          width: 20px; height: 20px; border-radius: 50%;
+          background: rgba(var(--warm-gold-rgb),0.15); color: var(--warm-gold);
+          display: flex; align-items: center; justify-content: center;
+          font-size: 11px; font-weight: 700; flex-shrink: 0;
+        }
+        .pb-alert-text { display: flex; flex-direction: column; gap: 2px; }
+        .pb-alert-text strong { font-family: var(--sans); font-size: 12px; color: var(--warm-gold); font-weight: 600; }
+        .pb-alert-text span { font-family: var(--sans); font-size: 11px; color: rgba(var(--sand-100-rgb),0.35); }
+
+        .pb-footer {
+          display: flex; align-items: center; gap: 7px;
+          padding: 10px 16px; border-top: 1px solid rgba(var(--sand-100-rgb),0.06);
+          font-family: var(--sans); font-size: 11px; color: rgba(var(--sand-100-rgb),0.25);
+          transition: color 0.3s ease;
+        }
+        .pb-status-dot {
+          width: 6px; height: 6px; border-radius: 50%;
+          background: rgba(var(--sand-100-rgb),0.15);
+          transition: background 0.3s ease;
+        }
+        .pb-status-dot.pb-status-warn { background: var(--warm-gold); }
+      `}</style>
+    </div>
+  );
+}

--- a/snippets/annimations/ProductMock.jsx
+++ b/snippets/annimations/ProductMock.jsx
@@ -1,0 +1,469 @@
+/**
+ * ProductMock — Reusable product interface mock
+ *
+ * Used across hero, solution pages, and use-case pages.
+ *
+ * Props:
+ *   variant  — 'database' | 'terminal' | 'kubernetes' | 'approval'
+ *   masked   — boolean (default false): show warm-gold masking on database/terminal variants
+ *   className
+ *
+ * Styleguide §4.5 — rgba transparency system on dark sections
+ * Styleguide §4.6 — code block for terminal/kubernetes variants
+ */
+
+export const ProductMock = ({ variant = 'database', masked = false, className = '' }) => {
+  /* ── Toolbar ─────────────────────────────────────────────────── */
+
+  const ProductMockToolbar = ({ variant }) => {
+    const titles = {
+      database:   'hoop · postgres:prod',
+      terminal:   'hoop · bash:bastion',
+      kubernetes: 'hoop · kubectl:cluster-prod',
+      approval:   '#security-alerts',
+    };
+
+    return (
+      <div className="mock-toolbar" style={{ justifyContent: 'space-between' }}>
+        <div style={{ display: 'flex', gap: 6 }}>
+          <div className="mock-dot" />
+          <div className="mock-dot" />
+          <div className="mock-dot" />
+        </div>
+        <span
+          style={{
+            fontFamily: 'var(--mono)',
+            fontSize: 11,
+            color: 'rgba(var(--sand-100-rgb),0.2)',
+          }}
+        >
+          {titles[variant] ?? ''}
+        </span>
+        <span style={{ width: 48 }} />
+      </div>
+    );
+  };
+
+  /* ── Database variant ────────────────────────────────────────── */
+
+  const DB_ROWS = [
+    { id: 1001, name: 'J. Smith',     ssn: '123-45-6789', email: 'jsmith@acme.com'     },
+    { id: 1002, name: 'M. Rodriguez', ssn: '234-56-7890', email: 'mrodriguez@acme.com'  },
+    { id: 1003, name: 'A. Chen',      ssn: '345-67-8901', email: 'achen@acme.com'       },
+    { id: 1004, name: 'S. Patel',     ssn: '456-78-9012', email: 'spatel@acme.com'      },
+  ];
+
+  const DatabaseBody = ({ masked }) => {
+    return (
+      <div style={{ padding: '4px 0 8px', overflowX: 'auto' }}>
+        <table
+          style={{
+            width: '100%',
+            borderCollapse: 'collapse',
+            fontFamily: 'var(--mono)',
+            fontSize: 12,
+          }}
+        >
+          <thead>
+            <tr>
+              <th className="db-th">id</th>
+              <th className="db-th">name</th>
+              <th className="db-th">ssn</th>
+              <th className="db-th">email</th>
+            </tr>
+          </thead>
+          <tbody>
+            {DB_ROWS.map((row) => (
+              <tr key={row.id} className="db-tr">
+                <td className="db-td" style={{ color: 'rgba(var(--sand-100-rgb),0.3)' }}>
+                  {row.id}
+                </td>
+                <td className="db-td" style={{ color: 'rgba(var(--sand-100-rgb),0.6)' }}>
+                  {row.name}
+                </td>
+                <td
+                  className="db-td"
+                  style={{
+                    color:      masked ? 'var(--warm-gold)' : 'rgba(var(--sand-100-rgb),0.55)',
+                    fontWeight: masked ? 600 : 400,
+                  }}
+                >
+                  {masked ? `***-**-${row.ssn.slice(-4)}` : row.ssn}
+                </td>
+                <td
+                  className="db-td"
+                  style={{
+                    color:      masked ? 'var(--warm-gold)' : 'rgba(var(--sand-100-rgb),0.55)',
+                    fontWeight: masked ? 600 : 400,
+                  }}
+                >
+                  {masked ? '****@****.com' : row.email}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+
+        <style>{`
+          .db-th {
+            text-align: left;
+            padding: 6px 16px;
+            color: rgba(var(--sand-100-rgb), 0.25);
+            font-weight: 500;
+            font-size: 10px;
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+            border-bottom: 1px solid rgba(var(--sand-100-rgb), 0.04);
+          }
+
+          .db-tr:not(:last-child) td {
+            border-bottom: 1px solid rgba(var(--sand-100-rgb), 0.04);
+          }
+
+          .db-td {
+            padding: 7px 16px;
+          }
+        `}</style>
+      </div>
+    );
+  };
+
+  /* ── Terminal variant ────────────────────────────────────────── */
+
+  const TerminalBody = ({ masked }) => {
+    const ssnColor = masked ? 'var(--warm-gold)' : 'rgba(var(--sand-100-rgb),0.55)';
+    const ssnWeight = masked ? 600 : 400;
+
+    return (
+      <div className="code-block" style={{ borderRadius: 0, margin: 0 }}>
+        <div>
+          <span className="prompt">$ </span>
+          <span className="command">hoop connect postgres:prod</span>
+        </div>
+        <div>
+          <span className="success">&#x2713; </span>
+          <span style={{ color: 'rgba(var(--sand-100-rgb),0.6)' }}>
+            Connected &middot; sess_01jkx7r2nb4f &middot; alice@corp.com
+          </span>
+        </div>
+        <div style={{ height: 8 }} />
+        <div>
+          <span className="prompt">psql&gt; </span>
+          <span className="command">SELECT id, name, ssn FROM customers LIMIT 3;</span>
+        </div>
+        <div style={{ height: 6 }} />
+        <div
+          style={{
+            color: 'rgba(var(--sand-100-rgb),0.3)',
+            fontSize: 11,
+            marginBottom: 3,
+          }}
+        >
+          id &nbsp;&nbsp; name &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ssn
+        </div>
+        <div
+          style={{
+            color: 'rgba(var(--sand-100-rgb),0.15)',
+            fontSize: 11,
+            marginBottom: 5,
+          }}
+        >
+          ---- -------------- ------------
+        </div>
+        {[
+          { id: '1001', name: 'J. Smith    ', raw: '123-45-6789', masked: '***-**-6789' },
+          { id: '1002', name: 'M. Rodriguez', raw: '234-56-7890', masked: '***-**-7890' },
+          { id: '1003', name: 'A. Chen     ', raw: '345-67-8901', masked: '***-**-8901' },
+        ].map((row) => (
+          <div key={row.id} style={{ color: 'rgba(var(--sand-100-rgb),0.55)' }}>
+            {row.id}&nbsp;&nbsp;{row.name}&nbsp;
+            <span style={{ color: ssnColor, fontWeight: ssnWeight }}>
+              {masked ? row.masked : row.raw}
+            </span>
+          </div>
+        ))}
+        <div style={{ height: 8 }} />
+        {masked && (
+          <div style={{ color: 'rgba(var(--warm-gold-rgb),0.6)', fontSize: 11 }}>
+            3 rows &middot; 3 SSN values masked by Hoop
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  /* ── Kubernetes variant ──────────────────────────────────────── */
+
+  const PODS = [
+    { name: 'api-server-7d9f8b-xk2p4',   ready: '1/1', status: 'Running', age: '3d'  },
+    { name: 'worker-6c8b9d-lm3q7',        ready: '1/1', status: 'Running', age: '3d'  },
+    { name: 'scheduler-5f7a2c-np8r1',     ready: '1/1', status: 'Running', age: '1d'  },
+    { name: 'ingress-nginx-4b6d1e-wt9s2', ready: '1/1', status: 'Running', age: '5h'  },
+  ];
+
+  const KubernetesBody = () => {
+    return (
+      <div className="code-block" style={{ borderRadius: 0, margin: 0 }}>
+        <div>
+          <span className="prompt">$ </span>
+          <span className="command">kubectl get pods -n production</span>
+        </div>
+        <div style={{ height: 8 }} />
+        <table
+          style={{
+            borderCollapse: 'collapse',
+            width: '100%',
+            fontFamily: 'var(--mono)',
+            fontSize: 12,
+          }}
+        >
+          <thead>
+            <tr>
+              {['NAME', 'READY', 'STATUS', 'AGE'].map((h) => (
+                <th
+                  key={h}
+                  style={{
+                    textAlign: 'left',
+                    paddingRight: 20,
+                    paddingBottom: 6,
+                    color: 'rgba(var(--sand-100-rgb),0.25)',
+                    fontWeight: 500,
+                    fontSize: 10,
+                    letterSpacing: '0.05em',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {h}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {PODS.map((pod) => (
+              <tr key={pod.name}>
+                <td style={{ paddingRight: 20, paddingTop: 3, paddingBottom: 3, color: 'rgba(var(--sand-100-rgb),0.6)', whiteSpace: 'nowrap' }}>
+                  {pod.name}
+                </td>
+                <td style={{ paddingRight: 20, color: 'rgba(var(--sand-100-rgb),0.4)' }}>
+                  {pod.ready}
+                </td>
+                <td style={{ paddingRight: 20, color: 'var(--warm-gold)', fontWeight: 600 }}>
+                  {pod.status}
+                </td>
+                <td style={{ color: 'rgba(var(--sand-100-rgb),0.3)' }}>
+                  {pod.age}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <div style={{ height: 8 }} />
+        <div style={{ color: 'rgba(var(--warm-gold-rgb),0.5)', fontSize: 11 }}>
+          Session recorded &middot; 4 pods &middot; identity: alice@corp.com
+        </div>
+      </div>
+    );
+  };
+
+  /* ── Approval variant (Slack-style card) ─────────────────────── */
+
+  const ApprovalBody = () => {
+    return (
+      <div className="apv-root">
+
+        {/* Header */}
+        <div className="apv-header">
+          <div className="apv-avatar">H</div>
+          <div>
+            <div className="apv-from">Hoop Gateway</div>
+            <div className="apv-time">just now</div>
+          </div>
+        </div>
+
+        {/* Message */}
+        <div className="apv-message">
+          <strong>Approval required</strong> for a write operation
+          by <strong>alice@corp.com</strong>.
+        </div>
+
+        {/* Command block */}
+        <div className="apv-cmd-block">
+          <div className="apv-cmd-label">Command</div>
+          <div className="apv-cmd-text">
+            DELETE FROM sessions WHERE expires_at &lt; NOW();
+          </div>
+        </div>
+
+        {/* Meta row */}
+        <div className="apv-meta">
+          <span>
+            <span className="apv-meta-key">Resource </span>
+            postgres:prod
+          </span>
+          <span>
+            <span className="apv-meta-key">Risk </span>
+            <span className="apv-risk">medium</span>
+          </span>
+        </div>
+
+        {/* Action buttons */}
+        <div className="apv-actions">
+          <button className="apv-btn apv-approve">Approve</button>
+          <button className="apv-btn apv-deny">Deny</button>
+        </div>
+
+        <style>{`
+          .apv-root {
+            padding: 16px 20px;
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+          }
+
+          .apv-header {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+          }
+
+          .apv-avatar {
+            width: 28px;
+            height: 28px;
+            border-radius: 6px;
+            background: rgba(var(--warm-gold-rgb), 0.15);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-family: var(--sans);
+            font-size: 12px;
+            font-weight: 600;
+            color: var(--warm-gold);
+            flex-shrink: 0;
+          }
+
+          .apv-from {
+            font-family: var(--sans);
+            font-size: 13px;
+            font-weight: 600;
+            color: rgba(var(--sand-100-rgb), 0.75);
+          }
+
+          .apv-time {
+            font-family: var(--sans);
+            font-size: 11px;
+            color: rgba(var(--sand-100-rgb), 0.3);
+          }
+
+          .apv-message {
+            font-family: var(--sans);
+            font-size: 13px;
+            color: rgba(var(--sand-100-rgb), 0.55);
+            line-height: 1.55;
+          }
+
+          .apv-message strong {
+            color: rgba(var(--sand-100-rgb), 0.8);
+            font-weight: 600;
+          }
+
+          .apv-cmd-block {
+            background: rgba(var(--sand-100-rgb), 0.04);
+            border: 1px solid rgba(var(--sand-100-rgb), 0.06);
+            border-radius: 6px;
+            padding: 10px 14px;
+          }
+
+          .apv-cmd-label {
+            font-family: var(--sans);
+            font-size: 10px;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+            color: rgba(var(--sand-100-rgb), 0.3);
+            margin-bottom: 5px;
+          }
+
+          .apv-cmd-text {
+            font-family: var(--mono);
+            font-size: 12px;
+            color: rgba(var(--sand-100-rgb), 0.7);
+            line-height: 1.6;
+          }
+
+          .apv-meta {
+            display: flex;
+            gap: 20px;
+            font-family: var(--sans);
+            font-size: 12px;
+            color: rgba(var(--sand-100-rgb), 0.55);
+          }
+
+          .apv-meta-key {
+            color: rgba(var(--sand-100-rgb), 0.3);
+          }
+
+          .apv-risk {
+            color: var(--warm-gold);
+            font-weight: 600;
+          }
+
+          .apv-actions {
+            display: flex;
+            gap: 8px;
+          }
+
+          .apv-btn {
+            font-family: var(--sans);
+            font-size: 12px;
+            font-weight: 500;
+            padding: 7px 18px;
+            border-radius: 6px;
+            cursor: pointer;
+            transition: opacity 0.15s;
+            border: none;
+          }
+
+          .apv-btn:hover { opacity: 0.8; }
+
+          .apv-approve {
+            background: rgba(var(--sand-100-rgb), 0.12);
+            color: rgba(var(--sand-100-rgb), 0.85);
+          }
+
+          .apv-deny {
+            background: transparent;
+            color: rgba(var(--sand-100-rgb), 0.4);
+            border: 1px solid rgba(var(--sand-100-rgb), 0.1) !important;
+          }
+        `}</style>
+      </div>
+    );
+  };
+
+  /* ── Body router ─────────────────────────────────────────────── */
+
+  const ProductMockBody = ({ variant, masked }) => {
+    switch (variant) {
+      case 'terminal':   return <TerminalBody masked={masked} />;
+      case 'kubernetes': return <KubernetesBody />;
+      case 'approval':   return <ApprovalBody />;
+      case 'database':
+      default:           return <DatabaseBody masked={masked} />;
+    }
+  };
+
+  return (
+    <div className={`mock-container product-mock product-mock--${variant} ${className}`}>
+      <ProductMockToolbar variant={variant} />
+      <ProductMockBody variant={variant} masked={masked} />
+
+      <style>{`
+        .product-mock {
+          border-radius: 10px;
+          overflow: hidden;
+          width: 100%;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/snippets/annimations/RiskMetricsAnimation.jsx
+++ b/snippets/annimations/RiskMetricsAnimation.jsx
@@ -1,0 +1,128 @@
+export const RiskMetricsAnimation = () => {
+  const METRICS = [
+    { label: 'Queries redacted',   target: 1247, color: 'var(--warm-gold)' },
+    { label: 'Operations blocked', target: 38,   color: 'var(--warm-gold)' },
+    { label: 'Sessions analyzed',  target: 8934, color: 'rgba(var(--sand-100-rgb),0.6)' },
+    { label: 'Approval requests',  target: 156,  color: 'rgba(var(--sand-100-rgb),0.6)' },
+  ];
+
+  const COUNT_DURATION = 2000;
+  const HOLD_DURATION  = 3000;
+  const CYCLE_DURATION = COUNT_DURATION + HOLD_DURATION;
+
+  function easeOutCubic(t) {
+    return 1 - Math.pow(1 - t, 3);
+  }
+
+  const [values, setValues] = useState(METRICS.map(() => 0));
+  const [cycle, setCycle]   = useState(0);
+  const raf                 = useRef(null);
+  const timers              = useRef([]);
+
+  useEffect(() => {
+    timers.current.forEach(clearTimeout);
+    timers.current = [];
+    if (raf.current) cancelAnimationFrame(raf.current);
+
+    setValues(METRICS.map(() => 0));
+
+    const start = performance.now();
+
+    function tick(now) {
+      const elapsed = now - start;
+      const progress = Math.min(elapsed / COUNT_DURATION, 1);
+      const eased = easeOutCubic(progress);
+
+      setValues(METRICS.map((m) => Math.round(eased * m.target)));
+
+      if (progress < 1) {
+        raf.current = requestAnimationFrame(tick);
+      }
+    }
+
+    raf.current = requestAnimationFrame(tick);
+
+    const resetId = setTimeout(() => setCycle((c) => c + 1), CYCLE_DURATION);
+    timers.current.push(resetId);
+
+    return () => {
+      if (raf.current) cancelAnimationFrame(raf.current);
+      timers.current.forEach(clearTimeout);
+    };
+  }, [cycle]);
+
+  const styles = {
+    root: { position: 'relative', width: '100%' },
+    mock: {
+      borderRadius: 12, overflow: 'hidden',
+      border: '1px solid rgba(var(--sand-100-rgb),0.08)',
+      background: 'linear-gradient(135deg, var(--gradient-dark-start) 0%, var(--gradient-dark-mid) 60%, var(--gradient-dark-end) 100%)',
+    },
+    toolbar: {
+      display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+      padding: '10px 16px', borderBottom: '1px solid rgba(var(--sand-100-rgb),0.06)',
+    },
+    dots: { display: 'flex', gap: 6 },
+    dot: { width: 8, height: 8, borderRadius: '50%', background: 'rgba(var(--sand-100-rgb),0.10)' },
+    title: { fontFamily: 'var(--mono)', fontSize: 11, color: 'rgba(var(--sand-100-rgb),0.2)' },
+    grid: {
+      display: 'grid', gridTemplateColumns: '1fr 1fr',
+      gap: 1, background: 'rgba(var(--sand-100-rgb),0.04)',
+    },
+    card: {
+      padding: 20, display: 'flex', flexDirection: 'column',
+      gap: 4, background: 'rgba(var(--sand-100-rgb),0.02)',
+    },
+    value: { fontFamily: 'var(--display)', fontSize: 28, fontWeight: 700, letterSpacing: '-0.02em', lineHeight: 1 },
+    label: { fontFamily: 'var(--sans)', fontSize: 11, color: 'rgba(var(--sand-100-rgb),0.3)', marginBottom: 8 },
+    barTrack: { height: 3, background: 'rgba(var(--sand-100-rgb),0.06)', borderRadius: 2, overflow: 'hidden' },
+    barFill: { height: '100%', borderRadius: 2, transition: 'width 0.1s linear', opacity: 0.6 },
+    status: {
+      display: 'flex', alignItems: 'center', gap: 7,
+      padding: '10px 16px', borderTop: '1px solid rgba(var(--sand-100-rgb),0.06)',
+      fontFamily: 'var(--sans)', fontSize: 11, color: 'rgba(var(--sand-100-rgb),0.25)',
+    },
+    statusDot: { width: 6, height: 6, borderRadius: '50%', background: 'var(--warm-gold)' },
+  };
+
+  return (
+    <div style={styles.root} aria-hidden="true">
+      <div style={styles.mock}>
+        <div style={styles.toolbar}>
+          <div style={styles.dots}>
+            <div style={styles.dot} />
+            <div style={styles.dot} />
+            <div style={styles.dot} />
+          </div>
+          <span style={styles.title}>hoop · risk dashboard</span>
+          <span style={{ width: 48 }} />
+        </div>
+
+        <div style={styles.grid}>
+          {METRICS.map((m, i) => (
+            <div key={m.label} style={styles.card}>
+              <span style={{ ...styles.value, color: m.color }}>
+                {values[i].toLocaleString()}
+              </span>
+              <span style={styles.label}>{m.label}</span>
+              <div style={styles.barTrack}>
+                <div
+                  style={{
+                    ...styles.barFill,
+                    width: `${(values[i] / m.target) * 100}%`,
+                    background: m.color,
+                  }}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div style={styles.status}>
+          <span style={styles.statusDot} />
+          <span>Live · last 30 days</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/snippets/annimations/RunbookAnimation.jsx
+++ b/snippets/annimations/RunbookAnimation.jsx
@@ -1,0 +1,380 @@
+/**
+ * RunbookAnimation — Interactive runbook template → form → execution flow
+ *
+ * Phases:
+ *   0 — Code template visible (3s)
+ *   1 — Lens sweeps revealing form view + typing (5s)
+ *   2 — Access review checks (2.5s)
+ *   3 — Results table (4s)
+ *
+ * Pure CSS keyframes + React state.
+ */
+
+export const RunbookAnimation = () => {
+  const WG = 'var(--warm-gold)';
+  const rgba = (a) => `rgba(var(--sand-100-rgb),${a})`;
+
+  const useTypewriter = (text, active, speed = 65) => {
+    const [out, setOut] = useState('');
+    const [done, setDone] = useState(false);
+    useEffect(() => {
+      if (!active) { setOut(''); setDone(false); return; }
+      let i = 0; setOut(''); setDone(false);
+      const iv = setInterval(() => { i++; setOut(text.slice(0, i)); if (i >= text.length) { clearInterval(iv); setDone(true); } }, speed);
+      return () => clearInterval(iv);
+    }, [text, active, speed]);
+    return [out, done];
+  };
+
+  const Overline = ({ children, style }) => {
+    return (
+      <div style={{
+        fontFamily: 'var(--sans)', fontSize: 10, fontWeight: 600,
+        color: WG, textTransform: 'uppercase', letterSpacing: '0.1em',
+        marginBottom: 10, ...style,
+      }}>
+        {children}
+      </div>
+    );
+  };
+
+  const Check = ({ checked, label }) => {
+    return (
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 7,
+        fontFamily: 'var(--sans)', fontSize: 11.5,
+        color: checked ? rgba(0.55) : rgba(0.25),
+        transition: 'color 0.3s',
+      }}>
+        <div style={{
+          width: 16, height: 16, borderRadius: 3,
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          background: checked ? 'rgba(var(--warm-gold-rgb),0.12)' : rgba(0.03),
+          border: checked ? '1px solid rgba(var(--warm-gold-rgb),0.3)' : `1px solid ${rgba(0.08)}`,
+          transition: 'all 0.4s',
+        }}>
+          {checked
+            ? <svg width="9" height="9" viewBox="0 0 16 16" fill="none"><path d="M3 8.5L6.5 12L13 4" stroke={WG} strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"/></svg>
+            : <div style={{ width: 7, height: 7, borderRadius: '50%', border: `2px solid ${rgba(0.12)}`, borderTopColor: 'rgba(var(--warm-gold-rgb),0.4)', animation: 'rb-spin 0.8s linear infinite' }}/>
+          }
+        </div>
+        {label}
+      </div>
+    );
+  };
+
+  const Connector = ({ visible }) => {
+    return (
+      <div style={{
+        display: 'flex', justifyContent: 'center',
+        height: visible ? 16 : 0, overflow: 'hidden',
+        transition: 'height 0.4s cubic-bezier(.4,0,.2,1)',
+      }}>
+        <div style={{ width: 1, height: '100%', background: 'linear-gradient(to bottom, rgba(var(--warm-gold-rgb),0.25), transparent)' }}/>
+      </div>
+    );
+  };
+
+  const CODE_LINES = [
+    { t: 'comment', v: '-- customer-lookup.runbook.sql' },
+    { t: 'kw', v: 'SELECT' },
+    { t: 'f', v: '  customer_id, name, email, status' },
+    { t: 'kw', v: 'FROM customers' },
+    { t: 'kw', v: 'WHERE' },
+    { t: 'param', v: '  customer_id = {{ .customer_id | required | type "number" }}' },
+  ];
+
+  const PHASES = [
+    { label: 'Template', ms: 3000 },
+    { label: 'Lens view', ms: 5000 },
+    { label: 'Review', ms: 2500 },
+    { label: 'Results', ms: 4000 },
+  ];
+
+  const [phase, setPhase] = useState(0);
+  const [checks, setChecks] = useState(0);
+  const [lensPos, setLensPos] = useState(0);
+
+  const [typed, typedDone] = useTypewriter('40192', phase >= 1, 75);
+
+  useEffect(() => {
+    let t;
+    const run = (p) => {
+      t = setTimeout(() => {
+        const n = (p + 1) % 4;
+        setPhase(n);
+        if (n === 0) { setChecks(0); setLensPos(0); }
+        run(n);
+      }, PHASES[p].ms);
+    };
+    run(0);
+    return () => clearTimeout(t);
+  }, []);
+
+  useEffect(() => {
+    if (phase !== 1) return;
+    setLensPos(0);
+    const start = performance.now();
+    const duration = 1800;
+    let frameId;
+    const animate = (now) => {
+      const elapsed = now - start;
+      const progress = Math.min(elapsed / duration, 1);
+      const eased = 1 - Math.pow(1 - progress, 3);
+      setLensPos(eased * 100);
+      if (progress < 1) frameId = requestAnimationFrame(animate);
+    };
+    frameId = requestAnimationFrame(animate);
+    return () => cancelAnimationFrame(frameId);
+  }, [phase]);
+
+  useEffect(() => {
+    if (phase !== 2) { setChecks(0); return; }
+    let c = 0;
+    const iv = setInterval(() => { c++; setChecks(c); if (c >= 3) clearInterval(iv); }, 600);
+    return () => clearInterval(iv);
+  }, [phase]);
+
+  const lensActive = phase >= 1;
+  const lensWidth = lensActive ? lensPos : 0;
+
+  return (
+    <div className="rb-root" aria-hidden="true">
+      <style>{`
+        @keyframes rb-blink { 0%,100%{opacity:1} 50%{opacity:0} }
+        @keyframes rb-up { from{opacity:0;transform:translateY(6px)} to{opacity:1;transform:translateY(0)} }
+        @keyframes rb-spin { to{transform:rotate(360deg)} }
+        @keyframes rb-pulse { 0%,100%{opacity:.12} 50%{opacity:.2} }
+
+        .rb-root {
+          position: relative;
+          width: 100%;
+          max-width: 580px;
+        }
+      `}</style>
+
+      <div style={{
+        background: 'linear-gradient(135deg, var(--gradient-dark-start) 0%, var(--gradient-dark-mid) 35%, var(--gradient-dark-end) 70%, var(--bronze) 100%)',
+        borderRadius: 14, overflow: 'hidden', position: 'relative',
+        fontFamily: 'var(--sans)',
+      }}>
+        <div style={{
+          position: 'absolute', top: '-30%', right: '-10%', width: '60%', height: '160%',
+          background: 'radial-gradient(ellipse at center, rgba(var(--warm-gold-rgb),0.12) 0%, transparent 70%)',
+          pointerEvents: 'none', animation: 'rb-pulse 4s ease-in-out infinite',
+        }}/>
+
+        {/* Top bar */}
+        <div style={{
+          position: 'relative', padding: '14px 22px',
+          display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+          borderBottom: `1px solid ${rgba(0.06)}`,
+        }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="var(--sand-100)">
+              <circle cx="7" cy="7" r="3.5"/><circle cx="17" cy="7" r="3.5"/>
+              <circle cx="7" cy="17" r="3.5"/><circle cx="17" cy="17" r="3.5"/>
+            </svg>
+            <span style={{ fontSize: 13, fontWeight: 700, color: 'var(--sand-100)' }}>Runbooks</span>
+          </div>
+          <div style={{ display: 'flex', gap: 6 }}>
+            {PHASES.map((_, i) => (
+              <div key={i} style={{
+                width: i === phase ? 22 : 7, height: 7, borderRadius: 4,
+                background: i === phase ? WG : i < phase ? 'rgba(var(--warm-gold-rgb),0.4)' : rgba(0.1),
+                transition: 'all 0.5s cubic-bezier(.4,0,.2,1)',
+              }}/>
+            ))}
+          </div>
+          <div style={{ fontSize: 11, fontWeight: 500, color: rgba(0.3) }}>{PHASES[phase].label}</div>
+        </div>
+
+        {/* Body — fixed height to prevent layout shift between phases */}
+        <div style={{ position: 'relative', padding: '20px 24px', display: 'flex', flexDirection: 'column', gap: 0, minHeight: 480 }}>
+
+          {/* Code + Lens */}
+          <div style={{ position: 'relative', borderRadius: 10, overflow: 'hidden', minHeight: 250 }}>
+
+            {/* Code layer */}
+            <div style={{
+              background: rgba(0.04), border: `1px solid ${rgba(0.08)}`,
+              borderRadius: 10, padding: '16px 20px',
+              fontFamily: 'var(--mono)', fontSize: 12.5, lineHeight: 2,
+              position: 'relative', zIndex: 1,
+            }}>
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
+                <Overline style={{ marginBottom: 0 }}>Template</Overline>
+                <div style={{ fontFamily: 'var(--mono)', fontSize: 9, color: rgba(0.2) }}>customer-lookup.runbook.sql</div>
+              </div>
+              {CODE_LINES.map((l, i) => {
+                let color = rgba(0.55);
+                let bg = 'transparent';
+                let weight = 400;
+                if (l.t === 'comment') color = 'var(--sand-500)';
+                if (l.t === 'kw') color = WG;
+                if (l.t === 'param') {
+                  color = WG;
+                  bg = 'rgba(var(--warm-gold-rgb),0.08)';
+                  weight = 500;
+                }
+                return (
+                  <div key={i} style={{
+                    color, fontWeight: weight, background: bg,
+                    borderRadius: l.t === 'param' ? 4 : 0,
+                    padding: l.t === 'param' ? '2px 6px' : 0,
+                    margin: l.t === 'param' ? '4px -6px 0' : 0,
+                    border: l.t === 'param' ? '1px solid rgba(var(--warm-gold-rgb),0.15)' : 'none',
+                  }}>
+                    {l.v}
+                  </div>
+                );
+              })}
+            </div>
+
+            {/* Lens overlay */}
+            <div style={{
+              position: 'absolute', top: 0, left: 0, bottom: 0,
+              width: `${lensWidth}%`,
+              overflow: 'hidden', zIndex: 2, borderRadius: 10,
+              transition: phase === 0 ? 'width 0.3s' : 'none',
+            }}>
+              <div style={{
+                background: 'rgba(var(--espresso-rgb),0.95)',
+                backdropFilter: 'blur(12px)', WebkitBackdropFilter: 'blur(12px)',
+                border: '1px solid rgba(var(--sand-100-rgb),0.08)',
+                borderRadius: 10, padding: '16px 20px',
+                width: '100%', minWidth: 0, height: '100%', boxSizing: 'border-box',
+                display: 'flex', flexDirection: 'column',
+              }}>
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 14 }}>
+                  <Overline style={{ marginBottom: 0 }}>Customer Lookup</Overline>
+                  <div style={{ fontFamily: 'var(--sans)', fontSize: 9, color: rgba(0.25), display: 'flex', alignItems: 'center', gap: 4 }}>
+                    <div style={{ width: 5, height: 5, borderRadius: '50%', background: WG }}/>
+                    Form view
+                  </div>
+                </div>
+
+                <div style={{ marginBottom: 14 }}>
+                  <div style={{ fontSize: 12, fontFamily: 'var(--sans)', fontWeight: 500, color: rgba(0.5), marginBottom: 5 }}>
+                    Customer ID <span style={{ fontSize: 9, color: 'rgba(var(--warm-gold-rgb),0.5)', fontStyle: 'italic' }}>required &middot; number</span>
+                  </div>
+                  <div style={{
+                    background: rgba(0.03),
+                    border: typedDone ? '1px solid rgba(var(--warm-gold-rgb),0.35)' : `1px solid ${rgba(0.1)}`,
+                    borderRadius: 6, padding: '9px 12px',
+                    fontFamily: 'var(--mono)', fontSize: 13, color: 'var(--sand-100)',
+                    minHeight: 18, transition: 'border-color 0.3s', display: 'flex', alignItems: 'center',
+                  }}>
+                    {typed}
+                    {phase === 1 && !typedDone && (
+                      <span style={{ display: 'inline-block', width: 2, height: 15, background: WG, marginLeft: 1, animation: 'rb-blink 1s step-end infinite' }}/>
+                    )}
+                  </div>
+                </div>
+
+                <div style={{ marginBottom: 14 }}>
+                  <div style={{ fontSize: 12, fontFamily: 'var(--sans)', fontWeight: 500, color: rgba(0.5), marginBottom: 5 }}>Output columns</div>
+                  <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+                    {['customer_id', 'name', 'email', 'status'].map(f => (
+                      <span key={f} style={{
+                        background: rgba(0.04), border: `1px solid ${rgba(0.08)}`,
+                        borderRadius: 4, padding: '3px 8px',
+                        fontFamily: 'var(--mono)', fontSize: 10, color: rgba(0.3),
+                      }}>{f}</span>
+                    ))}
+                  </div>
+                </div>
+
+                {typedDone && (
+                  <div style={{
+                    display: 'inline-flex', alignItems: 'center', gap: 5, alignSelf: 'flex-start',
+                    background: 'rgba(var(--warm-gold-rgb),0.08)', border: '1px solid rgba(var(--warm-gold-rgb),0.2)',
+                    borderRadius: 14, padding: '4px 10px',
+                    fontSize: 10, fontWeight: 500, color: WG, animation: 'rb-up 0.3s ease-out',
+                  }}>
+                    <svg width="10" height="10" viewBox="0 0 16 16" fill="none">
+                      <path d="M3 8.5L6.5 12L13 4" stroke={WG} strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"/>
+                    </svg>
+                    Ready to execute
+                  </div>
+                )}
+              </div>
+
+              {lensActive && lensWidth < 100 && (
+                <div style={{
+                  position: 'absolute', top: 0, right: -1, bottom: 0, width: 3,
+                  background: 'linear-gradient(to bottom, rgba(var(--warm-gold-rgb),0.5), rgba(var(--warm-gold-rgb),0.1))',
+                  borderRadius: 2, boxShadow: '0 0 12px rgba(var(--warm-gold-rgb),0.3)',
+                }}/>
+              )}
+            </div>
+          </div>
+
+          <Connector visible={phase >= 2} />
+
+          {/* Review */}
+          <div style={{
+            background: rgba(0.04), border: `1px solid ${rgba(0.08)}`, borderRadius: 10, padding: '14px 18px',
+            opacity: phase >= 2 ? 1 : 0, maxHeight: phase >= 2 ? 160 : 0, overflow: 'hidden',
+            transition: 'opacity 0.4s 0.1s, max-height 0.4s cubic-bezier(.4,0,.2,1)',
+          }}>
+            <Overline>Access Review</Overline>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 7 }}>
+              <Check checked={checks >= 1} label="Guardrails passed" />
+              <Check checked={checks >= 2} label="Data masking enabled" />
+              <Check checked={checks >= 3} label="Approved by policy" />
+            </div>
+          </div>
+
+          <Connector visible={phase >= 3} />
+
+          {/* Results */}
+          <div style={{
+            background: rgba(0.04), border: `1px solid ${rgba(0.08)}`, borderRadius: 10, padding: 0, overflow: 'hidden',
+            opacity: phase >= 3 ? 1 : 0, maxHeight: phase >= 3 ? 200 : 0,
+            transition: 'opacity 0.4s 0.1s, max-height 0.4s cubic-bezier(.4,0,.2,1)',
+          }}>
+            <div style={{
+              background: rgba(0.03), borderBottom: `1px solid ${rgba(0.06)}`,
+              padding: '8px 14px', display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+            }}>
+              <Overline style={{ marginBottom: 0 }}>Results</Overline>
+              <span style={{ fontFamily: 'var(--mono)', fontSize: 9, color: rgba(0.2) }}>1 row &middot; 42ms</span>
+            </div>
+            <div style={{ padding: '0 14px' }}>
+              <div style={{
+                display: 'grid', gridTemplateColumns: '50px 1fr 1fr 60px',
+                padding: '6px 0', borderBottom: `1px solid ${rgba(0.04)}`,
+                fontFamily: 'var(--sans)', fontSize: 9, fontWeight: 600, color: rgba(0.25), textTransform: 'uppercase',
+              }}>
+                <span>ID</span><span>Name</span><span>Email</span><span>Status</span>
+              </div>
+              <div style={{
+                display: 'grid', gridTemplateColumns: '50px 1fr 1fr 60px',
+                padding: '8px 0', fontFamily: 'var(--mono)', fontSize: 11, color: rgba(0.55),
+                animation: phase >= 3 ? 'rb-up 0.4s ease-out' : 'none',
+              }}>
+                <span>40192</span>
+                <span>Acme Corp</span>
+                <span style={{ color: WG, fontWeight: 500 }}>a&bull;&bull;&bull;@acme.io</span>
+                <span>
+                  <span style={{
+                    background: 'rgba(var(--warm-gold-rgb),0.08)', border: '1px solid rgba(var(--warm-gold-rgb),0.2)',
+                    borderRadius: 10, padding: '1px 6px', fontSize: 8.5,
+                    fontFamily: 'var(--sans)', fontWeight: 600, color: WG, textTransform: 'uppercase',
+                  }}>active</span>
+                </span>
+              </div>
+            </div>
+            <div style={{
+              borderTop: `1px solid ${rgba(0.04)}`, padding: '7px 14px',
+              display: 'flex', gap: 10, fontSize: 9, color: rgba(0.18),
+            }}>
+              <span>Recorded</span><span>&middot;</span><span>Audited</span><span>&middot;</span><span>Masked</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/snippets/annimations/ScrollReveal.jsx
+++ b/snippets/annimations/ScrollReveal.jsx
@@ -1,0 +1,41 @@
+/**
+ * ScrollReveal — Fade-in + slide-up on scroll
+ *
+ * Uses IntersectionObserver. Animates once, then unobserves.
+ *
+ * Props:
+ *   children
+ *   delay     — optional delay in ms (for stagger effects)
+ *   className — optional extra classes
+ */
+export const ScrollReveal = ({ children, delay = 0, className = '' }) => {
+  const ref = useRef(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          el.classList.add('reveal-visible');
+          observer.unobserve(el);
+        }
+      },
+      { threshold: 0.15, rootMargin: '0px 0px -40px 0px' }
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div
+      ref={ref}
+      className={`reveal ${className}`}
+      style={delay ? { '--reveal-delay': `${delay}ms` } : undefined}
+    >
+      {children}
+    </div>
+  );
+}

--- a/snippets/annimations/SessionAnimation.jsx
+++ b/snippets/annimations/SessionAnimation.jsx
@@ -1,0 +1,335 @@
+/**
+ * SessionAnimation — Full-session lifecycle walkthrough
+ *
+ * Used in: home page "How It Works" section
+ *
+ * Five steps auto-advance every 2.8s (or click to jump):
+ *   0 — Connection established (OIDC auth output)
+ *   1 — Query received (SQL prompt)
+ *   2 — Response intercepted (SSN pattern detection)
+ *   3 — Masking applied (warm-gold masked values)
+ *   4 — Session logged (audit entry + risk score)
+ *
+ * Panel content rendered inline (same component scope) so styled-jsx
+ * scoping works correctly without global styles.
+ *
+ * Props:
+ *   autoPlay  — boolean (default true)
+ *   protocol  — 'postgres' | 'kubernetes' | 'ssh'
+ */
+
+export const SessionAnimation = ({ autoPlay = true, protocol = 'postgres' }) => {
+  const STEP_DURATION = 2800;
+
+  const STEPS = [
+    { id: 0, label: 'Connection established' },
+    { id: 1, label: 'Query received'         },
+    { id: 2, label: 'Response intercepted'   },
+    { id: 3, label: 'Masking applied'        },
+    { id: 4, label: 'Session logged'         },
+  ];
+
+  const MASKED_ROWS = [
+    ['1001', 'J. Smith',     '***-**-6789'],
+    ['1002', 'M. Rodriguez', '***-**-7890'],
+    ['1003', 'A. Chen',      '***-**-8901'],
+    ['1004', 'S. Patel',     '***-**-9012'],
+  ];
+
+  const [activeStep, setActiveStep] = useState(0);
+  const [visible, setVisible]       = useState(true);
+  const [progress, setProgress]     = useState(0);
+  const activeStepRef               = useRef(activeStep);
+  activeStepRef.current             = activeStep;
+
+  function goTo(id) {
+    setVisible(false);
+    setTimeout(() => { setActiveStep(id); setVisible(true); }, 175);
+  }
+
+  useEffect(() => {
+    if (!autoPlay) return;
+    const id = setInterval(() => {
+      goTo((activeStepRef.current + 1) % STEPS.length);
+    }, STEP_DURATION);
+    return () => clearInterval(id);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [autoPlay]);
+
+  useEffect(() => {
+    setProgress(0);
+    const start = performance.now();
+    let frameId;
+
+    function tick(now) {
+      const elapsed = now - start;
+      const pct = Math.min((elapsed / STEP_DURATION) * 100, 100);
+      setProgress(pct);
+      if (pct < 100) {
+        frameId = requestAnimationFrame(tick);
+      }
+    }
+
+    frameId = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(frameId);
+  }, [activeStep]);
+
+  // ── Panel content rendered inline so styled-jsx scoping applies ──
+  function renderPanel() {
+    switch (activeStep) {
+      case 0:
+        return (
+          <div className="sa-code">
+            <div>
+              <span className="sa-prompt">$ </span>
+              <span className="sa-cmd">hoop connect {protocol}:prod</span>
+            </div>
+            <div className="sa-gap" />
+            <div>
+              <span className="sa-gold">&#x2713; </span>
+              <span className="sa-out">Connected to {protocol}:prod</span>
+            </div>
+            <div>
+              <span className="sa-muted">  Session   </span>
+              <span className="sa-val">sess_01jkx7r2nb4f</span>
+            </div>
+            <div>
+              <span className="sa-muted">  Identity  </span>
+              <span className="sa-val">alice@corp.com</span>
+            </div>
+            <div>
+              <span className="sa-muted">  Auth      </span>
+              <span className="sa-val">OIDC · token expires in 8h</span>
+            </div>
+          </div>
+        );
+
+      case 1:
+        return (
+          <div className="sa-code">
+            <div>
+              <span className="sa-muted">psql&gt; </span>
+              <span className="sa-cmd">SELECT id, name, ssn, email FROM customers LIMIT 4;</span>
+            </div>
+            <div className="sa-gap" />
+            <div className="sa-dim">Forwarding to {protocol}:prod...</div>
+            <div className="sa-dim">Response received &middot; 4 rows &middot; 3.2 KB</div>
+            <div className="sa-gap" />
+            <div className="sa-dim sa-small">Hoop inspecting response payload...</div>
+          </div>
+        );
+
+      case 2:
+        return (
+          <div className="sa-code">
+            {[
+              ['123-45-6789', 'row 1'],
+              ['234-56-7890', 'row 2'],
+              ['345-67-8901', 'row 3'],
+              ['456-78-9012', 'row 4'],
+            ].map(([val, label]) => (
+              <div className="sa-detect-row" key={label}>
+                <span className="sa-badge">SSN detected</span>
+                <span className="sa-val">{val}</span>
+                <span className="sa-muted sa-small">{label}</span>
+              </div>
+            ))}
+            <div className="sa-gap" />
+            <div className="sa-dim sa-small">
+              Pattern: \d{'{3}'}-\d{'{2}'}-\d{'{4}'} &middot; column: ssn &middot; 4 matches
+            </div>
+          </div>
+        );
+
+      case 3:
+        return (
+          <div className="sa-code">
+            <div className="sa-trow sa-thead">
+              <span>id</span>
+              <span>name</span>
+              <span>ssn</span>
+            </div>
+            <div className="sa-divider" />
+            {MASKED_ROWS.map(([id, name, ssn]) => (
+              <div className="sa-trow" key={id}>
+                <span className="sa-dim">{id}</span>
+                <span className="sa-out">{name}</span>
+                <span className="sa-gold sa-bold">{ssn}</span>
+              </div>
+            ))}
+          </div>
+        );
+
+      case 4:
+        return (
+          <div className="sa-code">
+            <div><span className="sa-muted">session  </span><span className="sa-val">sess_01jkx7r2nb4f</span></div>
+            <div><span className="sa-muted">identity </span><span className="sa-val">alice@corp.com</span></div>
+            <div><span className="sa-muted">resource </span><span className="sa-val">{protocol}:prod</span></div>
+            <div><span className="sa-muted">duration </span><span className="sa-val">1m 24s</span></div>
+            <div><span className="sa-muted">masked   </span><span className="sa-val">4 SSN values</span></div>
+            <div><span className="sa-muted">blocked  </span><span className="sa-val">0 operations</span></div>
+            <div><span className="sa-muted">risk     </span><span className="sa-gold sa-bold"> low</span></div>
+          </div>
+        );
+
+      default: return null;
+    }
+  }
+
+  return (
+    <div className="sa-root" aria-label="Session walkthrough">
+
+      {/* Step list */}
+      <div className="sa-steps">
+        {STEPS.map((step) => (
+          <button
+            key={step.id}
+            className={`sa-step${activeStep === step.id ? ' sa-active' : ''}`}
+            onClick={() => goTo(step.id)}
+          >
+            <span className="sa-num">{String(step.id + 1).padStart(2, '0')}</span>
+            <span className="sa-label">{step.label}</span>
+          </button>
+        ))}
+      </div>
+
+      {/* Progress bar */}
+      <div className="sa-progress-track">
+        <div className="sa-progress-fill" style={{ width: `${progress}%` }} />
+      </div>
+
+      {/* Panel */}
+      <div className="mock-container sa-panel">
+        <div className="mock-toolbar" style={{ justifyContent: 'space-between' }}>
+          <div style={{ display: 'flex', gap: 6 }}>
+            <div className="mock-dot" />
+            <div className="mock-dot" />
+            <div className="mock-dot" />
+          </div>
+          <span className="sa-protocol">{protocol}</span>
+          <span style={{ width: 48 }} />
+        </div>
+        <div className={`sa-body${visible ? ' sa-visible' : ' sa-hidden'}`}>
+          {renderPanel()}
+        </div>
+      </div>
+
+      <style>{`
+        .sa-root {
+          display: flex;
+          gap: 24px;
+          width: 100%;
+        }
+
+        /* ── Step list ── */
+        .sa-steps {
+          display: flex;
+          flex-direction: column;
+          gap: 2px;
+          min-width: 188px;
+        }
+
+        .sa-step {
+          display: flex;
+          align-items: flex-start;
+          gap: 10px;
+          background: none;
+          border: none;
+          cursor: pointer;
+          padding: 9px 12px;
+          border-radius: 6px;
+          text-align: left;
+          transition: background 0.15s;
+        }
+
+        .sa-step:hover       { background: rgba(var(--sand-100-rgb), 0.04); }
+        .sa-step.sa-active   { background: rgba(var(--sand-100-rgb), 0.06); }
+
+        .sa-num {
+          font-family: var(--mono);
+          font-size: 11px;
+          color: rgba(var(--sand-100-rgb), 0.25);
+          flex-shrink: 0;
+          padding-top: 1px;
+        }
+
+        .sa-step.sa-active .sa-num { color: var(--warm-gold); }
+
+        .sa-label {
+          font-family: var(--sans);
+          font-size: 12px;
+          color: rgba(var(--sand-100-rgb), 0.35);
+          line-height: 1.45;
+        }
+
+        .sa-step.sa-active .sa-label { color: rgba(var(--sand-100-rgb), 0.8); }
+
+        /* ── Progress bar ── */
+        .sa-progress-track {
+          height: 2px;
+          background: rgba(var(--sand-100-rgb), 0.06);
+          border-radius: 1px;
+          overflow: hidden;
+          margin-top: 8px;
+        }
+
+        .sa-progress-fill {
+          height: 100%;
+          background: var(--warm-gold);
+          border-radius: 1px;
+          transition: width 0.1s linear;
+          opacity: 0.6;
+        }
+
+        /* ── Panel ── */
+        .sa-panel {
+          flex: 1;
+          border-radius: 10px;
+          overflow: hidden;
+          height: 260px;
+          overflow: hidden;
+        }
+
+        .sa-protocol {
+          font-family: var(--mono);
+          font-size: 11px;
+          color: rgba(var(--sand-100-rgb), 0.2);
+        }
+
+        .sa-body {
+          padding: 20px;
+          height: 200px;
+          transition: opacity 0.175s ease;
+        }
+
+        .sa-visible { opacity: 1; }
+        .sa-hidden  { opacity: 0; }
+
+        /* ── Code content (colors in globals.css) ── */
+        .sa-code {
+          font-family: var(--mono);
+          font-size: 12px;
+          line-height: 1.9;
+          display: flex;
+          flex-direction: column;
+        }
+
+        .sa-detect-row {
+          display: flex;
+          align-items: center;
+          gap: 10px;
+          padding: 2px 0;
+        }
+
+        .sa-trow {
+          display: grid;
+          grid-template-columns: 52px 136px 1fr;
+          gap: 8px;
+          font-size: 12px;
+          line-height: 1.9;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/snippets/annimations/SessionRecording.jsx
+++ b/snippets/annimations/SessionRecording.jsx
@@ -1,0 +1,447 @@
+export const SessionRecording = () => {
+  const COLORS = {
+    espresso: "var(--gradient-dark-mid)",
+    bronzeDark: "var(--bronze-dark)",
+    bronze: "var(--bronze)",
+    warmGold: "var(--warm-gold)",
+    sand100: "var(--sand-100)",
+    sand200: "var(--sand-200)",
+    sand300: "var(--sand-300)",
+    sand400: "var(--sand-400)",
+    sand500: "var(--sand-500)",
+    nearBlack: "#111111",
+    strong: "#333333",
+    body: "#555555",
+    secondary: "#777777",
+    muted: "#999999",
+  };
+
+  const SESSION_LINES = [
+    { type: "prompt", text: "maria@prod-db-01:~$", cmd: " SELECT * FROM users WHERE role = 'admin';" },
+    { type: "output", lines: [
+      "  id  | name            | role   | last_login",
+      " -----+-----------------+--------+---------------------",
+      "  142 | sarah.chen       | admin  | 2026-03-21 09:14:22",
+      "  287 | james.walker     | admin  | 2026-03-20 18:47:01",
+      "  391 | alex.kumar       | admin  | 2026-03-21 11:02:55",
+      " (3 rows)",
+    ]},
+    { type: "prompt", text: "maria@prod-db-01:~$", cmd: " UPDATE users SET mfa_enabled = true WHERE role = 'admin';" },
+    { type: "output", lines: ["UPDATE 3"] },
+    { type: "prompt", text: "maria@prod-db-01:~$", cmd: " \\q" },
+    { type: "output", lines: ["Connection closed."] },
+  ];
+
+  const SESSION_META = {
+    user: "Maria Oliveira",
+    email: "maria@acme.com",
+    connection: "prod-db-01 (PostgreSQL)",
+    started: "Mar 21, 2026 · 11:02 UTC",
+    duration: "2m 34s",
+    status: "Completed",
+  };
+
+  /* ── Typewriter ── */
+  const useTypewriter = (text, speed = 32, startDelay = 0, active = false) => {
+    const [displayed, setDisplayed] = useState("");
+    const [done, setDone] = useState(false);
+    const timerRef = useRef(null);
+    const intervalRef = useRef(null);
+
+    useEffect(() => {
+      if (!active) {
+        if (!done) { setDisplayed(""); setDone(false); }
+        return;
+      }
+      setDisplayed(""); setDone(false);
+      let i = 0;
+      timerRef.current = setTimeout(() => {
+        intervalRef.current = setInterval(() => {
+          i++;
+          setDisplayed(text.slice(0, i));
+          if (i >= text.length) {
+            clearInterval(intervalRef.current);
+            setDone(true);
+          }
+        }, speed);
+      }, startDelay);
+      return () => {
+        clearTimeout(timerRef.current);
+        clearInterval(intervalRef.current);
+      };
+    }, [text, speed, startDelay, active]);
+
+    return { displayed, done };
+  };
+
+  /* ── Playback bar ── */
+  const PlaybackBar = ({ progress, elapsed, total }) => {
+    return (
+      <div style={{
+        display: "flex", alignItems: "center", gap: 10,
+        padding: "10px 18px",
+        background: "rgba(0,0,0,0.25)",
+        borderTop: "1px solid rgba(var(--sand-100-rgb),0.06)",
+        fontFamily: "'JetBrains Mono', monospace",
+        fontSize: 11,
+      }}>
+        <svg width="12" height="14" viewBox="0 0 12 14" fill="none">
+          <path d="M1.5 1v12l9.5-6L1.5 1z" fill={COLORS.warmGold} opacity={0.6} />
+        </svg>
+        <span style={{ color: "rgba(var(--sand-100-rgb),0.35)", minWidth: 38 }}>{elapsed}</span>
+        <div style={{
+          flex: 1, height: 3, borderRadius: 2,
+          background: "rgba(var(--sand-100-rgb),0.08)",
+          overflow: "hidden",
+        }}>
+          <div style={{
+            width: `${progress}%`, height: "100%",
+            background: `linear-gradient(90deg, ${COLORS.warmGold}, ${COLORS.bronze})`,
+            borderRadius: 2, transition: "width 0.4s linear",
+          }} />
+        </div>
+        <span style={{ color: "rgba(var(--sand-100-rgb),0.2)", minWidth: 38, textAlign: "right" }}>{total}</span>
+      </div>
+    );
+  };
+
+  /* ── Meta sidebar ── */
+  const MetaPanel = ({ visible }) => {
+    const rows = [
+      { label: "USER", value: SESSION_META.user, sub: SESSION_META.email },
+      { label: "CONNECTION", value: SESSION_META.connection },
+      { label: "STARTED", value: SESSION_META.started },
+      { label: "DURATION", value: SESSION_META.duration },
+      { label: "STATUS", value: SESSION_META.status, badge: true },
+    ];
+    return (
+      <div style={{
+        width: 210, flexShrink: 0,
+        background: "rgba(0,0,0,0.18)",
+        borderLeft: "1px solid rgba(var(--sand-100-rgb),0.06)",
+        padding: "18px 16px",
+        display: "flex", flexDirection: "column", gap: 14,
+        opacity: visible ? 1 : 0,
+        transform: visible ? "translateX(0)" : "translateX(16px)",
+        transition: "opacity 0.6s ease, transform 0.6s ease",
+        fontFamily: "'DM Sans', sans-serif",
+        overflow: "hidden",
+      }}>
+        <div style={{
+          fontSize: 10, fontWeight: 600, letterSpacing: "0.1em",
+          color: COLORS.warmGold, textTransform: "uppercase",
+          paddingBottom: 6,
+          borderBottom: "1px solid rgba(var(--sand-100-rgb),0.06)",
+        }}>Session Details</div>
+        {rows.map((r, i) => (
+          <div key={i} style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+            <span style={{
+              fontSize: 9, fontWeight: 600, letterSpacing: "0.08em",
+              color: "rgba(var(--sand-100-rgb),0.25)", textTransform: "uppercase",
+            }}>{r.label}</span>
+            {r.badge ? (
+              <span style={{
+                display: "inline-block", width: "fit-content",
+                fontSize: 10, fontWeight: 600,
+                padding: "2px 8px", borderRadius: 99,
+                background: "rgba(var(--warm-gold-rgb),0.15)",
+                color: COLORS.warmGold,
+              }}>{r.value}</span>
+            ) : (
+              <span style={{ fontSize: 12, color: "rgba(var(--sand-100-rgb),0.6)", lineHeight: 1.4 }}>
+                {r.value}
+              </span>
+            )}
+            {r.sub && (
+              <span style={{ fontSize: 11, color: "rgba(var(--sand-100-rgb),0.3)" }}>{r.sub}</span>
+            )}
+          </div>
+        ))}
+        <div style={{ display: "flex", flexDirection: "column", gap: 5, marginTop: 2 }}>
+          <span style={{
+            fontSize: 9, fontWeight: 600, letterSpacing: "0.08em",
+            color: "rgba(var(--sand-100-rgb),0.25)", textTransform: "uppercase",
+          }}>TAGS</span>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
+            {["production", "database", "mfa-update"].map(tag => (
+              <span key={tag} style={{
+                fontSize: 10, padding: "2px 7px", borderRadius: 4,
+                background: "rgba(var(--sand-100-rgb),0.06)",
+                color: "rgba(var(--sand-100-rgb),0.3)",
+                border: "1px solid rgba(var(--sand-100-rgb),0.08)",
+              }}>{tag}</span>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  /* ── Recording dot ── */
+  const RecordingDot = ({ active }) => {
+    return (
+      <div style={{
+        display: "flex", alignItems: "center", gap: 6,
+        opacity: active ? 1 : 0.3, transition: "opacity 0.4s ease",
+      }}>
+        <div style={{
+          width: 7, height: 7, borderRadius: "50%",
+          background: active ? "#E05A47" : "rgba(var(--sand-100-rgb),0.2)",
+          boxShadow: active ? "0 0 8px rgba(224,90,71,0.4)" : "none",
+          animation: active ? "recPulse 1.4s ease-in-out infinite" : "none",
+        }} />
+        <span style={{
+          fontSize: 10, fontWeight: 600, letterSpacing: "0.06em",
+          color: active ? "rgba(var(--sand-100-rgb),0.45)" : "rgba(var(--sand-100-rgb),0.15)",
+          textTransform: "uppercase", fontFamily: "'DM Sans', sans-serif",
+        }}>REC</span>
+      </div>
+    );
+  };
+
+  /* ── Terminal line ── */
+  const TermLine = ({ item, animate, onDone, delay = 0 }) => {
+    const [showOutput, setShowOutput] = useState(false);
+    const [outputCount, setOutputCount] = useState(0);
+
+    const { displayed: cmdText, done: cmdDone } = useTypewriter(
+      item.type === "prompt" ? item.cmd : "", 32, delay,
+      animate && item.type === "prompt"
+    );
+
+    useEffect(() => {
+      if (item.type === "prompt" && cmdDone) {
+        const t = setTimeout(() => onDone?.(), 250);
+        return () => clearTimeout(t);
+      }
+    }, [cmdDone]);
+
+    useEffect(() => {
+      if (item.type === "output" && animate) {
+        const t = setTimeout(() => {
+          setShowOutput(true);
+          let i = 0;
+          const interval = setInterval(() => {
+            i++;
+            setOutputCount(i);
+            if (i >= item.lines.length) {
+              clearInterval(interval);
+              setTimeout(() => onDone?.(), 350);
+            }
+          }, 100);
+        }, delay);
+        return () => clearTimeout(t);
+      }
+    }, [animate]);
+
+    if (item.type === "prompt") {
+      return (
+        <div style={{ display: "flex", lineHeight: 2.0, whiteSpace: "pre" }}>
+          <span style={{ color: COLORS.warmGold, opacity: 0.7 }}>{item.text}</span>
+          <span style={{ color: COLORS.sand100, opacity: 0.85 }}>{cmdText}</span>
+          {animate && !cmdDone && (
+            <span style={{
+              display: "inline-block", width: 7, height: 15,
+              background: COLORS.warmGold, marginLeft: 1,
+              animation: "blink 0.7s step-end infinite",
+              verticalAlign: "middle", marginTop: 5,
+              borderRadius: 1,
+            }} />
+          )}
+        </div>
+      );
+    }
+
+    if (!showOutput) return null;
+    return (
+      <div style={{ marginBottom: 4 }}>
+        {item.lines.slice(0, outputCount).map((line, i) => (
+          <div key={i} style={{
+            color: "rgba(var(--sand-100-rgb),0.45)", lineHeight: 1.8,
+            whiteSpace: "pre", opacity: 0,
+            animation: "fadeInLine 0.25s ease forwards",
+            animationDelay: `${i * 50}ms`,
+          }}>{line}</div>
+        ))}
+      </div>
+    );
+  };
+
+  /* ── Main state ── */
+  const [phase, setPhase] = useState(0);
+  const [metaVisible, setMetaVisible] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [cycle, setCycle] = useState(0);
+  const termRef = useRef(null);
+  const totalSteps = SESSION_LINES.length;
+
+  const handleLineDone = useCallback(() => {
+    setPhase(p => {
+      const next = p + 1;
+      setProgress((next / totalSteps) * 100);
+      return next;
+    });
+  }, [totalSteps]);
+
+  useEffect(() => {
+    const t = setTimeout(() => setMetaVisible(true), 900);
+    return () => clearTimeout(t);
+  }, [cycle]);
+
+  useEffect(() => {
+    if (termRef.current) {
+      termRef.current.scrollTop = termRef.current.scrollHeight;
+    }
+  }, [phase]);
+
+  useEffect(() => {
+    if (phase >= totalSteps) {
+      const t = setTimeout(() => {
+        setPhase(0);
+        setProgress(0);
+        setMetaVisible(false);
+        setCycle(c => c + 1);
+      }, 5000);
+      return () => clearTimeout(t);
+    }
+  }, [phase, totalSteps]);
+
+  const fmtTime = (pct) => {
+    const s = Math.round((pct / 100) * 154);
+    return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, "0")}`;
+  };
+
+  return (
+    <div style={{ width: "100%", maxWidth: 860, margin: "0 auto" }}>
+      <style>{`
+        @import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&family=Sora:wght@600;700;800&display=swap');
+        @keyframes blink { 0%,100%{opacity:1} 50%{opacity:0} }
+        @keyframes recPulse { 0%,100%{opacity:1;transform:scale(1)} 50%{opacity:0.3;transform:scale(0.85)} }
+        @keyframes fadeInLine { from{opacity:0;transform:translateY(2px)} to{opacity:1;transform:translateY(0)} }
+        @keyframes slideUp { from{opacity:0;transform:translateY(8px)} to{opacity:1;transform:translateY(0)} }
+      `}</style>
+
+      {/* Outer frame: self-contained dark gradient */}
+      <div style={{
+        background: "linear-gradient(135deg, var(--gradient-dark-start) 0%, var(--gradient-dark-mid) 35%, var(--gradient-dark-end) 70%, var(--bronze) 100%)",
+        borderRadius: 12,
+        position: "relative",
+        overflow: "hidden",
+        boxShadow: "0 4px 32px rgba(0,0,0,0.3), 0 1px 4px rgba(0,0,0,0.2)",
+      }}>
+        {/* Radial glow overlay */}
+        <div style={{
+          position: "absolute", top: "-30%", right: "-10%",
+          width: "60%", height: "160%",
+          background: "radial-gradient(ellipse at center, rgba(var(--warm-gold-rgb),0.12) 0%, transparent 70%)",
+          pointerEvents: "none", zIndex: 0,
+        }} />
+
+        <div style={{
+          position: "relative", zIndex: 1,
+          fontFamily: "'JetBrains Mono', monospace", fontSize: 13,
+        }}>
+          {/* Toolbar */}
+          <div style={{
+            display: "flex", alignItems: "center", justifyContent: "space-between",
+            padding: "11px 18px",
+            background: "rgba(0,0,0,0.2)",
+            borderBottom: "1px solid rgba(var(--sand-100-rgb),0.06)",
+          }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 7 }}>
+              <div style={{ width: 9, height: 9, borderRadius: "50%", background: "rgba(var(--sand-100-rgb),0.12)" }} />
+              <div style={{ width: 9, height: 9, borderRadius: "50%", background: "rgba(var(--sand-100-rgb),0.12)" }} />
+              <div style={{ width: 9, height: 9, borderRadius: "50%", background: "rgba(var(--sand-100-rgb),0.12)" }} />
+            </div>
+            <div style={{
+              display: "flex", alignItems: "center", gap: 8,
+              padding: "4px 14px", borderRadius: 5,
+              background: "rgba(0,0,0,0.15)",
+              border: "1px solid rgba(var(--sand-100-rgb),0.04)",
+              fontSize: 11, color: "rgba(var(--sand-100-rgb),0.25)",
+              fontFamily: "'DM Sans', sans-serif",
+            }}>
+              <svg width="10" height="10" viewBox="0 0 16 16" fill="none">
+                <rect x="2" y="7" width="12" height="2" rx="1" fill="rgba(var(--sand-100-rgb),0.15)" />
+                <rect x="7" y="2" width="2" height="12" rx="1" fill="rgba(var(--sand-100-rgb),0.15)" />
+              </svg>
+              app.hoop.dev/sessions/rec-3f8a2e
+            </div>
+            <RecordingDot active={phase < totalSteps} />
+          </div>
+
+          {/* Tabs */}
+          <div style={{
+            display: "flex", gap: 0,
+            background: "rgba(0,0,0,0.12)",
+            borderBottom: "1px solid rgba(var(--sand-100-rgb),0.06)",
+            fontFamily: "'DM Sans', sans-serif", fontSize: 12,
+          }}>
+            {["Terminal", "Logs", "Video"].map((tab, i) => (
+              <div key={tab} style={{
+                padding: "9px 20px",
+                color: i === 0 ? "rgba(var(--sand-100-rgb),0.75)" : "rgba(var(--sand-100-rgb),0.2)",
+                borderBottom: i === 0 ? `2px solid ${COLORS.warmGold}` : "2px solid transparent",
+                background: i === 0 ? "rgba(var(--sand-100-rgb),0.02)" : "transparent",
+                cursor: "default",
+              }}>{tab}</div>
+            ))}
+          </div>
+
+          {/* Main content */}
+          <div style={{
+            display: "flex",
+            background: "rgba(0,0,0,0.10)",
+            minHeight: 340,
+          }}>
+            {/* Terminal */}
+            <div
+              ref={termRef}
+              style={{
+                flex: 1, padding: "20px 22px",
+                overflowY: "auto", overflowX: "hidden",
+                maxHeight: 340, scrollbarWidth: "none",
+              }}
+            >
+              {SESSION_LINES.filter((_, i) => i <= phase).map((item, i) => (
+                <TermLine
+                  key={`${cycle}-${i}`}
+                  item={item}
+                  animate={phase === i}
+                  onDone={handleLineDone}
+                  delay={i === 0 ? 700 : 200}
+                />
+              ))}
+
+              {phase >= totalSteps && (
+                <div style={{
+                  marginTop: 18, padding: "10px 14px",
+                  borderRadius: 6,
+                  background: "rgba(var(--warm-gold-rgb),0.08)",
+                  border: "1px solid rgba(var(--warm-gold-rgb),0.15)",
+                  display: "flex", alignItems: "center", gap: 8,
+                  animation: "slideUp 0.5s ease forwards",
+                }}>
+                  <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+                    <circle cx="7" cy="7" r="5.5" stroke={COLORS.warmGold} strokeWidth="1" opacity={0.5} />
+                    <path d="M4.5 7l1.8 1.8L9.5 5.5" stroke={COLORS.warmGold} strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" fill="none" />
+                  </svg>
+                  <span style={{
+                    fontSize: 12, color: COLORS.warmGold, opacity: 0.8,
+                    fontFamily: "'DM Sans', sans-serif",
+                  }}>Session recorded. 6 events captured.</span>
+                </div>
+              )}
+            </div>
+
+            {/* Sidebar */}
+            <MetaPanel visible={metaVisible} />
+          </div>
+
+          {/* Playback */}
+          <PlaybackBar progress={progress} elapsed={fmtTime(progress)} total="2:34" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/snippets/annimations/TerminalMasking.jsx
+++ b/snippets/annimations/TerminalMasking.jsx
@@ -1,0 +1,584 @@
+export const TerminalMasking = () => {
+  const FONTS_URL =
+    "https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&display=swap";
+
+  const C = {
+    termBg: "var(--gradient-dark-start)",
+    border: "rgba(var(--sand-100-rgb),0.06)",
+    warmGold: "var(--warm-gold)",
+    command: "var(--sand-300)",
+    rawFlash: "rgba(var(--sand-100-rgb),0.4)",
+    dimText: "rgba(var(--sand-100-rgb),0.20)",
+    sand100: "var(--sand-100)",
+  };
+
+  const PROMPT = "maria@prod-app-01:~$ ";
+
+  // Phase 1: cat customers.csv
+  const PHASE1_CMD = 'cat /var/data/customers.csv';
+  const PHASE1_HEADER = 'id,name,email,ssn,phone';
+  const PHASE1_ROWS = [
+    {
+      prefix: '1,',
+      fields: [
+        { raw: 'Sarah Chen', masked: '[PERSON]' },
+        { raw: 'sarah.chen@acme.io', masked: '[EMAIL]' },
+        { raw: '284-19-7653', masked: '[SSN]' },
+        { raw: '+1 415-892-3041', masked: '[PHONE]' },
+      ],
+    },
+    {
+      prefix: '2,',
+      fields: [
+        { raw: 'Marcus Webb', masked: '[PERSON]' },
+        { raw: 'm.webb@globex.com', masked: '[EMAIL]' },
+        { raw: '531-77-0294', masked: '[SSN]' },
+        { raw: '+1 212-555-8817', masked: '[PHONE]' },
+      ],
+    },
+    {
+      prefix: '3,',
+      fields: [
+        { raw: 'Elena Ruiz', masked: '[PERSON]' },
+        { raw: 'eruiz@initech.co', masked: '[EMAIL]' },
+        { raw: '719-42-8106', masked: '[SSN]' },
+        { raw: '+44 20-7946-0958', masked: '[PHONE]' },
+      ],
+    },
+  ];
+
+  // Phase 2: grep transactions
+  const PHASE2_CMD = 'grep "payment" /var/log/transactions.log';
+  const PHASE2_ROWS = [
+    {
+      prefix: '2026-03-22 14:01:22 payment_received ',
+      fields: [
+        { raw: 'card=4532-XXXX-XXXX-7891', masked: 'card=[PCI]' },
+        { raw: ' amount=$2,450.00 ', masked: ' amount=$2,450.00 ' },
+        { raw: 'user=sarah.chen@acme.io', masked: 'user=[EMAIL]' },
+      ],
+    },
+    {
+      prefix: '2026-03-22 14:01:45 payment_failed ',
+      fields: [
+        { raw: 'card=6011-XXXX-XXXX-4523', masked: 'card=[PCI]' },
+        { raw: ' amount=$180.00 ', masked: ' amount=$180.00 ' },
+        { raw: 'user=m.webb@globex.com', masked: 'user=[EMAIL]' },
+      ],
+    },
+    {
+      prefix: '2026-03-22 14:02:11 refund_processed ',
+      fields: [
+        { raw: 'card=3782-XXXX-XXXX-0052', masked: 'card=[PCI]' },
+        { raw: ' amount=$450.00 ', masked: ' amount=$450.00 ' },
+        { raw: 'user=eruiz@initech.co', masked: 'user=[EMAIL]' },
+      ],
+    },
+  ];
+
+  // Phase 3: env secrets
+  const PHASE3_CMD = 'env | grep -i secret';
+  const PHASE3_ROWS = [
+    {
+      prefix: 'DATABASE_URL=',
+      fields: [
+        { raw: 'postgres://admin:s3cretP@ss@db.internal:5432/prod', masked: '[CREDENTIAL]' },
+      ],
+    },
+    {
+      prefix: 'API_KEY=',
+      fields: [
+        { raw: 'sk-live-4f8b2c9a1d3e7f6b0a2c8e4d5f9b1a3c', masked: '[CREDENTIAL]' },
+      ],
+    },
+    {
+      prefix: 'AWS_SECRET_ACCESS_KEY=',
+      fields: [
+        { raw: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY', masked: '[CREDENTIAL]' },
+      ],
+    },
+  ];
+
+  const TYPING_SPEED = 45;
+  const RAW_FLASH_MS = 200;
+  const ROW_STAGGER = 500;
+  const PHASE_GAP = 1800;
+  const HOLD_END = 2000;
+
+  const [lines, setLines] = useState([]);
+  const [cursorVisible, setCursorVisible] = useState(true);
+  const [opacity, setOpacity] = useState(1);
+  const timeoutsRef = useRef([]);
+  const cursorIntervalRef = useRef(null);
+
+  const clearAll = useCallback(() => {
+    timeoutsRef.current.forEach(clearTimeout);
+    timeoutsRef.current = [];
+  }, []);
+
+  const later = useCallback((fn, ms) => {
+    const id = setTimeout(fn, ms);
+    timeoutsRef.current.push(id);
+    return id;
+  }, []);
+
+  // Blink cursor
+  useEffect(() => {
+    cursorIntervalRef.current = setInterval(() => {
+      setCursorVisible(v => !v);
+    }, 530);
+    return () => clearInterval(cursorIntervalRef.current);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const addLine = (line) => {
+      if (cancelled) return;
+      setLines(prev => [...prev, line]);
+    };
+
+    const updateLastLine = (updater) => {
+      if (cancelled) return;
+      setLines(prev => {
+        if (prev.length === 0) return prev;
+        const copy = [...prev];
+        copy[copy.length - 1] = updater(copy[copy.length - 1]);
+        return copy;
+      });
+    };
+
+    // Type a command character by character
+    const typeCommand = (cmd, startTime) => {
+      // Add prompt line with empty typed portion
+      later(() => {
+        addLine({ type: 'command', text: '', fullCmd: cmd, typing: true });
+      }, startTime);
+
+      // Type each character
+      for (let i = 0; i < cmd.length; i++) {
+        const charIdx = i;
+        later(() => {
+          if (cancelled) return;
+          setLines(prev => {
+            const copy = [...prev];
+            const last = copy.length - 1;
+            if (last >= 0 && copy[last].type === 'command') {
+              copy[last] = { ...copy[last], text: cmd.slice(0, charIdx + 1) };
+            }
+            return copy;
+          });
+        }, startTime + (i + 1) * TYPING_SPEED);
+      }
+
+      // Mark done typing
+      later(() => {
+        if (cancelled) return;
+        setLines(prev => {
+          const copy = [...prev];
+          const last = copy.length - 1;
+          if (last >= 0 && copy[last].type === 'command') {
+            copy[last] = { ...copy[last], typing: false };
+          }
+          return copy;
+        });
+      }, startTime + cmd.length * TYPING_SPEED + 100);
+
+      return startTime + cmd.length * TYPING_SPEED + 200;
+    };
+
+    // Output rows with masking animation
+    const outputRows = (rows, startTime, isCSV, fieldCount) => {
+      let t = startTime;
+      let totalMasked = fieldCount || 0;
+
+      rows.forEach((row, rowIdx) => {
+        const rowTime = t + rowIdx * ROW_STAGGER;
+
+        // Add row in raw state
+        later(() => {
+          addLine({
+            type: 'output',
+            prefix: row.prefix,
+            fields: row.fields.map(f => ({ ...f, state: 'raw' })),
+            visible: true,
+            fadeIn: true,
+          });
+        }, rowTime);
+
+        // Mask each field
+        row.fields.forEach((field, fIdx) => {
+          // Only mask fields where raw !== masked (skip amount fields)
+          if (field.raw === field.masked) return;
+
+          const maskTime = rowTime + RAW_FLASH_MS + fIdx * 80;
+          later(() => {
+            if (cancelled) return;
+            // Find this row's line and flip the field to masked
+            setLines(prev => {
+              const copy = [...prev];
+              // Find the output line for this row
+              let outputIdx = 0;
+              for (let li = copy.length - 1; li >= 0; li--) {
+                if (copy[li].type === 'output') {
+                  if (outputIdx === rows.length - 1 - rowIdx) {
+                    // This is our row — but we need to count from the end
+                    break;
+                  }
+                  outputIdx++;
+                }
+              }
+              // Simpler: find the correct row by counting output lines
+              let count = 0;
+              for (let li = 0; li < copy.length; li++) {
+                if (copy[li].type === 'output' && copy[li].prefix === row.prefix) {
+                  const newFields = [...copy[li].fields];
+                  newFields[fIdx] = { ...newFields[fIdx], state: 'masked' };
+                  copy[li] = { ...copy[li], fields: newFields, fadeIn: false };
+                  break;
+                }
+              }
+              return copy;
+            });
+          }, maskTime);
+
+          totalMasked++;
+        });
+      });
+
+      return {
+        endTime: t + (rows.length - 1) * ROW_STAGGER + RAW_FLASH_MS + 400,
+        masked: totalMasked,
+      };
+    };
+
+    const countMaskableFields = (rows) => {
+      let count = 0;
+      rows.forEach(row => {
+        row.fields.forEach(f => {
+          if (f.raw !== f.masked) count++;
+        });
+      });
+      return count;
+    };
+
+    const addStatusLine = (time, fieldsMasked) => {
+      later(() => {
+        addLine({
+          type: 'status',
+          text: `hoop gateway \u00B7 ${fieldsMasked} fields masked \u00B7 0ms added latency`,
+          visible: true,
+        });
+      }, time);
+    };
+
+    const cycle = () => {
+      if (cancelled) return;
+      setLines([]);
+      setOpacity(1);
+
+      let t = 300;
+
+      // === Phase 1: cat ===
+      t = typeCommand(PHASE1_CMD, t);
+      t += 200;
+
+      // Header line (no masking)
+      later(() => {
+        addLine({ type: 'output-plain', text: PHASE1_HEADER, fadeIn: true });
+      }, t);
+      t += 300;
+
+      const p1Fields = countMaskableFields(PHASE1_ROWS);
+      const p1 = outputRows(PHASE1_ROWS, t, true, 0);
+      t = p1.endTime + 400;
+
+      // Status line
+      addStatusLine(t, p1Fields);
+      t += PHASE_GAP;
+
+      // === Phase 2: grep ===
+      t = typeCommand(PHASE2_CMD, t);
+      t += 200;
+
+      const p2Fields = countMaskableFields(PHASE2_ROWS);
+      const p2 = outputRows(PHASE2_ROWS, t, false, 0);
+      t = p2.endTime + 400;
+
+      addStatusLine(t, p2Fields);
+      t += PHASE_GAP;
+
+      // === Phase 3: env ===
+      t = typeCommand(PHASE3_CMD, t);
+      t += 200;
+
+      const p3Fields = countMaskableFields(PHASE3_ROWS);
+      const p3 = outputRows(PHASE3_ROWS, t, false, 0);
+      t = p3.endTime + 400;
+
+      addStatusLine(t, p3Fields);
+      t += HOLD_END;
+
+      // Fade out and restart
+      later(() => {
+        if (cancelled) return;
+        setOpacity(0);
+      }, t);
+
+      later(() => {
+        if (cancelled) return;
+        cycle();
+      }, t + 800);
+    };
+
+    cycle();
+    return () => {
+      cancelled = true;
+      clearAll();
+    };
+  }, [later, clearAll]);
+
+  return (
+    <>
+      <link rel="stylesheet" href={FONTS_URL} />
+      <style>{`
+        @keyframes termFadeIn {
+          from { opacity: 0; transform: translateY(6px); }
+          to { opacity: 1; transform: translateY(0); }
+        }
+        @keyframes maskFlip {
+          0% { opacity: 1; }
+          40% { opacity: 0.3; transform: scaleX(0.95); }
+          100% { opacity: 1; transform: scaleX(1); }
+        }
+        @keyframes badgePulse {
+          0%, 100% { opacity: 0.6; transform: scale(1); }
+          50% { opacity: 1; transform: scale(1.15); }
+        }
+        @keyframes cursorBlink {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0; }
+        }
+      `}</style>
+
+      <div style={{
+        maxWidth: 580,
+        margin: '0 auto',
+        borderRadius: 10,
+        overflow: 'hidden',
+        border: `1px solid ${C.border}`,
+        background: C.termBg,
+        fontFamily: "'JetBrains Mono', monospace",
+        opacity,
+        transition: 'opacity 0.7s ease',
+        position: 'relative',
+        height: 460,
+      }}>
+        {/* Terminal chrome / toolbar */}
+        <div style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          padding: '10px 14px',
+          background: 'rgba(var(--sand-100-rgb),0.03)',
+          borderBottom: `1px solid ${C.border}`,
+        }}>
+          {/* Traffic lights */}
+          <div style={{ display: 'flex', gap: 6 }}>
+            <div style={{ width: 10, height: 10, borderRadius: '50%', background: '#FF5F57' }} />
+            <div style={{ width: 10, height: 10, borderRadius: '50%', background: '#FEBC2E' }} />
+            <div style={{ width: 10, height: 10, borderRadius: '50%', background: '#28C840' }} />
+          </div>
+          <div style={{
+            flex: 1,
+            textAlign: 'center',
+            fontSize: 11,
+            color: 'rgba(var(--sand-100-rgb),0.35)',
+            letterSpacing: '0.01em',
+          }}>
+            Terminal &mdash; ssh prod-app-01
+          </div>
+          {/* Tab indicator */}
+          <div style={{
+            fontSize: 9,
+            color: 'rgba(var(--sand-100-rgb),0.20)',
+            background: 'rgba(var(--sand-100-rgb),0.04)',
+            padding: '2px 8px',
+            borderRadius: 4,
+            fontWeight: 500,
+          }}>
+            bash
+          </div>
+        </div>
+
+        {/* Terminal body */}
+        <div style={{
+          padding: '14px 16px 24px',
+          height: 360,
+          position: 'relative',
+          overflow: 'hidden',
+        }}>
+          {lines.map((line, i) => {
+            if (line.type === 'command') {
+              return (
+                <div key={i} style={{
+                  animation: 'termFadeIn 0.25s ease-out both',
+                  marginBottom: 2,
+                  lineHeight: 1.7,
+                  fontSize: 12,
+                  whiteSpace: 'pre-wrap',
+                  wordBreak: 'break-all',
+                }}>
+                  <span style={{ color: 'rgba(var(--sand-100-rgb),0.45)' }}>maria@</span>
+                  <span style={{ color: C.warmGold }}>prod-app-01</span>
+                  <span style={{ color: 'rgba(var(--sand-100-rgb),0.45)' }}>:~$ </span>
+                  <span style={{ color: C.command }}>{line.text}</span>
+                  {line.typing && (
+                    <span style={{
+                      display: 'inline-block',
+                      width: 7,
+                      height: 14,
+                      background: C.command,
+                      marginLeft: 1,
+                      verticalAlign: 'text-bottom',
+                      opacity: cursorVisible ? 1 : 0,
+                    }} />
+                  )}
+                </div>
+              );
+            }
+
+            if (line.type === 'output-plain') {
+              return (
+                <div key={i} style={{
+                  animation: line.fadeIn ? 'termFadeIn 0.3s ease-out both' : undefined,
+                  fontSize: 12,
+                  lineHeight: 1.7,
+                  color: 'rgba(var(--sand-100-rgb),0.5)',
+                  whiteSpace: 'pre-wrap',
+                  marginBottom: 1,
+                }}>
+                  {line.text}
+                </div>
+              );
+            }
+
+            if (line.type === 'output') {
+              return (
+                <div key={i} style={{
+                  animation: line.fadeIn ? 'termFadeIn 0.3s ease-out both' : undefined,
+                  fontSize: 12,
+                  lineHeight: 1.7,
+                  whiteSpace: 'pre-wrap',
+                  marginBottom: 1,
+                  display: 'flex',
+                  flexWrap: 'wrap',
+                  alignItems: 'baseline',
+                }}>
+                  <span style={{ color: 'rgba(var(--sand-100-rgb),0.5)' }}>{line.prefix}</span>
+                  {line.fields.map((f, fi) => {
+                    const isMasked = f.state === 'masked';
+                    const isPassthrough = f.raw === f.masked;
+                    if (isPassthrough) {
+                      return (
+                        <span key={fi} style={{ color: 'rgba(var(--sand-100-rgb),0.5)' }}>{f.raw}</span>
+                      );
+                    }
+                    return (
+                      <span key={fi} style={{ position: 'relative', display: 'inline' }}>
+                        <span style={{
+                          color: isMasked ? C.warmGold : C.rawFlash,
+                          fontWeight: isMasked ? 600 : 400,
+                          transition: 'color 0.15s ease, font-weight 0.15s ease',
+                        }}>
+                          {isMasked ? f.masked : f.raw}
+                        </span>
+                        {isMasked && fi === 0 && (
+                          <span style={{
+                            display: 'inline-block',
+                            marginLeft: 4,
+                            fontSize: 9,
+                            color: C.warmGold,
+                            opacity: 0.7,
+                            animation: 'badgePulse 0.6s ease-out',
+                            verticalAlign: 'middle',
+                          }}>
+                            &#x26C9;
+                          </span>
+                        )}
+                        {fi < line.fields.length - 1 && !isPassthrough && (
+                          <span style={{ color: 'rgba(var(--sand-100-rgb),0.5)' }}>,</span>
+                        )}
+                      </span>
+                    );
+                  })}
+                </div>
+              );
+            }
+
+            if (line.type === 'status') {
+              return (
+                <div key={i} style={{
+                  animation: 'termFadeIn 0.4s ease-out both',
+                  fontSize: 10,
+                  lineHeight: 1.7,
+                  color: C.dimText,
+                  marginTop: 6,
+                  marginBottom: 10,
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 6,
+                }}>
+                  <span style={{
+                    display: 'inline-block',
+                    width: 5,
+                    height: 5,
+                    borderRadius: '50%',
+                    background: C.warmGold,
+                    opacity: 0.6,
+                    flexShrink: 0,
+                  }} />
+                  <span>&#x26C9; {line.text}</span>
+                </div>
+              );
+            }
+
+            return null;
+          })}
+
+          {/* Blinking cursor on empty prompt at the end when not typing */}
+          {lines.length > 0 && !lines[lines.length - 1]?.typing && lines[lines.length - 1]?.type !== 'command' && (
+            <div style={{
+              fontSize: 12,
+              lineHeight: 1.7,
+              marginTop: lines[lines.length - 1]?.type === 'status' ? 0 : 2,
+            }}>
+              <span style={{ color: 'rgba(var(--sand-100-rgb),0.45)' }}>maria@</span>
+              <span style={{ color: C.warmGold }}>prod-app-01</span>
+              <span style={{ color: 'rgba(var(--sand-100-rgb),0.45)' }}>:~$ </span>
+              <span style={{
+                display: 'inline-block',
+                width: 7,
+                height: 14,
+                background: C.command,
+                verticalAlign: 'text-bottom',
+                opacity: cursorVisible ? 1 : 0,
+              }} />
+            </div>
+          )}
+
+          {/* Bottom fade gradient */}
+          <div style={{
+            position: 'absolute',
+            bottom: 0,
+            left: 0,
+            right: 0,
+            height: 40,
+            background: `linear-gradient(to bottom, transparent, ${C.termBg})`,
+            pointerEvents: 'none',
+          }} />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/snippets/annimations/WebinarAnimation.jsx
+++ b/snippets/annimations/WebinarAnimation.jsx
@@ -1,0 +1,297 @@
+/**
+ * WebinarAnimation — Visualizes the gap the webinar addresses.
+ *
+ * Split-screen terminal:
+ *   Left:  "Without Hoop" — Claude Code queries prod, sees raw PII
+ *   Right: "With Hoop" — same query, data masked, destructive cmd blocked
+ *
+ * Fixed height: 380px. Loops every ~18s.
+ */
+
+export const WebinarAnimation = () => {
+  const TYPING_MS = 40;
+  const CMD_DELAY = 1600;
+  const HOLD_MS = 3500;
+
+  const useTypewriter = (text, active, speed = TYPING_MS) => {
+    const [displayed, setDisplayed] = useState('');
+    const idx = useRef(0);
+
+    useEffect(() => {
+      if (!active) { setDisplayed(''); idx.current = 0; return; }
+      if (idx.current >= text.length) return;
+      const t = setTimeout(() => {
+        idx.current++;
+        setDisplayed(text.slice(0, idx.current));
+      }, speed);
+      return () => clearTimeout(t);
+    }, [active, displayed, text, speed]);
+
+    return displayed;
+  };
+
+  /* ── Sequence steps ───────────────────────────────────── */
+  const LEFT_STEPS = [
+    { type: 'cmd', text: 'claude "query user emails from prod"' },
+    { type: 'output', lines: [
+      { text: '> SELECT email, ssn, phone FROM users LIMIT 3', cls: 'sql' },
+    ]},
+    { type: 'delay', ms: 800 },
+    { type: 'output', lines: [
+      { text: 'sarah.chen@acme.io   284-19-7653   +1 415-892-3041', cls: 'raw' },
+      { text: 'marcus.webb@globex.com 531-77-0294  +1 212-555-8817', cls: 'raw' },
+      { text: 'elena.ruiz@initech.co  719-42-8106  +44 20-7946-0958', cls: 'raw' },
+    ]},
+    { type: 'delay', ms: 1400 },
+    { type: 'output', lines: [
+      { text: '  No masking. No audit trail. No gate.', cls: 'warn' },
+    ]},
+  ];
+
+  const RIGHT_STEPS = [
+    { type: 'cmd', text: 'claude "query user emails from prod"' },
+    { type: 'output', lines: [
+      { text: '> SELECT email, ssn, phone FROM users LIMIT 3', cls: 'sql' },
+    ]},
+    { type: 'delay', ms: 600 },
+    { type: 'output', lines: [
+      { text: '\u2B22 hoop | masking PII in transit...', cls: 'hoop' },
+    ]},
+    { type: 'delay', ms: 800 },
+    { type: 'output', lines: [
+      { text: '[EMAIL]              [SSN]         [PHONE]', cls: 'masked' },
+      { text: '[EMAIL]              [SSN]         [PHONE]', cls: 'masked' },
+      { text: '[EMAIL]              [SSN]         [PHONE]', cls: 'masked' },
+    ]},
+    { type: 'delay', ms: 1200 },
+    { type: 'cmd', text: 'claude "drop the staging table"' },
+    { type: 'output', lines: [
+      { text: '\u2B22 hoop | \u26D4 blocked: DROP TABLE', cls: 'blocked' },
+      { text: '  Routed to #infra-approvals for review', cls: 'hoop' },
+    ]},
+  ];
+
+  const [phase, setPhase] = useState(0); // 0=idle, 1=left-playing, 2=right-playing, 3=hold
+  const [leftLines, setLeftLines] = useState([]);
+  const [rightLines, setRightLines] = useState([]);
+  const [typing, setTyping] = useState({ side: null, text: '' });
+  const [fading, setFading] = useState(false);
+  const timer = useRef(null);
+  const mounted = useRef(true);
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => { mounted.current = false; };
+  }, []);
+
+  const sleep = useCallback((ms) => new Promise(r => { timer.current = setTimeout(r, ms); }), []);
+
+  const typeCmd = useCallback(async (text) => {
+    for (let i = 1; i <= text.length; i++) {
+      if (!mounted.current) return;
+      setTyping(prev => ({ ...prev, text: text.slice(0, i) }));
+      await sleep(TYPING_MS);
+    }
+    await sleep(200);
+  }, [sleep]);
+
+  const playSteps = useCallback(async (steps, side, setLines) => {
+    setTyping({ side, text: '' });
+    for (const step of steps) {
+      if (!mounted.current) return;
+      if (step.type === 'cmd') {
+        setTyping({ side, text: '' });
+        await typeCmd(step.text);
+        setLines(prev => [...prev, { text: `$ ${step.text}`, cls: 'cmd' }]);
+        setTyping({ side: null, text: '' });
+        await sleep(CMD_DELAY);
+      } else if (step.type === 'output') {
+        for (const line of step.lines) {
+          if (!mounted.current) return;
+          setLines(prev => [...prev, line]);
+          await sleep(300);
+        }
+      } else if (step.type === 'delay') {
+        await sleep(step.ms);
+      }
+    }
+  }, [typeCmd, sleep]);
+
+  const runSequence = useCallback(async () => {
+    if (!mounted.current) return;
+    setLeftLines([]);
+    setRightLines([]);
+    setFading(false);
+    setTyping({ side: null, text: '' });
+
+    // Play left side
+    await sleep(800);
+    await playSteps(LEFT_STEPS, 'left', setLeftLines);
+    await sleep(1200);
+
+    // Play right side
+    await playSteps(RIGHT_STEPS, 'right', setRightLines);
+
+    // Hold
+    await sleep(HOLD_MS);
+
+    // Fade and reset
+    if (!mounted.current) return;
+    setFading(true);
+    await sleep(1000);
+    if (mounted.current) runSequence();
+  }, [playSteps, sleep]);
+
+  useEffect(() => {
+    runSequence();
+    return () => { mounted.current = false; clearTimeout(timer.current); };
+  }, [runSequence]);
+
+  const termStyle = {
+    flex: 1,
+    minWidth: 0,
+    background: 'rgba(var(--sand-100-rgb),0.03)',
+    border: '1px solid rgba(var(--sand-100-rgb),0.06)',
+    borderRadius: 10,
+    overflow: 'hidden',
+    display: 'flex',
+    flexDirection: 'column',
+  };
+
+  const headerStyle = (isProtected) => ({
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+    padding: '10px 16px',
+    borderBottom: '1px solid rgba(var(--sand-100-rgb),0.06)',
+    background: 'rgba(var(--sand-100-rgb),0.02)',
+  });
+
+  const bodyStyle = {
+    padding: '14px 16px',
+    flex: 1,
+    overflow: 'hidden',
+    fontFamily: 'var(--mono)',
+    fontSize: 11,
+    lineHeight: 1.8,
+  };
+
+  return (
+    <div style={{
+      height: 380,
+      display: 'flex',
+      gap: 12,
+      opacity: fading ? 0 : 1,
+      transition: 'opacity 0.8s ease',
+    }}>
+      {/* Left: Without Hoop */}
+      <div style={termStyle}>
+        <div style={headerStyle(false)}>
+          <div style={{ display: 'flex', gap: 5 }}>
+            <span style={{ width: 7, height: 7, borderRadius: '50%', background: 'rgba(var(--sand-100-rgb),0.12)' }} />
+            <span style={{ width: 7, height: 7, borderRadius: '50%', background: 'rgba(var(--sand-100-rgb),0.12)' }} />
+            <span style={{ width: 7, height: 7, borderRadius: '50%', background: 'rgba(var(--sand-100-rgb),0.12)' }} />
+          </div>
+          <span style={{
+            fontFamily: 'var(--sans)', fontSize: 10, fontWeight: 600,
+            color: 'rgba(var(--sand-100-rgb),0.35)',
+            textTransform: 'uppercase', letterSpacing: '0.06em',
+          }}>
+            Without controls
+          </span>
+        </div>
+        <div style={bodyStyle}>
+          {leftLines.map((line, i) => (
+            <div key={i} className={`wa-line wa-${line.cls}`}>{line.text}</div>
+          ))}
+          {typing.side === 'left' && typing.text && (
+            <div className="wa-line wa-cmd">
+              <span style={{ color: 'var(--warm-gold)' }}>$ </span>
+              {typing.text}
+              <span className="wa-cursor" />
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Right: With Hoop */}
+      <div style={{ ...termStyle, border: '1px solid rgba(var(--warm-gold-rgb),0.12)' }}>
+        <div style={headerStyle(true)}>
+          <div style={{ display: 'flex', gap: 5 }}>
+            <span style={{ width: 7, height: 7, borderRadius: '50%', background: 'rgba(var(--sand-100-rgb),0.12)' }} />
+            <span style={{ width: 7, height: 7, borderRadius: '50%', background: 'rgba(var(--sand-100-rgb),0.12)' }} />
+            <span style={{ width: 7, height: 7, borderRadius: '50%', background: 'rgba(var(--sand-100-rgb),0.12)' }} />
+          </div>
+          <span style={{
+            fontFamily: 'var(--sans)', fontSize: 10, fontWeight: 600,
+            color: 'var(--warm-gold)',
+            textTransform: 'uppercase', letterSpacing: '0.06em',
+          }}>
+            With Hoop
+          </span>
+          <span style={{
+            marginLeft: 'auto',
+            fontFamily: 'var(--mono)', fontSize: 9, fontWeight: 500,
+            color: 'rgba(var(--warm-gold-rgb),0.5)',
+            background: 'rgba(var(--warm-gold-rgb),0.08)',
+            padding: '2px 8px', borderRadius: 99,
+          }}>
+            gateway active
+          </span>
+        </div>
+        <div style={bodyStyle}>
+          {rightLines.map((line, i) => (
+            <div key={i} className={`wa-line wa-${line.cls}`}>{line.text}</div>
+          ))}
+          {typing.side === 'right' && typing.text && (
+            <div className="wa-line wa-cmd">
+              <span style={{ color: 'var(--warm-gold)' }}>$ </span>
+              {typing.text}
+              <span className="wa-cursor" />
+            </div>
+          )}
+        </div>
+      </div>
+
+      <style>{`
+        .wa-line {
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+        .wa-cmd { color: var(--sand-300); }
+        .wa-sql { color: rgba(var(--sand-100-rgb),0.35); font-style: italic; }
+        .wa-raw { color: rgba(var(--sand-100-rgb),0.7); }
+        .wa-warn {
+          color: rgba(var(--error-rgb),0.7);
+          font-style: italic;
+          margin-top: 4px;
+        }
+        .wa-hoop { color: var(--warm-gold); }
+        .wa-masked {
+          color: var(--warm-gold);
+          font-weight: 600;
+        }
+        .wa-blocked {
+          color: rgba(var(--error-rgb),0.85);
+          font-weight: 600;
+        }
+        .wa-cursor {
+          display: inline-block;
+          width: 7px;
+          height: 14px;
+          background: var(--warm-gold);
+          margin-left: 2px;
+          vertical-align: middle;
+          animation: wa-blink 0.8s step-end infinite;
+        }
+        @keyframes wa-blink {
+          50% { opacity: 0; }
+        }
+        @media (max-width: 768px) {
+          .wa-line { font-size: 9px; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/snippets/annimations/actionaccessrequest.jsx
+++ b/snippets/annimations/actionaccessrequest.jsx
@@ -1,0 +1,414 @@
+export const ActionAccessAnimation = () => {
+  const ESPRESSO = "var(--gradient-dark-mid)";
+  const WARM_GOLD = "var(--warm-gold)";
+  const SAND_100 = "var(--sand-100)";
+  const SAND_300 = "var(--sand-300)";
+  const SAND_500 = "var(--sand-500)";
+
+  const FONTS = `@import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;0,9..40,800&family=JetBrains+Mono:wght@400;500&family=Sora:wght@600;700;800&display=swap');`;
+
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+  function useTypingText(text, speed, trigger) {
+    const [displayed, setDisplayed] = useState("");
+    const [done, setDone] = useState(false);
+    useEffect(() => {
+      if (!trigger) { setDisplayed(""); setDone(false); return; }
+      setDisplayed(""); setDone(false);
+      let i = 0;
+      const iv = setInterval(() => {
+        i++;
+        setDisplayed(text.slice(0, i));
+        if (i >= text.length) { clearInterval(iv); setDone(true); }
+      }, speed);
+      return () => clearInterval(iv);
+    }, [trigger, text, speed]);
+    return { displayed, done };
+  }
+
+  const Cursor = ({ visible = true }) => (
+    <span style={{
+      display: "inline-block", width: 2, height: "1.1em",
+      background: visible ? WARM_GOLD : "transparent",
+      marginLeft: 2, verticalAlign: "text-bottom",
+      animation: visible ? "hoop_blink 1s step-end infinite" : "none",
+    }} />
+  );
+
+  const StepIndicator = ({ steps, activeStep }) => (
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "center", paddingTop: 18, minWidth: 44 }}>
+      {steps.map((s, i) => {
+        const isActive = i === activeStep;
+        const isPast = i < activeStep;
+        return (
+          <div key={i} style={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+            <div style={{
+              width: 28, height: 28, borderRadius: "50%",
+              display: "flex", alignItems: "center", justifyContent: "center",
+              fontFamily: "'JetBrains Mono', monospace", fontSize: 12, fontWeight: 500,
+              transition: "all 0.5s ease",
+              background: isPast ? WARM_GOLD : isActive ? "rgba(var(--warm-gold-rgb),0.18)" : "rgba(var(--sand-100-rgb),0.06)",
+              color: isPast ? ESPRESSO : isActive ? WARM_GOLD : "rgba(var(--sand-100-rgb),0.25)",
+              border: isActive ? `1.5px solid ${WARM_GOLD}` : "1.5px solid transparent",
+            }}>
+              {isPast ? (
+                <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+                  <path d="M3 7l3 3 5-5" stroke={ESPRESSO} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+                </svg>
+              ) : i + 1}
+            </div>
+            {i < steps.length - 1 && (
+              <div style={{
+                width: 1.5, height: 24,
+                background: isPast ? WARM_GOLD : "rgba(var(--sand-100-rgb),0.08)",
+                transition: "background 0.5s ease",
+              }} />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+
+  const [phase, setPhase] = useState("idle");
+  const [typingTrigger, setTypingTrigger] = useState(0);
+  const [slackVisible, setSlackVisible] = useState(false);
+  const [approveClicked, setApproveClicked] = useState(false);
+  const [resultTrigger, setResultTrigger] = useState(0);
+  const [activeStep, setActiveStep] = useState(-1);
+  const [pendingVisible, setPendingVisible] = useState(false);
+  const [approvedLine, setApprovedLine] = useState(false);
+  const [showResult, setShowResult] = useState(false);
+  const [fade, setFade] = useState(true);
+  const running = useRef(false);
+
+  const COMMAND = `UPDATE users SET status = 'inactive' WHERE id = 123`;
+  const RESULT_TEXT = `UPDATE 1\n\n1 row affected.`;
+
+  const commandTyping = useTypingText(COMMAND, 38, typingTrigger);
+  const resultTyping = useTypingText(RESULT_TEXT, 28, resultTrigger);
+
+  async function runLoop() {
+    if (running.current) return;
+    running.current = true;
+
+    while (running.current) {
+      // Reset all state while faded out
+      setPhase("idle");
+      setSlackVisible(false);
+      setApproveClicked(false);
+      setActiveStep(-1);
+      setPendingVisible(false);
+      setApprovedLine(false);
+      setShowResult(false);
+      await sleep(400);
+
+      // Fade in
+      setFade(false);
+      await sleep(500);
+
+      // 1: Type command
+      setPhase("typing");
+      setActiveStep(0);
+      setTypingTrigger((t) => t + 1);
+      await sleep(COMMAND.length * 38 + 500);
+
+      // 2: Pending
+      setPhase("pending");
+      setActiveStep(1);
+      setPendingVisible(true);
+      await sleep(1400);
+
+      // 3: Slack appears, pending stays
+      setPhase("slack");
+      setActiveStep(2);
+      setSlackVisible(true);
+      await sleep(2000);
+
+      // 4: Approve click, everything stays
+      setApproveClicked(true);
+      await sleep(700);
+
+      // 5: Swap pending to approved line, slack stays with approved state
+      setPhase("approved");
+      setActiveStep(3);
+      setPendingVisible(false);
+      setApprovedLine(true);
+      await sleep(800);
+
+      // 6: Result streams in, everything still visible
+      setShowResult(true);
+      setResultTrigger((t) => t + 1);
+      await sleep(RESULT_TEXT.length * 28 + 2800);
+
+      // 7: Fade out whole card
+      setFade(true);
+      await sleep(1200);
+    }
+  }
+
+  useEffect(() => {
+    runLoop();
+    return () => { running.current = false; };
+  }, []);
+
+  const steps = ["Execute", "Review", "Approve", "Complete"];
+  const showCmdCursor = phase === "typing" && !commandTyping.done;
+  const showResCursor = showResult && !resultTyping.done;
+
+  return (
+    <div style={{
+      width: "100%", maxWidth: 780, margin: "0 auto",
+      fontFamily: "'DM Sans', system-ui, sans-serif",
+    }}>
+      <style>{FONTS}{`
+        @keyframes hoop_blink { 0%,100%{opacity:1} 50%{opacity:0} }
+        @keyframes hoop_fadeInUp { from{opacity:0;transform:translateY(8px)} to{opacity:1;transform:translateY(0)} }
+        @keyframes hoop_fadeIn { from{opacity:0} to{opacity:1} }
+        @keyframes hoop_pulse { 0%,100%{opacity:1} 50%{opacity:0.35} }
+        @keyframes hoop_scaleIn { from{opacity:0;transform:scale(0.96)} to{opacity:1;transform:scale(1)} }
+        @keyframes hoop_checkPop { 0%{transform:scale(0);opacity:0} 50%{transform:scale(1.15)} 100%{transform:scale(1);opacity:1} }
+      `}</style>
+
+      {/* Overline */}
+      <div style={{
+        fontFamily: "'DM Sans', sans-serif", fontSize: 11, fontWeight: 600,
+        color: WARM_GOLD, letterSpacing: "0.1em", textTransform: "uppercase",
+        marginBottom: 12, textAlign: "center",
+      }}>
+        Action Access Requests
+      </div>
+
+      {/* Main card, fades as a whole */}
+      <div style={{
+        background: "linear-gradient(135deg, var(--gradient-dark-start) 0%, var(--gradient-dark-mid) 35%, var(--gradient-dark-end) 70%, var(--bronze) 100%)",
+        borderRadius: 14, padding: "32px 28px 28px",
+        position: "relative", overflow: "hidden", height: 520,
+        transition: "opacity 0.9s ease",
+        opacity: fade ? 0 : 1,
+      }}>
+        {/* Glow */}
+        <div style={{
+          position: "absolute", top: "-30%", right: "-10%", width: "60%", height: "160%",
+          background: "radial-gradient(ellipse at center, rgba(var(--warm-gold-rgb),0.12) 0%, transparent 70%)",
+          pointerEvents: "none",
+        }} />
+
+        <div style={{ display: "flex", gap: 20, position: "relative", zIndex: 1 }}>
+          <StepIndicator steps={steps} activeStep={activeStep} />
+
+          <div style={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column", gap: 16 }}>
+
+            {/* ---- TERMINAL ---- */}
+            <div style={{
+              background: "rgba(var(--sand-100-rgb),0.04)",
+              border: "1px solid rgba(var(--sand-100-rgb),0.08)",
+              borderRadius: 10, overflow: "hidden",
+              minHeight: 220,
+            }}>
+              {/* Toolbar */}
+              <div style={{
+                display: "flex", alignItems: "center", gap: 6,
+                padding: "10px 14px",
+                borderBottom: "1px solid rgba(var(--sand-100-rgb),0.06)",
+                background: "rgba(var(--sand-100-rgb),0.03)",
+              }}>
+                {[0,1,2].map(i => (
+                  <div key={i} style={{ width: 8, height: 8, borderRadius: "50%", background: "rgba(var(--sand-100-rgb),0.10)" }} />
+                ))}
+                <span style={{
+                  marginLeft: 10, fontFamily: "'JetBrains Mono', monospace",
+                  fontSize: 11, color: "rgba(var(--sand-100-rgb),0.25)",
+                }}>Terminal</span>
+              </div>
+
+              {/* Body */}
+              <div style={{ padding: "16px 18px" }}>
+                {/* Command */}
+                <div style={{ display: "flex", flexWrap: "wrap", alignItems: "flex-start" }}>
+                  <span style={{
+                    fontFamily: "'JetBrains Mono', monospace", fontSize: 13,
+                    color: SAND_500, marginRight: 8, lineHeight: 2.0,
+                  }}>$</span>
+                  <span style={{
+                    fontFamily: "'JetBrains Mono', monospace", fontSize: 13,
+                    color: SAND_300, lineHeight: 2.0,
+                  }}>hoop exec prod-db -i "</span>
+                  <span style={{
+                    fontFamily: "'JetBrains Mono', monospace", fontSize: 13,
+                    color: WARM_GOLD, fontWeight: 500, lineHeight: 2.0,
+                  }}>{commandTyping.displayed}</span>
+                  {showCmdCursor && <Cursor />}
+                  {commandTyping.done && commandTyping.displayed && (
+                    <span style={{
+                      fontFamily: "'JetBrains Mono', monospace", fontSize: 13,
+                      color: SAND_300, lineHeight: 2.0,
+                    }}>"</span>
+                  )}
+                </div>
+
+                {/* Pending */}
+                {pendingVisible && (
+                  <div style={{
+                    marginTop: 14, display: "flex", alignItems: "center", gap: 10,
+                    animation: "hoop_fadeIn 0.4s ease",
+                  }}>
+                    <div style={{
+                      width: 8, height: 8, borderRadius: "50%", background: WARM_GOLD,
+                      animation: "hoop_pulse 1.5s ease infinite",
+                    }} />
+                    <span style={{
+                      fontFamily: "'JetBrains Mono', monospace", fontSize: 12,
+                      color: "rgba(var(--sand-100-rgb),0.35)",
+                    }}>Waiting for approval...</span>
+                  </div>
+                )}
+
+                {/* Approved */}
+                {approvedLine && (
+                  <div style={{
+                    marginTop: 14, display: "flex", alignItems: "center", gap: 10,
+                    animation: "hoop_fadeIn 0.3s ease",
+                  }}>
+                    <div style={{ animation: "hoop_checkPop 0.4s ease", display: "flex" }}>
+                      <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+                        <circle cx="7" cy="7" r="7" fill={WARM_GOLD} />
+                        <path d="M4 7l2 2 4-4" stroke={ESPRESSO} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+                      </svg>
+                    </div>
+                    <span style={{
+                      fontFamily: "'JetBrains Mono', monospace", fontSize: 12,
+                      color: WARM_GOLD,
+                    }}>Approved. Executing...</span>
+                  </div>
+                )}
+
+                {/* Result */}
+                {showResult && (
+                  <div style={{ marginTop: 16, animation: "hoop_fadeInUp 0.4s ease" }}>
+                    <div style={{ height: 1, background: "rgba(var(--sand-100-rgb),0.06)", marginBottom: 14 }} />
+                    <pre style={{
+                      fontFamily: "'JetBrains Mono', monospace", fontSize: 12,
+                      color: WARM_GOLD, lineHeight: 1.7, margin: 0, whiteSpace: "pre-wrap",
+                    }}>
+                      {resultTyping.displayed}{showResCursor && <Cursor />}
+                    </pre>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* ---- SLACK CARD ---- */}
+            <div style={{
+              overflow: "hidden",
+              transition: "max-height 0.5s ease, opacity 0.5s ease",
+              maxHeight: slackVisible ? 260 : 0,
+              opacity: slackVisible ? 1 : 0,
+            }}>
+              <div style={{
+                background: "rgba(var(--sand-100-rgb),0.04)",
+                border: "1px solid rgba(var(--sand-100-rgb),0.08)",
+                borderRadius: 10, padding: "16px 18px",
+                animation: slackVisible ? "hoop_scaleIn 0.4s cubic-bezier(0.34, 1.4, 0.64, 1)" : "none",
+              }}>
+                {/* Header */}
+                <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 12 }}>
+                  <div style={{
+                    width: 20, height: 20, borderRadius: 4,
+                    background: "rgba(var(--sand-100-rgb),0.08)",
+                    display: "flex", alignItems: "center", justifyContent: "center",
+                  }}>
+                    <span style={{ fontSize: 11, color: "rgba(var(--sand-100-rgb),0.4)" }}>#</span>
+                  </div>
+                  <span style={{
+                    fontFamily: "'DM Sans', sans-serif", fontSize: 12, fontWeight: 600,
+                    color: "rgba(var(--sand-100-rgb),0.60)",
+                  }}>#access-requests</span>
+                  <span style={{
+                    fontFamily: "'DM Sans', sans-serif", fontSize: 10,
+                    color: "rgba(var(--sand-100-rgb),0.20)", marginLeft: "auto",
+                  }}>just now</span>
+                </div>
+
+                {/* Body */}
+                <div style={{ borderLeft: `2.5px solid ${WARM_GOLD}`, paddingLeft: 14, marginBottom: 14 }}>
+                  <div style={{
+                    fontFamily: "'DM Sans', sans-serif", fontSize: 12, fontWeight: 600,
+                    color: "rgba(var(--sand-100-rgb),0.70)", marginBottom: 6,
+                  }}>
+                    Access Request from alice@company.com
+                  </div>
+                  <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                    <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                      <span style={{
+                        fontFamily: "'DM Sans', sans-serif", fontSize: 11,
+                        color: "rgba(var(--sand-100-rgb),0.30)", minWidth: 70,
+                      }}>Connection</span>
+                      <span style={{
+                        fontFamily: "'JetBrains Mono', monospace", fontSize: 11,
+                        color: "rgba(var(--sand-100-rgb),0.50)",
+                      }}>prod-db</span>
+                    </div>
+                    <div style={{ display: "flex", gap: 8, alignItems: "flex-start" }}>
+                      <span style={{
+                        fontFamily: "'DM Sans', sans-serif", fontSize: 11,
+                        color: "rgba(var(--sand-100-rgb),0.30)", minWidth: 70,
+                      }}>Command</span>
+                      <span style={{
+                        fontFamily: "'JetBrains Mono', monospace", fontSize: 11,
+                        color: WARM_GOLD, fontWeight: 500, wordBreak: "break-all",
+                      }}>UPDATE users SET status = 'inactive' WHERE id = 123</span>
+                    </div>
+                  </div>
+                </div>
+
+                {/* Buttons */}
+                <div style={{ display: "flex", gap: 8 }}>
+                  <button style={{
+                    fontFamily: "'DM Sans', sans-serif", fontSize: 12, fontWeight: 600,
+                    padding: "6px 20px", borderRadius: 6, border: "none", cursor: "pointer",
+                    transition: "all 0.3s ease",
+                    background: approveClicked ? WARM_GOLD : SAND_100,
+                    color: ESPRESSO,
+                    transform: approveClicked ? "scale(0.96)" : "scale(1)",
+                  }}>
+                    {approveClicked ? "✓ Approved" : "Approve"}
+                  </button>
+                  <button style={{
+                    fontFamily: "'DM Sans', sans-serif", fontSize: 12, fontWeight: 500,
+                    padding: "6px 20px", borderRadius: 6,
+                    border: "1px solid rgba(var(--sand-100-rgb),0.12)",
+                    background: "transparent", color: "rgba(var(--sand-100-rgb),0.35)",
+                    cursor: "pointer",
+                    opacity: approveClicked ? 0.3 : 1,
+                    transition: "opacity 0.3s ease",
+                  }}>
+                    Reject
+                  </button>
+                </div>
+              </div>
+            </div>
+
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div style={{
+          display: "flex", alignItems: "center", gap: 10,
+          marginTop: 28, paddingTop: 12,
+          borderTop: "1px solid rgba(var(--sand-100-rgb),0.06)",
+        }}>
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="rgba(var(--sand-100-rgb),0.2)">
+            <circle cx="7" cy="7" r="3.5"/><circle cx="17" cy="7" r="3.5"/>
+            <circle cx="7" cy="17" r="3.5"/><circle cx="17" cy="17" r="3.5"/>
+          </svg>
+          <span style={{
+            fontFamily: "'DM Sans', sans-serif", fontSize: 12, fontWeight: 500,
+            color: "rgba(var(--sand-100-rgb),0.2)",
+          }}>hoop.dev</span>
+          <div style={{ flex: 1, height: 1, background: "rgba(var(--sand-100-rgb),0.06)" }} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/snippets/annimations/aiagentterminalhumaninloop.jsx
+++ b/snippets/annimations/aiagentterminalhumaninloop.jsx
@@ -1,0 +1,580 @@
+export const ClaudeCodeTerminal = () => {
+  /* ── Phase labels ──────────────────────────────────────────── */
+  const PHASES = [
+    'Read-only diagnosis',
+    'Agent proposes fix',
+    'Routed for approval',
+    'Human rejects',
+    'Agent retries',
+    'Human approves',
+    'Audit trail',
+  ];
+
+  /* ── Hoop badge HTML (safe: static markup) ─────────────────── */
+  const HOOP = '<span class="hp">\u2B22 hoop</span>';
+
+  /* ── Sequence definition ───────────────────────────────────── */
+  function buildSequence() {
+    return [
+      // Phase 0: Diagnosis
+      { type: 'phase', phase: 0 },
+      { type: 'line', html: '<span class="pr">$</span> <span class="cm">claude</span> <span class="fl">"payments returning 503s, diagnose"</span>' },
+      { type: 'delay', ms: 1200 },
+      { type: 'line', html: '<span class="dm">\u27E1</span> <span class="cm">Connecting via Hoop read-only profile...</span>' },
+      { type: 'delay', ms: 1000 },
+      { type: 'line', html: `${HOOP} <span class="dm">|</span> profile: <span class="fl">readonly-prod</span> <span class="dm">|</span> cluster: <span class="ar">prod-us-east</span>` },
+      { type: 'delay', ms: 1400 },
+      { type: 'line', html: '<span class="dm">\u27E1</span> <span class="cm">3/5 pods CrashLoopBackOff, OOMKilled at 256Mi</span><span class="cursor"></span>', cursor: true },
+      { type: 'delay', ms: 2000 },
+
+      // Phase 1: Propose
+      { type: 'phase', phase: 1 },
+      { type: 'line', html: '', cls: 'br' },
+      { type: 'line', html: '<span class="dm">\u27E1</span> <span class="cm">Proposed fix:</span>' },
+      { type: 'delay', ms: 600 },
+      { type: 'line', html: '  <span class="ar">kubectl set resources deploy/payments</span> <span class="fl">--limits=memory=512Mi</span>' },
+      { type: 'delay', ms: 1200 },
+      { type: 'line', html: `${HOOP} <span class="dm">|</span> <span class="cm">Write command detected. Routing for approval...</span>` },
+      { type: 'delay', ms: 1500 },
+
+      // Phase 2: Slack notification
+      { type: 'phase', phase: 2 },
+      {
+        type: 'toast-show',
+        head: { channel: '#infra-approvals', time: 'now' },
+        msg: '<b>Hoop</b> &middot; request from <b>claude-agent</b>',
+        code: 'kubectl set resources deploy/payments --limits=memory=512Mi',
+        meta: 'prod-us-east \u00B7 payments',
+        actions: 'buttons',
+      },
+      { type: 'delay', ms: 3500 },
+
+      // Phase 3: Rejected
+      { type: 'phase', phase: 3 },
+      { type: 'toast-result', result: 'reject', text: '\u2717 Rejected by @sarah.chen' },
+      { type: 'delay', ms: 800 },
+      { type: 'toast-feedback', html: '<b>@sarah.chen:</b> Roll back to v2.3.1 first, then investigate the leak.' },
+      { type: 'delay', ms: 1000 },
+      { type: 'line', html: `${HOOP} <span class="dm">|</span> <span class="er">\u2717 Rejected</span> <span class="dm">"Roll back to v2.3.1 first"</span>` },
+      { type: 'delay', ms: 2500 },
+
+      // Phase 4: Retry
+      { type: 'phase', phase: 4 },
+      { type: 'toast-hide' },
+      { type: 'delay', ms: 600 },
+      { type: 'line', html: '', cls: 'br' },
+      { type: 'line', html: '<span class="dm">\u27E1</span> <span class="cm">Revised: rollback to last stable image</span>' },
+      { type: 'delay', ms: 800 },
+      { type: 'line', html: '  <span class="ar">kubectl set image deploy/payments</span> <span class="fl">payments:v2.3.1</span>' },
+      { type: 'delay', ms: 1200 },
+      { type: 'line', html: `${HOOP} <span class="dm">|</span> <span class="cm">Write command detected. Routing for approval...</span>` },
+      { type: 'delay', ms: 1500 },
+
+      // Phase 5: Approved
+      { type: 'phase', phase: 5 },
+      {
+        type: 'toast-show',
+        head: { channel: '#infra-approvals', time: 'now' },
+        msg: '<b>Hoop</b> &middot; request from <b>claude-agent</b>',
+        code: 'kubectl set image deploy/payments payments:v2.3.1',
+        meta: 'prod-us-east \u00B7 payments',
+        actions: 'approved',
+        resultText: '\u2713 Approved by @sarah.chen',
+      },
+      { type: 'delay', ms: 1200 },
+      { type: 'line', html: `${HOOP} <span class="dm">|</span> <span class="ok">\u2713 Approved by @sarah.chen</span>` },
+      { type: 'delay', ms: 1000 },
+      { type: 'line', html: '<span class="ok">Rollout complete. 5/5 pods running. 503s resolved.</span>' },
+      { type: 'delay', ms: 3000 },
+
+      // Phase 6: Audit
+      { type: 'phase', phase: 6 },
+      { type: 'toast-hide' },
+      { type: 'delay', ms: 600 },
+      { type: 'line', html: '', cls: 'br' },
+      { type: 'line', html: `${HOOP} <span class="dm">|</span> <span class="dm">Audit: 4 cmds, 1 rejected, 1 approved, 47s</span>` },
+      { type: 'delay', ms: 1000 },
+      { type: 'line', html: `${HOOP} <span class="dm">|</span> <span class="dm">Replay:</span> <span class="fl">app.hoop.dev/sessions/7f3a91c2</span>` },
+      { type: 'delay', ms: 4000 },
+
+      // Restart marker
+      { type: 'restart' },
+    ];
+  }
+
+  const [lines, setLines] = useState([]);
+  const [activePhase, setActivePhase] = useState(0);
+
+  // Toast state
+  const [toastVisible, setToastVisible] = useState(false);
+  const [toastExiting, setToastExiting] = useState(false);
+  const [toastData, setToastData] = useState(null);
+  const [toastResult, setToastResult] = useState(null); // { type: 'ok'|'no', text }
+  const [toastFeedback, setToastFeedback] = useState(null);
+
+  // Line visibility: track which lines have been "turned on"
+  const [visibleIds, setVisibleIds] = useState(new Set());
+
+  const scrollRef = useRef(null);
+  const terminalRef = useRef(null);
+  const timersRef = useRef([]);
+  const lineIdRef = useRef(0);
+  const runIdRef = useRef(0);
+
+  // Auto-scroll
+  const [scrollOffset, setScrollOffset] = useState(0);
+
+  const clearTimers = useCallback(() => {
+    timersRef.current.forEach(clearTimeout);
+    timersRef.current = [];
+  }, []);
+
+  const scheduleTimeout = useCallback((fn, ms) => {
+    const id = setTimeout(fn, ms);
+    timersRef.current.push(id);
+    return id;
+  }, []);
+
+  const resetState = useCallback(() => {
+    setLines([]);
+    setActivePhase(0);
+    setToastVisible(false);
+    setToastExiting(false);
+    setToastData(null);
+    setToastResult(null);
+    setToastFeedback(null);
+    setVisibleIds(new Set());
+    setScrollOffset(0);
+    lineIdRef.current = 0;
+  }, []);
+
+  const runSequence = useCallback(() => {
+    clearTimers();
+    resetState();
+
+    const currentRun = ++runIdRef.current;
+    const seq = buildSequence();
+    let cumulative = 0;
+
+    let pendingLines = [];
+
+    seq.forEach((step) => {
+      if (step.type === 'delay') {
+        cumulative += step.ms;
+        return;
+      }
+
+      const atTime = cumulative;
+
+      if (step.type === 'phase') {
+        const p = step.phase;
+        scheduleTimeout(() => {
+          if (runIdRef.current !== currentRun) return;
+          setActivePhase(p);
+        }, atTime);
+      }
+
+      if (step.type === 'line') {
+        const id = lineIdRef.current++;
+        const lineObj = { id, html: step.html, cls: step.cls || '', cursor: step.cursor || false };
+        pendingLines.push({ lineObj, atTime });
+
+        scheduleTimeout(() => {
+          if (runIdRef.current !== currentRun) return;
+          setLines((prev) => [...prev, lineObj]);
+          // Trigger visibility after a small delay (simulating double rAF)
+          scheduleTimeout(() => {
+            if (runIdRef.current !== currentRun) return;
+            setVisibleIds((prev) => new Set([...prev, id]));
+          }, 32);
+        }, atTime);
+      }
+
+      if (step.type === 'toast-show') {
+        scheduleTimeout(() => {
+          if (runIdRef.current !== currentRun) return;
+          setToastResult(null);
+          setToastFeedback(null);
+          setToastExiting(false);
+          setToastData(step);
+          // Show after a frame
+          scheduleTimeout(() => {
+            if (runIdRef.current !== currentRun) return;
+            setToastVisible(true);
+          }, 32);
+        }, atTime);
+      }
+
+      if (step.type === 'toast-hide') {
+        scheduleTimeout(() => {
+          if (runIdRef.current !== currentRun) return;
+          setToastExiting(true);
+          setToastVisible(false);
+        }, atTime);
+      }
+
+      if (step.type === 'toast-result') {
+        scheduleTimeout(() => {
+          if (runIdRef.current !== currentRun) return;
+          setToastResult({ type: step.result === 'reject' ? 'no' : 'ok', text: step.text });
+        }, atTime);
+      }
+
+      if (step.type === 'toast-feedback') {
+        scheduleTimeout(() => {
+          if (runIdRef.current !== currentRun) return;
+          setToastFeedback(step.html);
+        }, atTime);
+      }
+
+      if (step.type === 'restart') {
+        scheduleTimeout(() => {
+          if (runIdRef.current !== currentRun) return;
+          runSequence();
+        }, atTime);
+      }
+    });
+  }, [clearTimers, resetState, scheduleTimeout]);
+
+  // Auto-scroll effect
+  useEffect(() => {
+    if (!scrollRef.current || !terminalRef.current) return;
+    const totalH = scrollRef.current.scrollHeight;
+    const viewH = terminalRef.current.clientHeight - 70;
+    if (totalH > viewH) {
+      setScrollOffset(totalH - viewH);
+    }
+  }, [lines]);
+
+  // Start on mount
+  useEffect(() => {
+    runSequence();
+    return () => clearTimers();
+  }, [runSequence, clearTimers]);
+
+  /* ── Toast styles (inline to avoid styled-jsx scoping issues) ── */
+  const isShowing = toastVisible && !toastExiting;
+  const toastCardStyle = {
+    background: '#FFFFFF',
+    borderRadius: 12,
+    boxShadow: '0 20px 60px rgba(0,0,0,0.5), 0 0 0 1px rgba(0,0,0,0.06)',
+    fontFamily: 'var(--sans)',
+    overflow: 'hidden',
+    transform: isShowing ? 'translateX(0) scale(1)' : toastExiting ? 'translateX(340px) scale(0.96)' : 'translateX(340px) scale(0.96)',
+    opacity: isShowing ? 1 : 0,
+    transition: 'transform 0.5s cubic-bezier(0.16,1,0.3,1), opacity 0.4s',
+    pointerEvents: 'auto',
+  };
+
+  const btnBase = {
+    flex: 1, padding: '8px 14px', borderRadius: 8, border: 'none',
+    fontFamily: 'var(--sans)', fontSize: 11, fontWeight: 600,
+    textAlign: 'center', cursor: 'default',
+  };
+
+  const renderToast = () => {
+    if (!toastData) return null;
+
+    return (
+      <div style={toastCardStyle}>
+        {/* Header */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '14px 14px 6px' }}>
+          <div style={{
+            width: 28, height: 28, borderRadius: 6,
+            background: 'var(--bronze-dark)',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            fontSize: 13, color: '#fff', fontWeight: 800, flexShrink: 0,
+          }}>H</div>
+          <div style={{ flex: 1 }}>
+            <div style={{ fontSize: 12, fontWeight: 700, color: '#111' }}>Hoop access request</div>
+            <div style={{ fontSize: 10, color: '#888', marginTop: 1 }}>
+              from claude-agent · {toastData.head.channel}
+            </div>
+          </div>
+        </div>
+
+        {/* Command block */}
+        <div style={{ padding: '6px 14px 10px' }}>
+          <div style={{
+            fontSize: 9, fontWeight: 600, textTransform: 'uppercase',
+            letterSpacing: '0.08em', color: '#999', marginBottom: 5,
+          }}>Command</div>
+          <div style={{
+            background: '#F5F3F0', borderRadius: 6, padding: '8px 10px',
+            fontFamily: 'var(--mono)', fontSize: 10.5, color: '#222',
+            borderLeft: '3px solid var(--bronze)', lineHeight: 1.5,
+            whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+          }}>{toastData.code}</div>
+          <div style={{ fontSize: 10, color: '#999', marginTop: 6 }}>{toastData.meta}</div>
+        </div>
+
+        {/* Actions / result */}
+        <div style={{ display: 'flex', gap: 8, padding: '0 14px 14px', alignItems: 'center' }}>
+          {toastResult ? (
+            <div style={{
+              ...btnBase,
+              background: toastResult.type === 'ok' ? '#EBEBEB' : 'rgba(196,80,80,0.08)',
+              color: toastResult.type === 'ok' ? '#333' : '#C45050',
+            }}>
+              {toastResult.text}
+            </div>
+          ) : toastData.actions === 'buttons' ? (
+            <>
+              <div style={{ ...btnBase, background: 'var(--bronze-dark)', color: '#fff' }}>Approve</div>
+              <div style={{ ...btnBase, background: 'transparent', color: '#888', border: '1px solid #DDD' }}>Reject</div>
+            </>
+          ) : toastData.actions === 'approved' ? (
+            <div style={{ ...btnBase, background: '#EBEBEB', color: '#333' }}>{toastData.resultText}</div>
+          ) : null}
+        </div>
+
+        {/* Reviewer feedback */}
+        {toastFeedback && (
+          <div style={{
+            padding: '10px 14px 14px', fontSize: 11, color: '#333',
+            lineHeight: 1.45, fontFamily: 'var(--sans)',
+            borderTop: '1px solid #EEE', margin: '0 14px',
+          }} dangerouslySetInnerHTML={{ __html: toastFeedback }} />
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <div className="scene">
+      {/* Chrome bar */}
+      <div className="chrome">
+        <div className="d dr" />
+        <div className="d dy" />
+        <div className="d dg" />
+        <div className="ct">claude code</div>
+      </div>
+
+      {/* Terminal body */}
+      <div className="terminal" ref={terminalRef}>
+        <div
+          className="scroll-inner"
+          ref={scrollRef}
+          style={{ transform: `translateY(-${scrollOffset}px)` }}
+        >
+          {lines.map((line) => {
+            const isVisible = visibleIds.has(line.id);
+            const cls = ['ln', line.cls, isVisible ? 'on' : ''].filter(Boolean).join(' ');
+            return (
+              <div
+                key={line.id}
+                className={cls}
+                dangerouslySetInnerHTML={{ __html: line.html }}
+              />
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Slack toast */}
+      <div className="slack-wrap">
+        {renderToast()}
+      </div>
+
+      {/* Footer phase dots */}
+      <div className="footer">
+        <div className="phase-lbl">{PHASES[activePhase]}</div>
+        <div className="dots">
+          {PHASES.map((_, i) => (
+            <button
+              key={i}
+              className={`dot${i === activePhase ? ' active' : ''}`}
+              style={{ cursor: 'default' }}
+              aria-label={PHASES[i]}
+            >
+              <span />
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <style>{`
+        .scene {
+          position: relative;
+          width: 100%;
+          max-width: 680px;
+          height: 460px;
+          margin: 0 auto;
+          overflow: hidden;
+          border-radius: 12px;
+          background: var(--gradient-dark-start);
+          font-family: 'JetBrains Mono', monospace;
+        }
+        .scene::before {
+          content: '';
+          position: absolute;
+          top: -30%;
+          right: -10%;
+          width: 60%;
+          height: 160%;
+          background: radial-gradient(ellipse at center, rgba(var(--warm-gold-rgb),0.05) 0%, transparent 70%);
+          pointer-events: none;
+          z-index: 0;
+        }
+
+        .chrome {
+          display: flex;
+          align-items: center;
+          gap: 6px;
+          padding: 10px 14px;
+          background: var(--gradient-dark-start);
+          border-bottom: 1px solid rgba(var(--sand-100-rgb),0.08);
+          position: relative;
+          z-index: 1;
+        }
+        .d {
+          width: 10px;
+          height: 10px;
+          border-radius: 50%;
+        }
+        .dr { background: var(--error); opacity: 0.6; }
+        .dy { background: #E8B44C; opacity: 0.6; }
+        .dg { background: var(--warm-gold); opacity: 0.6; }
+        .ct {
+          flex: 1;
+          text-align: center;
+          font-size: 11px;
+          color: rgba(var(--sand-100-rgb),0.25);
+          font-family: 'DM Sans', system-ui, sans-serif;
+          letter-spacing: 0.3px;
+          font-weight: 500;
+        }
+
+        .terminal {
+          position: relative;
+          z-index: 1;
+          height: 380px;
+          overflow: hidden;
+          padding: 16px 18px 60px;
+        }
+        .terminal::after {
+          content: '';
+          position: absolute;
+          bottom: 0;
+          left: 0;
+          right: 0;
+          height: 70px;
+          background: linear-gradient(transparent, var(--gradient-dark-start));
+          pointer-events: none;
+          z-index: 2;
+        }
+
+        .scroll-inner {
+          display: flex;
+          flex-direction: column;
+          gap: 0;
+          transition: transform 0.5s cubic-bezier(0.16, 1, 0.3, 1);
+        }
+
+        .ln {
+          font-size: 13px;
+          line-height: 1.8;
+          color: var(--sand-500);
+          white-space: nowrap;
+          min-height: 23px;
+          opacity: 0;
+          transform: translateY(6px);
+          transition: opacity 0.5s ease, transform 0.5s ease;
+        }
+        .ln.on {
+          opacity: 1;
+          transform: translateY(0);
+        }
+        .ln.br {
+          min-height: 10px;
+        }
+
+        .ln .pr { color: var(--warm-gold); font-weight: 600; }
+        .ln .cm { color: var(--sand-300); }
+        .ln .fl { color: var(--warm-gold); }
+        .ln .ar { color: #E8B44C; }
+        .ln .ok { color: var(--warm-gold); }
+        .ln .er { color: var(--error); }
+        .ln .dm { color: rgba(var(--sand-100-rgb),0.25); }
+        .ln .hp { color: var(--bronze); font-weight: 500; }
+        .ln .cursor {
+          display: inline-block;
+          width: 7px;
+          height: 14px;
+          background: var(--sand-100);
+          vertical-align: middle;
+          margin-left: 2px;
+          animation: blink 1s step-end infinite;
+        }
+
+        @keyframes blink {
+          0%, 50% { opacity: 1; }
+          51%, 100% { opacity: 0; }
+        }
+
+        /* Toast wrapper — positioning only, styles are inline */
+        .slack-wrap {
+          position: absolute;
+          top: 50px;
+          right: 14px;
+          width: 300px;
+          z-index: 10;
+          pointer-events: none;
+        }
+
+        /* Footer phase indicator */
+        .footer {
+          position: absolute;
+          bottom: 0;
+          left: 0;
+          right: 0;
+          height: 44px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          gap: 6px;
+          z-index: 3;
+          background: var(--gradient-dark-start);
+        }
+        .dots { display: flex; gap: 4px; }
+        .dot {
+          width: 24px;
+          height: 24px;
+          border: none;
+          background: transparent;
+          cursor: pointer;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        }
+        .dot span {
+          width: 6px;
+          height: 6px;
+          border-radius: 50%;
+          background: rgba(var(--sand-100-rgb),0.25);
+          transition: background 0.4s, transform 0.4s;
+          pointer-events: none;
+        }
+        .dot:hover span {
+          background: var(--sand-500);
+          transform: scale(1.3);
+        }
+        .dot.active span {
+          background: var(--bronze);
+          transform: scale(1.4);
+        }
+        .phase-lbl {
+          font-family: 'DM Sans', system-ui, sans-serif;
+          font-size: 11px;
+          color: rgba(var(--sand-100-rgb),0.25);
+          font-weight: 500;
+          letter-spacing: 0.2px;
+          margin-right: 8px;
+          min-width: 200px;
+          text-align: right;
+          transition: opacity 0.3s;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/snippets/annimations/aichat.jsx
+++ b/snippets/annimations/aichat.jsx
@@ -1,0 +1,508 @@
+export const AIChatThread = () => {
+  const STEP_NAMES = ['Diagnose', 'Propose', 'Review', 'Reject', 'Retry', 'Approve', 'Audit'];
+
+  function msgEntry(avatar, avatarClass, name, time, content) {
+    return { type: 'msg', avatar, avatarClass, name, time, content };
+  }
+  function dividerEntry(text) {
+    return { type: 'divider', text };
+  }
+  function typingEntry(avatar, avatarClass) {
+    return { type: 'typing', avatar, avatarClass };
+  }
+
+  function Message({ avatar, avatarClass, name, time, content, visible }) {
+    return (
+      <div
+        className="aichat-msg"
+        style={{
+          display: 'flex', gap: 10, alignItems: 'flex-start', padding: '6px 0',
+          opacity: visible ? 1 : 0,
+          transform: visible ? 'translateY(0)' : 'translateY(8px)',
+          transition: 'opacity 0.45s ease, transform 0.45s ease',
+        }}
+      >
+        <div className={`aichat-msg-avatar ${avatarClass}`}>{avatar}</div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div className="aichat-msg-name">
+            {name} <span className="aichat-msg-time">{time}</span>
+          </div>
+          {content}
+        </div>
+      </div>
+    );
+  }
+
+  function Divider({ text, visible }) {
+    return (
+      <div
+        className="aichat-divider"
+        style={{
+          display: 'flex', alignItems: 'center', gap: 10, padding: '8px 0',
+          opacity: visible ? 1 : 0,
+          transform: visible ? 'translateY(0)' : 'translateY(8px)',
+          transition: 'opacity 0.45s ease, transform 0.45s ease',
+        }}
+      >
+        <div className="aichat-divider-line" />
+        <div className="aichat-divider-text">{text}</div>
+        <div className="aichat-divider-line" />
+      </div>
+    );
+  }
+
+  function TypingIndicator({ avatar, avatarClass }) {
+    return (
+      <div
+        style={{
+          display: 'flex', gap: 10, alignItems: 'flex-start', padding: '6px 0',
+          opacity: 1, transform: 'translateY(0)',
+        }}
+      >
+        <div className={`aichat-msg-avatar ${avatarClass}`}>{avatar}</div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div className="aichat-typing">
+            <span className="aichat-typing-dot" style={{ animationDelay: '0s' }} />
+            <span className="aichat-typing-dot" style={{ animationDelay: '0.15s' }} />
+            <span className="aichat-typing-dot" style={{ animationDelay: '0.3s' }} />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  function MsgText({ children }) {
+    return <div className="aichat-msg-text">{children}</div>;
+  }
+  function MsgCode({ children }) {
+    return <div className="aichat-msg-code">{children}</div>;
+  }
+  function MsgTag({ className, children }) {
+    return <span className={`aichat-msg-tag ${className}`}>{children}</span>;
+  }
+  function MsgActions({ children }) {
+    return <div className="aichat-msg-actions">{children}</div>;
+  }
+  function MsgBtn({ className, children }) {
+    return <span className={`aichat-msg-btn ${className}`}>{children}</span>;
+  }
+
+  const [items, setItems] = useState([]);
+  const [visibleSet, setVisibleSet] = useState(new Set());
+  const [step, setStep] = useState(0);
+  const [statusLabel, setStatusLabel] = useState('Live');
+  const [statusClass, setStatusClass] = useState('active');
+
+  const innerRef = useRef(null);
+  const threadRef = useRef(null);
+  const timersRef = useRef([]);
+  const idCounterRef = useRef(0);
+  const cancelledRef = useRef(false);
+
+  /* ── helpers ── */
+  const clearTimers = useCallback(() => {
+    cancelledRef.current = true;
+    timersRef.current.forEach(clearTimeout);
+    timersRef.current = [];
+  }, []);
+
+  const delay = useCallback((ms) => {
+    return new Promise((resolve) => {
+      if (cancelledRef.current) return;
+      const id = setTimeout(resolve, ms);
+      timersRef.current.push(id);
+    });
+  }, []);
+
+  const autoScroll = useCallback(() => {
+    const inner = innerRef.current;
+    const thread = threadRef.current;
+    if (!inner || !thread) return;
+    const totalH = inner.scrollHeight;
+    const viewH = thread.clientHeight - 50;
+    if (totalH > viewH) {
+      inner.style.transform = `translateY(-${totalH - viewH}px)`;
+    }
+  }, []);
+
+  const addItem = useCallback((item) => {
+    const id = ++idCounterRef.current;
+    const entry = { ...item, id };
+    setItems((prev) => [...prev, entry]);
+    // Show after a frame for fade-in animation
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        setVisibleSet((prev) => new Set([...prev, id]));
+      });
+    });
+    // Scroll after DOM updates
+    setTimeout(autoScroll, 50);
+    return id;
+  }, [autoScroll]);
+
+  const removeItem = useCallback((id) => {
+    setItems((prev) => prev.filter((it) => it.id !== id));
+    setTimeout(autoScroll, 50);
+  }, [autoScroll]);
+
+  /* ── animation sequence ── */
+  const runSequence = useCallback(async () => {
+    cancelledRef.current = false;
+    idCounterRef.current = 0;
+    setItems([]);
+    setVisibleSet(new Set());
+    setStep(0);
+    setStatusLabel('Live');
+    setStatusClass('active');
+    if (innerRef.current) innerRef.current.style.transform = 'translateY(0)';
+
+    const cancelled = () => cancelledRef.current;
+
+    // Phase 0: Diagnose
+    setStep(0);
+    let typId = addItem(typingEntry('C', 'aichat-avatar-agent'));
+    await delay(1200);
+    if (cancelled()) return;
+    removeItem(typId);
+
+    addItem(msgEntry('C', 'aichat-avatar-agent', 'claude-agent', '2:41 PM', (
+      <>
+        <MsgText>Payments service returning 503s. Connecting to diagnose.</MsgText>
+        <MsgTag className="aichat-tag-readonly">read-only profile</MsgTag>
+      </>
+    )));
+    await delay(1800);
+    if (cancelled()) return;
+
+    typId = addItem(typingEntry('C', 'aichat-avatar-agent'));
+    await delay(1000);
+    if (cancelled()) return;
+    removeItem(typId);
+
+    addItem(msgEntry('C', 'aichat-avatar-agent', 'claude-agent', '2:41 PM', (
+      <MsgText>Found 3/5 pods in CrashLoopBackOff. Root cause: OOMKilled at 256Mi.</MsgText>
+    )));
+    await delay(2000);
+    if (cancelled()) return;
+
+    // Phase 1: Propose
+    setStep(1);
+    typId = addItem(typingEntry('C', 'aichat-avatar-agent'));
+    await delay(1200);
+    if (cancelled()) return;
+    removeItem(typId);
+
+    addItem(msgEntry('C', 'aichat-avatar-agent', 'claude-agent', '2:42 PM', (
+      <>
+        <MsgText>Proposed fix: increase memory limit.</MsgText>
+        <MsgCode>
+          kubectl set resources deploy/payments<br />--limits=memory=512Mi
+        </MsgCode>
+      </>
+    )));
+    await delay(1200);
+    if (cancelled()) return;
+
+    // Phase 2: Review
+    setStep(2);
+    addItem(msgEntry('H', 'aichat-avatar-hoop', 'Hoop', '2:42 PM', (
+      <>
+        <MsgText>Write command detected on <b>prod-us-east</b>. Approval required.</MsgText>
+        <MsgTag className="aichat-tag-write">escalation: write</MsgTag>
+      </>
+    )));
+    await delay(1000);
+    if (cancelled()) return;
+
+    addItem(msgEntry('H', 'aichat-avatar-hoop', 'Hoop', '2:42 PM', (
+      <>
+        <MsgText>Waiting for approval...</MsgText>
+        <MsgActions>
+          <MsgBtn className="aichat-btn-approve">Approve</MsgBtn>
+          <MsgBtn className="aichat-btn-reject">Reject</MsgBtn>
+        </MsgActions>
+      </>
+    )));
+    await delay(3000);
+    if (cancelled()) return;
+
+    // Phase 3: Rejected
+    setStep(3);
+    addItem(msgEntry('S', 'aichat-avatar-human', 'sarah.chen', '2:42 PM', (
+      <>
+        <MsgText>Don&apos;t bump limits blindly. Roll back to v2.3.1 first, then investigate the leak.</MsgText>
+        <MsgTag className="aichat-tag-rejected">Rejected</MsgTag>
+      </>
+    )));
+    await delay(2500);
+    if (cancelled()) return;
+
+    // Phase 4: Retry
+    setStep(4);
+    addItem(dividerEntry('Agent adjusting approach'));
+    await delay(800);
+    if (cancelled()) return;
+
+    typId = addItem(typingEntry('C', 'aichat-avatar-agent'));
+    await delay(1400);
+    if (cancelled()) return;
+    removeItem(typId);
+
+    addItem(msgEntry('C', 'aichat-avatar-agent', 'claude-agent', '2:43 PM', (
+      <>
+        <MsgText>Understood. Rolling back to last stable version instead.</MsgText>
+        <MsgCode>
+          kubectl set image deploy/payments<br />payments=payments:v2.3.1
+        </MsgCode>
+      </>
+    )));
+    await delay(1200);
+    if (cancelled()) return;
+
+    addItem(msgEntry('H', 'aichat-avatar-hoop', 'Hoop', '2:43 PM', (
+      <>
+        <MsgText>Write command detected. Approval required.</MsgText>
+        <MsgActions>
+          <MsgBtn className="aichat-btn-approve">Approve</MsgBtn>
+          <MsgBtn className="aichat-btn-reject">Reject</MsgBtn>
+        </MsgActions>
+      </>
+    )));
+    await delay(2500);
+    if (cancelled()) return;
+
+    // Phase 5: Approved
+    setStep(5);
+    addItem(msgEntry('S', 'aichat-avatar-human', 'sarah.chen', '2:43 PM', (
+      <>
+        <MsgText>Approved. Good call.</MsgText>
+        <MsgTag className="aichat-tag-approved">Approved</MsgTag>
+      </>
+    )));
+    await delay(1500);
+    if (cancelled()) return;
+
+    addItem(msgEntry('H', 'aichat-avatar-hoop', 'Hoop', '2:43 PM', (
+      <MsgText>Deployed. All 5/5 pods running. 503s resolved.</MsgText>
+    )));
+    await delay(2500);
+    if (cancelled()) return;
+
+    // Phase 6: Audit
+    setStep(6);
+    addItem(dividerEntry('Session complete'));
+    await delay(600);
+    if (cancelled()) return;
+
+    setStatusLabel('Resolved');
+    setStatusClass('done');
+
+    addItem(msgEntry('H', 'aichat-avatar-hoop', 'Hoop', '2:44 PM', (
+      <MsgText>
+        4 commands, 1 rejected, 1 approved, 47s total.<br />
+        Replay: app.hoop.dev/sessions/7f3a91c2
+      </MsgText>
+    )));
+    await delay(5000);
+    if (cancelled()) return;
+
+    // Loop
+    runSequence();
+  }, [addItem, removeItem, delay]);
+
+  useEffect(() => {
+    runSequence();
+    return clearTimers;
+  }, [runSequence, clearTimers]);
+
+  /* ── render ── */
+  return (
+    <div className="aichat-scene">
+      <style>{`
+        .aichat-scene {
+          position: relative; width: 100%; max-width: 520px; height: 520px;
+          margin: 0 auto; overflow: hidden; border-radius: 14px;
+          background: #fff; font-family: var(--sans);
+          border: 1px solid var(--sand-200);
+          box-shadow: 0 4px 24px rgba(0,0,0,0.06);
+        }
+        .aichat-header {
+          display: flex; align-items: center; gap: 10px;
+          padding: 14px 18px; border-bottom: 1px solid var(--sand-200);
+          background: #fff;
+        }
+        .aichat-h-icon {
+          width: 32px; height: 32px; border-radius: 8px;
+          background: linear-gradient(135deg, var(--espresso), var(--bronze));
+          display: flex; align-items: center; justify-content: center;
+          color: var(--sand-100); font-weight: 800; font-size: 14px;
+        }
+        .aichat-h-info { flex: 1; }
+        .aichat-h-title { font-size: 14px; font-weight: 700; color: #111; }
+        .aichat-h-sub { font-size: 11px; color: #999; margin-top: 1px; }
+        .aichat-h-status {
+          font-size: 9px; font-weight: 700; text-transform: uppercase;
+          letter-spacing: 0.08em; padding: 3px 10px; border-radius: 20px;
+          transition: all 0.4s;
+        }
+        .aichat-h-status-active { background: var(--sand-200); color: var(--bronze); }
+        .aichat-h-status-done { background: var(--sand-200); color: var(--bronze-dark); }
+
+        .aichat-thread {
+          height: 420px; overflow: hidden; position: relative;
+          padding: 14px 18px 50px;
+        }
+        .aichat-thread-inner {
+          display: flex; flex-direction: column; gap: 4px;
+          transition: transform 0.5s cubic-bezier(0.16,1,0.3,1);
+        }
+        .aichat-thread::after {
+          content: ''; position: absolute; bottom: 0; left: 0; right: 0; height: 50px;
+          background: linear-gradient(transparent, #fff);
+          pointer-events: none;
+        }
+
+        .aichat-msg-avatar {
+          width: 26px; height: 26px; border-radius: 7px; flex-shrink: 0;
+          display: flex; align-items: center; justify-content: center;
+          font-size: 10px; font-weight: 700; margin-top: 2px;
+        }
+        .aichat-avatar-agent { background: #1A1A2E; color: #A8A8C8; }
+        .aichat-avatar-hoop { background: var(--bronze-dark); color: var(--sand-100); }
+        .aichat-avatar-human { background: var(--sand-300); color: var(--bronze); }
+
+        .aichat-msg-name {
+          font-size: 11px; font-weight: 600; color: #111; margin-bottom: 2px;
+          display: flex; align-items: center; gap: 6px;
+        }
+        .aichat-msg-time { font-size: 9px; color: #bbb; font-weight: 400; }
+        .aichat-msg-text { font-size: 12.5px; color: #555; line-height: 1.55; }
+
+        .aichat-msg-code {
+          margin-top: 5px; padding: 7px 10px; background: var(--sand-100);
+          border-radius: 6px; font-family: var(--mono); font-size: 10.5px;
+          color: var(--espresso); border-left: 3px solid var(--bronze);
+          line-height: 1.5; word-break: break-all;
+        }
+
+        .aichat-msg-tag {
+          display: inline-block; font-size: 9px; font-weight: 700;
+          text-transform: uppercase; letter-spacing: 0.06em;
+          padding: 2px 7px; border-radius: 4px; margin-top: 4px;
+        }
+        .aichat-tag-rejected { background: rgba(var(--error-rgb),0.08); color: var(--error); }
+        .aichat-tag-approved { background: var(--sand-200); color: var(--bronze-dark); }
+        .aichat-tag-readonly { background: var(--sand-200); color: var(--sand-500); }
+        .aichat-tag-write { background: var(--sand-200); color: var(--bronze); }
+
+        .aichat-msg-actions {
+          display: flex; gap: 6px; margin-top: 6px;
+        }
+        .aichat-msg-btn {
+          padding: 5px 14px; border-radius: 6px; font-size: 11px;
+          font-weight: 600; font-family: var(--sans); border: none; cursor: default;
+          display: inline-block;
+        }
+        .aichat-btn-approve { background: var(--bronze-dark); color: var(--sand-100); }
+        .aichat-btn-reject { background: transparent; color: #777; border: 1px solid var(--sand-300); }
+
+        .aichat-divider-line { flex: 1; height: 1px; background: var(--sand-200); }
+        .aichat-divider-text {
+          font-size: 9px; font-weight: 600; color: #bbb;
+          text-transform: uppercase; letter-spacing: 0.08em; white-space: nowrap;
+        }
+
+        .aichat-typing {
+          display: flex; gap: 3px; padding: 4px 0;
+        }
+        .aichat-typing-dot {
+          width: 5px; height: 5px; border-radius: 50%; background: var(--sand-400);
+          animation: aichatTypingBounce 1.2s ease-in-out infinite;
+          display: inline-block;
+        }
+        @keyframes aichatTypingBounce {
+          0%, 60%, 100% { transform: translateY(0); opacity: 0.4; }
+          30% { transform: translateY(-4px); opacity: 1; }
+        }
+
+        .aichat-footer-bar {
+          position: absolute; bottom: 0; left: 0; right: 0; height: 44px;
+          display: flex; align-items: center; justify-content: center; gap: 6px;
+          z-index: 3; background: #fff; border-top: 1px solid var(--sand-200);
+        }
+        .aichat-f-dots { display: flex; gap: 5px; }
+        .aichat-f-dot {
+          width: 6px; height: 6px; border-radius: 50%; background: var(--sand-300);
+          transition: background 0.4s, transform 0.4s;
+        }
+        .aichat-f-dot-active { background: var(--bronze); transform: scale(1.4); }
+        .aichat-f-label {
+          font-size: 10px; color: #bbb; font-weight: 500;
+          min-width: 120px; text-align: right; margin-right: 8px;
+        }
+      `}</style>
+
+      {/* Header */}
+      <div className="aichat-header">
+        <div className="aichat-h-icon">H</div>
+        <div className="aichat-h-info">
+          <div className="aichat-h-title">#infra-approvals</div>
+          <div className="aichat-h-sub">claude-agent, hoop, sarah.chen</div>
+        </div>
+        <div className={`aichat-h-status aichat-h-status-${statusClass}`}>
+          {statusLabel}
+        </div>
+      </div>
+
+      {/* Thread */}
+      <div className="aichat-thread" ref={threadRef}>
+        <div className="aichat-thread-inner" ref={innerRef}>
+          {items.map((item) => {
+            if (item.type === 'typing') {
+              return (
+                <TypingIndicator
+                  key={item.id}
+                  avatar={item.avatar}
+                  avatarClass={item.avatarClass}
+                />
+              );
+            }
+            if (item.type === 'divider') {
+              return (
+                <Divider
+                  key={item.id}
+                  text={item.text}
+                  visible={visibleSet.has(item.id)}
+                />
+              );
+            }
+            return (
+              <Message
+                key={item.id}
+                avatar={item.avatar}
+                avatarClass={item.avatarClass}
+                name={item.name}
+                time={item.time}
+                content={item.content}
+                visible={visibleSet.has(item.id)}
+              />
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div className="aichat-footer-bar">
+        <div className="aichat-f-label">{STEP_NAMES[step]}</div>
+        <div className="aichat-f-dots">
+          {STEP_NAMES.map((_, i) => (
+            <div
+              key={i}
+              className={`aichat-f-dot${i === step ? ' aichat-f-dot-active' : ''}`}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/snippets/annimations/aihumanintheloop.jsx
+++ b/snippets/annimations/aihumanintheloop.jsx
@@ -1,0 +1,461 @@
+export const ApprovalCard = () => {
+  const T = {
+    bronze: 'var(--bronze)',
+    bronzeDark: 'var(--bronze-dark)',
+    espresso: 'var(--gradient-dark-mid)',
+    warmGold: 'var(--warm-gold)',
+    sand100: 'var(--sand-100)',
+    sand200: 'var(--sand-200)',
+    sand300: 'var(--sand-300)',
+    sand400: 'var(--sand-400)',
+    sand500: 'var(--sand-500)',
+  };
+
+  const GHOST_LINES = [
+    '$ claude "payments returning 503s, diagnose"',
+    '',
+    '\u27E1 Connecting via Hoop read-only profile...',
+    '\u2B21 hoop | profile: readonly-prod | cluster: prod-us-east',
+    '\u2B21 hoop | kubectl get pods -n payments',
+    '\u27E1 Found 3/5 pods in CrashLoopBackOff',
+    '\u27E1 Root cause: OOMKilled, memory limit 256Mi',
+    '',
+    '\u27E1 Proposed fix:',
+    '  kubectl set resources deploy/payments',
+    '    --limits=memory=512Mi',
+    '',
+    '\u2B21 hoop | Write command detected. Routing...',
+    '',
+    '\u2B21 Revised: rollback to stable image',
+    '  kubectl set image deploy/payments',
+    '    payments=payments:v2.3.1',
+    '',
+    '\u2B21 hoop | Approved. Deploying...',
+    'deployment.apps/payments updated to v2.3.1',
+    '\u27E1 Rollout complete. 5/5 pods running.',
+    '',
+    '\u2B21 hoop | Audit: 4 cmds, 1 rejected, 1 approved',
+    '\u2B21 hoop | Replay: app.hoop.dev/sessions/7f3a91c2',
+  ];
+
+  const STEPS = ['Request', 'Review', 'Reject', 'Retry', 'Approve'];
+
+  const PHASE_REQUEST = {
+    command: 'kubectl set resources deploy/payments\n--limits=memory=512Mi --requests=memory=256Mi',
+    badge: 'Pending',
+    badgeClass: 'pending',
+    actions: 'buttons',
+    context: '3/5 pods OOMKilled at 256Mi. Increasing memory limit to 512Mi to restore service.',
+    feedback: null,
+  };
+
+  const PHASE_RETRY = {
+    command: 'kubectl set image deploy/payments\npayments=payments:v2.3.1',
+    badge: 'Pending',
+    badgeClass: 'pending',
+    actions: 'buttons',
+    context: 'Following reviewer guidance. Rolling back to v2.3.1 before investigating the memory leak.',
+    feedback: null,
+  };
+
+  const S = {
+    scene: {
+      position: 'relative',
+      width: '100%',
+      maxWidth: 680,
+      height: 440,
+      margin: '0 auto',
+      overflow: 'hidden',
+      borderRadius: 12,
+      background: `linear-gradient(135deg, var(--gradient-dark-start) 0%, ${T.espresso} 35%, var(--gradient-dark-end) 70%, ${T.bronze} 100%)`,
+      fontFamily: "var(--sans, 'DM Sans', system-ui, sans-serif)",
+    },
+    sceneGlow: {
+      content: '""',
+      position: 'absolute',
+      top: '-20%',
+      right: '-5%',
+      width: '50%',
+      height: '140%',
+      background: `radial-gradient(ellipse at center, rgba(var(--warm-gold-rgb),0.12) 0%, transparent 70%)`,
+      pointerEvents: 'none',
+    },
+    bgTerminal: {
+      position: 'absolute',
+      inset: 0,
+      padding: '40px 30px',
+      fontFamily: "var(--mono, 'JetBrains Mono', monospace)",
+      fontSize: 11,
+      lineHeight: 2.2,
+      color: 'rgba(var(--sand-100-rgb),0.06)',
+      overflow: 'hidden',
+      pointerEvents: 'none',
+      whiteSpace: 'pre',
+    },
+    cardStage: {
+      position: 'absolute',
+      inset: 0,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      zIndex: 2,
+    },
+    topLabel: {
+      position: 'absolute',
+      top: 16,
+      left: 0,
+      right: 0,
+      textAlign: 'center',
+      zIndex: 3,
+      fontFamily: "var(--display, 'Sora', system-ui, sans-serif)",
+      fontSize: 12,
+      fontWeight: 600,
+      color: 'rgba(var(--sand-100-rgb),0.2)',
+      letterSpacing: '0.15em',
+      textTransform: 'uppercase',
+    },
+    phaseBar: {
+      position: 'absolute',
+      bottom: 16,
+      left: 0,
+      right: 0,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: 6,
+      zIndex: 3,
+    },
+    pLabel: {
+      fontSize: 11,
+      color: 'rgba(var(--sand-100-rgb),0.3)',
+      fontWeight: 500,
+      minWidth: 140,
+      transition: 'opacity 0.3s',
+    },
+    pDots: {
+      display: 'flex',
+      gap: 5,
+    },
+    pDot: (active) => ({
+      width: 6,
+      height: 6,
+      borderRadius: '50%',
+      background: active ? T.warmGold : 'rgba(var(--sand-100-rgb),0.15)',
+      transition: 'background 0.4s, transform 0.4s',
+      transform: active ? 'scale(1.4)' : 'scale(1)',
+    }),
+  };
+
+  const cardBase = {
+    width: 360,
+    background: '#fff',
+    borderRadius: 12,
+    boxShadow: '0 20px 60px rgba(var(--gradient-dark-start-rgb),0.6), 0 0 0 1px rgba(var(--sand-100-rgb),0.08)',
+    overflow: 'hidden',
+    transition: 'transform 0.6s cubic-bezier(0.16,1,0.3,1), opacity 0.5s',
+  };
+
+  const cardTransitions = {
+    hidden: { transform: 'translateY(20px) scale(0.96)', opacity: 0 },
+    entering: { transform: 'translateY(20px) scale(0.96)', opacity: 0 },
+    visible: { transform: 'translateY(0) scale(1)', opacity: 1 },
+    exiting: {
+      transform: 'translateY(-20px) scale(0.96)',
+      opacity: 0,
+      transitionDuration: '0.4s',
+    },
+  };
+
+  const badgeBase = {
+    fontSize: 9,
+    fontWeight: 700,
+    textTransform: 'uppercase',
+    letterSpacing: '0.08em',
+    padding: '3px 8px',
+    borderRadius: 20,
+  };
+
+  const badgeVariants = {
+    pending: { background: T.sand200, color: T.sand500 },
+    rejected: { background: 'rgba(var(--error-rgb),0.08)', color: 'var(--error)' },
+    approved: { background: 'var(--sand-200)', color: T.bronzeDark },
+  };
+
+  function CardHeader({ badge, badgeClass }) {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '14px 16px 6px' }}>
+        <div
+          style={{
+            width: 28, height: 28, borderRadius: 6, background: T.bronzeDark,
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            color: T.sand100, fontWeight: 800, fontSize: 13,
+          }}
+        >
+          H
+        </div>
+        <div style={{ flex: 1 }}>
+          <div style={{ fontSize: 13, fontWeight: 700, color: '#111' }}>Hoop access request</div>
+          <div style={{ fontSize: 10, color: '#999', marginTop: 1 }}>from claude-agent via #infra-approvals</div>
+        </div>
+        <div style={{ ...badgeBase, ...badgeVariants[badgeClass] }}>{badge}</div>
+      </div>
+    );
+  }
+
+  function CardBody({ command }) {
+    return (
+      <div style={{ padding: '8px 16px 12px' }}>
+        <div style={{
+          fontSize: 10, fontWeight: 600, color: '#999',
+          textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: 6,
+        }}>
+          Command
+        </div>
+        <div style={{
+          background: T.sand100, borderRadius: 6, padding: '10px 12px',
+          fontFamily: "var(--mono, 'JetBrains Mono', monospace)",
+          fontSize: 11.5, color: T.espresso,
+          borderLeft: `3px solid ${T.bronze}`, lineHeight: 1.5,
+          wordBreak: 'break-all', whiteSpace: 'pre-wrap',
+        }}>
+          {command}
+        </div>
+        <div style={{ display: 'flex', gap: 16, marginTop: 10, fontSize: 10, color: '#999' }}>
+          <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>prod-us-east</span>
+          <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>namespace: payments</span>
+        </div>
+      </div>
+    );
+  }
+
+  function CardContext({ context }) {
+    if (!context) return null;
+    return (
+      <div style={{
+        padding: '0 16px 12px', fontSize: 11, color: '#555', lineHeight: 1.5,
+        borderTop: `1px solid ${T.sand200}`, margin: '0 16px', paddingTop: 10,
+      }}>
+        <div style={{
+          fontSize: 9, fontWeight: 600, color: T.bronze,
+          textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: 4,
+        }}>
+          Agent reasoning
+        </div>
+        {context}
+      </div>
+    );
+  }
+
+  function CardFeedback({ feedback, visible }) {
+    if (!feedback) return null;
+    return (
+      <div style={{
+        padding: '0 16px 14px', fontSize: 11.5, color: '#333', lineHeight: 1.5,
+        opacity: visible ? 1 : 0,
+        transform: visible ? 'translateY(0)' : 'translateY(4px)',
+        transition: 'opacity 0.4s, transform 0.4s',
+      }}>
+        {feedback}
+      </div>
+    );
+  }
+
+  function CardActions({ mode, actionsVisible }) {
+    const btnBase = {
+      flex: 1, padding: 10, borderRadius: 8, border: 'none',
+      fontFamily: "var(--sans, 'DM Sans', system-ui, sans-serif)",
+      fontSize: 13, fontWeight: 600, cursor: 'default', textAlign: 'center',
+      transition: 'transform 0.2s, opacity 0.2s',
+    };
+
+    return (
+      <div style={{
+        display: 'flex', gap: 8, padding: '0 16px 16px',
+        transition: 'opacity 0.3s',
+        opacity: actionsVisible ? 1 : 0,
+      }}>
+        {mode === 'buttons' && (
+          <>
+            <div style={{ ...btnBase, background: T.bronzeDark, color: T.sand100 }}>Approve</div>
+            <div style={{ ...btnBase, background: 'transparent', color: '#777', border: `1px solid ${T.sand300}` }}>Reject</div>
+          </>
+        )}
+        {mode === 'rejected' && (
+          <div style={{ ...btnBase, background: 'rgba(var(--error-rgb),0.08)', color: 'var(--error)' }}>{'\u2717'} Rejected by @sarah.chen</div>
+        )}
+        {mode === 'approved' && (
+          <div style={{ ...btnBase, background: 'var(--sand-200)', color: T.bronzeDark }}>{'\u2713'} Approved by @sarah.chen</div>
+        )}
+      </div>
+    );
+  }
+
+  const [cardVisibility, setCardVisibility] = useState('hidden');
+  const [cardState, setCardState] = useState(PHASE_REQUEST);
+  const [activeStep, setActiveStep] = useState(0);
+  const [stepLabel, setStepLabel] = useState('');
+  const [actionsMode, setActionsMode] = useState('buttons');
+  const [actionsVisible, setActionsVisible] = useState(true);
+  const [feedbackVisible, setFeedbackVisible] = useState(false);
+  const [feedbackText, setFeedbackText] = useState(null);
+  const timersRef = useRef([]);
+
+  const clearTimers = useCallback(() => {
+    timersRef.current.forEach(clearTimeout);
+    timersRef.current = [];
+  }, []);
+
+  const schedule = useCallback((fn, ms) => {
+    const id = setTimeout(fn, ms);
+    timersRef.current.push(id);
+    return id;
+  }, []);
+
+  const showCard = useCallback((data) => {
+    setCardState(data);
+    setActionsMode('buttons');
+    setActionsVisible(true);
+    setFeedbackVisible(false);
+    setFeedbackText(null);
+    setCardVisibility('entering');
+    // Double rAF to ensure the entering state is painted before transitioning
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        setCardVisibility('visible');
+      });
+    });
+  }, []);
+
+  const exitCard = useCallback(() => {
+    setCardVisibility('exiting');
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    function run() {
+      if (cancelled) return;
+      clearTimers();
+
+      // Step 1: Request arrives
+      setActiveStep(0);
+      setStepLabel('Request received');
+      showCard(PHASE_REQUEST);
+
+      // Step 2: Rejected (at 4000ms)
+      schedule(() => {
+        if (cancelled) return;
+        setActiveStep(2);
+        setStepLabel('Rejected by @sarah.chen');
+        setActionsVisible(false);
+
+        schedule(() => {
+          if (cancelled) return;
+          setActionsMode('rejected');
+          setActionsVisible(true);
+          setCardState((prev) => ({ ...prev, badge: 'Rejected', badgeClass: 'rejected' }));
+
+          // Show feedback at +800ms
+          schedule(() => {
+            if (cancelled) return;
+            setFeedbackText(
+              <><b style={{ fontWeight: 600 }}>@sarah.chen:</b> Don&rsquo;t bump limits blindly. Roll back to v2.3.1 first, then investigate the leak.</>
+            );
+            schedule(() => {
+              if (cancelled) return;
+              setFeedbackVisible(true);
+            }, 100);
+          }, 800);
+        }, 300);
+      }, 4000);
+
+      // Step 3: Exit first card (at 4000 + 300 + 800 + 100 + 4000 = 9200ms)
+      schedule(() => {
+        if (cancelled) return;
+        exitCard();
+      }, 9200);
+
+      // Step 3b: Show retry card (at 9200 + 450 + 400 = 10050ms)
+      schedule(() => {
+        if (cancelled) return;
+        setActiveStep(3);
+        setStepLabel('Agent retried with rollback');
+        showCard(PHASE_RETRY);
+      }, 10050);
+
+      // Step 4: Approved (at 10050 + 3500 = 13550ms)
+      schedule(() => {
+        if (cancelled) return;
+        setActiveStep(4);
+        setStepLabel('Approved by @sarah.chen');
+        setActionsVisible(false);
+
+        schedule(() => {
+          if (cancelled) return;
+          setActionsMode('approved');
+          setActionsVisible(true);
+          setCardState((prev) => ({ ...prev, badge: 'Approved', badgeClass: 'approved' }));
+        }, 300);
+      }, 13550);
+
+      // Step 5: Exit and loop (at 13550 + 300 + 4000 = 17850ms)
+      schedule(() => {
+        if (cancelled) return;
+        exitCard();
+      }, 17850);
+
+      // Restart (at 17850 + 450 + 1000 = 19300ms)
+      schedule(() => {
+        if (cancelled) return;
+        setCardVisibility('hidden');
+        run();
+      }, 19300);
+    }
+
+    run();
+
+    return () => {
+      cancelled = true;
+      clearTimers();
+    };
+  }, [clearTimers, schedule, showCard, exitCard]);
+
+  const cardStyle = {
+    ...cardBase,
+    ...cardTransitions[cardVisibility],
+  };
+
+  return (
+    <div style={S.scene}>
+      {/* Radial glow overlay */}
+      <div style={S.sceneGlow} />
+
+      {/* Ghost terminal background */}
+      <div style={S.bgTerminal}>{GHOST_LINES.join('\n')}</div>
+
+      {/* Top label */}
+      <div style={S.topLabel}>Agent approval flow</div>
+
+      {/* Card stage */}
+      <div style={S.cardStage}>
+        <div style={cardStyle}>
+          <CardHeader badge={cardState.badge} badgeClass={cardState.badgeClass} />
+          <CardBody command={cardState.command} />
+          <CardContext context={cardState.context} />
+          <CardFeedback feedback={feedbackText} visible={feedbackVisible} />
+          <CardActions mode={actionsMode} actionsVisible={actionsVisible} />
+        </div>
+      </div>
+
+      {/* Phase dots */}
+      <div style={S.phaseBar}>
+        <div style={S.pLabel}>{stepLabel}</div>
+        <div style={S.pDots}>
+          {STEPS.map((_, i) => (
+            <div key={i} style={S.pDot(i === activeStep)} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/snippets/annimations/datamaskingscan.jsx
+++ b/snippets/annimations/datamaskingscan.jsx
@@ -1,0 +1,563 @@
+export const LiveDataMasking = () => {
+  const FONTS_URL =
+    "https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;0,9..40,800&family=JetBrains+Mono:wght@400;500&family=Sora:wght@600;700;800&display=swap";
+
+  const C = {
+    nearBlack: "#111111",
+    strong: "#333333",
+    body: "#555555",
+    secondary: "#777777",
+    muted: "#999999",
+    bronze: "var(--bronze)",
+    bronzeDark: "var(--bronze-dark)",
+    espresso: "var(--gradient-dark-mid)",
+    warmGold: "var(--warm-gold)",
+    sand100: "var(--sand-100)",
+    sand200: "var(--sand-200)",
+    sand300: "var(--sand-300)",
+    sand400: "var(--sand-400)",
+    sand500: "var(--sand-500)",
+  };
+
+  const ROWS = [
+    {
+      name: "Sarah Chen",
+      email: "sarah.chen@acme.io",
+      ssn: "284-19-7653",
+      phone: "+1 415-892-3041",
+      avatar: "SC",
+    },
+    {
+      name: "Marcus Webb",
+      email: "m.webb@globex.com",
+      ssn: "531-77-0294",
+      phone: "+1 212-555-8817",
+      avatar: "MW",
+    },
+    {
+      name: "Elena Ruiz",
+      email: "eruiz@initech.co",
+      ssn: "719-42-8106",
+      phone: "+44 20-7946-0958",
+      avatar: "ER",
+    },
+    {
+      name: "James Okafor",
+      email: "j.okafor@stark.dev",
+      ssn: "603-88-1542",
+      phone: "+1 650-331-7720",
+      avatar: "JO",
+    },
+  ];
+
+  const FIELDS = ["name", "email", "ssn", "phone"];
+
+  const MASK_LABELS = {
+    name: "[PERSON]",
+    email: "[EMAIL]",
+    ssn: "[SSN]",
+    phone: "[PHONE]",
+  };
+
+  const DETECTION_LABELS = {
+    name: "PII detected",
+    email: "Email pattern",
+    ssn: "Gov. ID detected",
+    phone: "Phone number",
+  };
+
+  const QUERY = "SELECT name, email, ssn, phone FROM customers LIMIT 4;";
+
+  const ROW_STAGGER = 900;
+  const SCAN_START = 400;
+  const CELL_MASK_START = 500;
+  const CELL_MASK_STAGGER = 120;
+  const DETECTION_SHOW = 80;
+  const DETECTION_DURATION = 900;
+  const SCAN_DURATION = 700;
+
+  function QueryHighlight({ text, chars }) {
+    const visible = text.slice(0, chars);
+    const keywords = /\b(SELECT|FROM|LIMIT)\b/g;
+    const parts = [];
+    let lastIdx = 0;
+    let m;
+    while ((m = keywords.exec(visible)) !== null) {
+      if (m.index > lastIdx) parts.push({ t: visible.slice(lastIdx, m.index), kw: false });
+      parts.push({ t: m[0], kw: true });
+      lastIdx = keywords.lastIndex;
+    }
+    if (lastIdx < visible.length) parts.push({ t: visible.slice(lastIdx), kw: false });
+
+    return (
+      <>
+        {parts.map((p, i) => (
+          <span key={i} style={{ color: p.kw ? "rgba(var(--sand-100-rgb),0.12)" : "var(--sand-300)" }}>{p.t}</span>
+        ))}
+      </>
+    );
+  }
+
+  function ShieldIcon({ active, done }) {
+    return (
+      <svg width="18" height="18" viewBox="0 0 20 20" fill="none" style={{
+        animation: done ? "shieldIn 0.5s ease-out" : undefined,
+        opacity: active ? 1 : 0.3, transition: "opacity 0.4s ease",
+      }}>
+        <path d="M10 2L3 5.5V10C3 14.5 6 17.5 10 19C14 17.5 17 14.5 17 10V5.5L10 2Z"
+          fill={done ? "rgba(var(--warm-gold-rgb),0.15)" : "rgba(var(--sand-100-rgb),0.05)"}
+          stroke={done ? "var(--warm-gold)" : "rgba(var(--sand-100-rgb),0.15)"} strokeWidth="1.2" />
+        {done && (
+          <path d="M7 10.5L9 12.5L13 8" stroke="var(--warm-gold)" strokeWidth="1.5"
+            strokeLinecap="round" strokeLinejoin="round" />
+        )}
+      </svg>
+    );
+  }
+
+  function PhaseBadge({ phase }) {
+    const map = {
+      idle: { label: "Ready", gold: false },
+      typing: { label: "Composing", gold: false },
+      executing: { label: "Querying", gold: false },
+      streaming: { label: "Intercepting", gold: true },
+      done: { label: "Protected", gold: true },
+    };
+    const c = map[phase] || map.idle;
+
+    return (
+      <span style={{
+        fontFamily: "'DM Sans', sans-serif", fontSize: 10, fontWeight: 600,
+        textTransform: "uppercase", letterSpacing: "0.06em",
+        color: c.gold ? C.warmGold : "rgba(var(--sand-100-rgb),0.18)",
+        background: c.gold ? "rgba(var(--warm-gold-rgb),0.10)" : "rgba(var(--sand-100-rgb),0.04)",
+        padding: "2px 8px", borderRadius: 99, transition: "all 0.3s ease",
+      }}>{c.label}</span>
+    );
+  }
+
+  const [phase, setPhase] = useState("idle");
+  const [typedChars, setTypedChars] = useState(0);
+  const [rowStates, setRowStates] = useState(ROWS.map(() => "hidden"));
+  const [maskedCells, setMaskedCells] = useState(new Set());
+  const [detections, setDetections] = useState(new Set());
+  const [scanProgress, setScanProgress] = useState(ROWS.map(() => -1));
+  const [allDone, setAllDone] = useState(false);
+
+  const timeouts = useRef([]);
+  const intervals = useRef([]);
+
+  const clearAll = useCallback(() => {
+    timeouts.current.forEach(clearTimeout);
+    intervals.current.forEach(clearInterval);
+    timeouts.current = [];
+    intervals.current = [];
+  }, []);
+
+  const later = useCallback((fn, ms) => {
+    const id = setTimeout(fn, ms);
+    timeouts.current.push(id);
+    return id;
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const runCycle = () => {
+      if (cancelled) return;
+
+      setPhase("idle");
+      setTypedChars(0);
+      setRowStates(ROWS.map(() => "hidden"));
+      setMaskedCells(new Set());
+      setDetections(new Set());
+      setScanProgress(ROWS.map(() => -1));
+      setAllDone(false);
+
+      // Typing
+      later(() => {
+        if (cancelled) return;
+        setPhase("typing");
+        let ci = 0;
+        const iv = setInterval(() => {
+          if (cancelled) { clearInterval(iv); return; }
+          ci++;
+          setTypedChars(ci);
+          if (ci >= QUERY.length) clearInterval(iv);
+        }, 2000 / QUERY.length);
+        intervals.current.push(iv);
+      }, 600);
+
+      // Executing
+      const execAt = 600 + 2000 + 200;
+      later(() => {
+        if (cancelled) return;
+        setPhase("executing");
+      }, execAt);
+
+      // Streaming with in-transit masking
+      const streamAt = execAt + 1000;
+      later(() => {
+        if (cancelled) return;
+        setPhase("streaming");
+
+        ROWS.forEach((_, rowIdx) => {
+          const t0 = rowIdx * ROW_STAGGER;
+
+          // Row appears (raw)
+          later(() => {
+            if (cancelled) return;
+            setRowStates((p) => { const n = [...p]; n[rowIdx] = "raw"; return n; });
+          }, t0);
+
+          // Scan starts
+          later(() => {
+            if (cancelled) return;
+            setRowStates((p) => { const n = [...p]; n[rowIdx] = "scanning"; return n; });
+            let step = 0;
+            const steps = 30;
+            const iv = setInterval(() => {
+              if (cancelled) { clearInterval(iv); return; }
+              step++;
+              const prog = Math.min(step / steps, 1);
+              setScanProgress((p) => { const n = [...p]; n[rowIdx] = prog; return n; });
+              if (step >= steps) clearInterval(iv);
+            }, SCAN_DURATION / steps);
+            intervals.current.push(iv);
+          }, t0 + SCAN_START);
+
+          // Mask cells as scan sweeps
+          FIELDS.forEach((field, colIdx) => {
+            const maskAt = t0 + CELL_MASK_START + colIdx * CELL_MASK_STAGGER;
+
+            later(() => {
+              if (cancelled) return;
+              setMaskedCells((p) => { const n = new Set(p); n.add(`${rowIdx}-${field}`); return n; });
+            }, maskAt);
+
+            later(() => {
+              if (cancelled) return;
+              const key = `${rowIdx}-${field}`;
+              setDetections((p) => { const n = new Set(p); n.add(key); return n; });
+              later(() => {
+                if (cancelled) return;
+                setDetections((p) => { const n = new Set(p); n.delete(key); return n; });
+              }, DETECTION_DURATION);
+            }, maskAt + DETECTION_SHOW);
+          });
+
+          // Row done
+          const rowDone = t0 + CELL_MASK_START + FIELDS.length * CELL_MASK_STAGGER + 200;
+          later(() => {
+            if (cancelled) return;
+            setRowStates((p) => { const n = [...p]; n[rowIdx] = "masked"; return n; });
+            setScanProgress((p) => { const n = [...p]; n[rowIdx] = -1; return n; });
+          }, rowDone);
+        });
+
+        // All done
+        const total = (ROWS.length - 1) * ROW_STAGGER + CELL_MASK_START + FIELDS.length * CELL_MASK_STAGGER + 500;
+        later(() => {
+          if (cancelled) return;
+          setPhase("done");
+          setAllDone(true);
+        }, total);
+
+        later(() => {
+          if (cancelled) return;
+          runCycle();
+        }, total + 3000);
+      }, streamAt);
+    };
+
+    runCycle();
+    return () => { cancelled = true; clearAll(); };
+  }, [later, clearAll]);
+
+  const isAfter = (target) => {
+    const order = ["idle", "typing", "executing", "streaming", "done"];
+    return order.indexOf(phase) >= order.indexOf(target);
+  };
+
+  return (
+    <>
+      <link rel="stylesheet" href={FONTS_URL} />
+      <style>{`
+        @keyframes cursorBlink {
+          0%, 100% { opacity: 1; } 50% { opacity: 0; }
+        }
+        @keyframes dotPulse {
+          0%, 80%, 100% { opacity: 0.2; transform: scale(0.8); }
+          40% { opacity: 1; transform: scale(1); }
+        }
+        @keyframes maskFlip {
+          0% { opacity: 0; transform: scaleX(0.7); filter: blur(3px); }
+          60% { opacity: 1; transform: scaleX(1.03); filter: blur(0); }
+          100% { opacity: 1; transform: scaleX(1); filter: blur(0); }
+        }
+        @keyframes detectionFloat {
+          0% { opacity: 0; transform: translateY(4px) scale(0.9); }
+          20% { opacity: 1; transform: translateY(-2px) scale(1); }
+          80% { opacity: 1; transform: translateY(-2px) scale(1); }
+          100% { opacity: 0; transform: translateY(-8px) scale(0.95); }
+        }
+        @keyframes shieldIn {
+          0% { opacity: 0; transform: scale(0.6); }
+          60% { opacity: 1; transform: scale(1.08); }
+          100% { opacity: 1; transform: scale(1); }
+        }
+        @keyframes statusPulse {
+          0%, 100% { opacity: 0.5; } 50% { opacity: 1; }
+        }
+        @keyframes glowPulse {
+          0%, 100% { box-shadow: 0 0 0 0 rgba(var(--warm-gold-rgb),0); }
+          50% { box-shadow: 0 0 16px 2px rgba(var(--warm-gold-rgb),0.12); }
+        }
+      `}</style>
+
+      <div
+        style={{
+          background: "linear-gradient(135deg, var(--gradient-dark-start) 0%, var(--gradient-dark-mid) 35%, var(--gradient-dark-end) 70%, var(--bronze) 100%)",
+          borderRadius: 14,
+          padding: "32px 36px 28px",
+          fontFamily: "'DM Sans', system-ui, sans-serif",
+          position: "relative",
+          overflow: "hidden",
+          maxWidth: 720,
+          margin: "0 auto",
+          height: 520,
+        }}
+      >
+        {/* Radial glow */}
+        <div style={{
+          position: "absolute", top: "-30%", right: "-10%", width: "60%", height: "160%",
+          background: "radial-gradient(ellipse at center, rgba(var(--warm-gold-rgb),0.12) 0%, transparent 70%)",
+          pointerEvents: "none",
+        }} />
+
+        {/* Header */}
+        <div style={{
+          display: "flex", alignItems: "center", justifyContent: "space-between",
+          marginBottom: 18, position: "relative", zIndex: 1,
+        }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+            <ShieldIcon done={allDone} active={isAfter("streaming")} />
+            <span style={{
+              fontFamily: "'Sora', sans-serif", fontSize: 14, fontWeight: 600,
+              color: C.sand100, letterSpacing: "-0.01em",
+            }}>
+              Live Data Masking
+            </span>
+            <PhaseBadge phase={phase} />
+          </div>
+          <div style={{ display: "flex", gap: 6 }}>
+            {[0, 1, 2].map((i) => (
+              <div key={i} style={{
+                width: 8, height: 8, borderRadius: "50%", background: "rgba(var(--sand-100-rgb),0.10)",
+              }} />
+            ))}
+          </div>
+        </div>
+
+        {/* Query input */}
+        <div style={{
+          background: "rgba(var(--sand-100-rgb),0.03)", border: "1px solid rgba(var(--sand-100-rgb),0.06)",
+          borderRadius: 8, padding: "13px 16px", marginBottom: 14,
+          position: "relative", zIndex: 1, minHeight: 42, display: "flex", alignItems: "center",
+        }}>
+          <span style={{
+            fontFamily: "'JetBrains Mono', monospace", fontSize: 13,
+            color: "rgba(var(--sand-100-rgb),0.25)", marginRight: 10, userSelect: "none",
+          }}>&gt;</span>
+          <span style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: 13, lineHeight: 1.5 }}>
+            {isAfter("typing") ? (
+              <QueryHighlight text={QUERY} chars={phase === "typing" ? typedChars : QUERY.length} />
+            ) : (
+              <span style={{ color: "rgba(var(--sand-100-rgb),0.15)" }}>Enter a query...</span>
+            )}
+            {(phase === "typing" || phase === "idle") && (
+              <span style={{
+                display: "inline-block", width: 2, height: 14, background: C.warmGold,
+                marginLeft: 1, verticalAlign: "text-bottom", animation: "cursorBlink 1s infinite",
+              }} />
+            )}
+          </span>
+          {phase === "executing" && (
+            <span style={{ marginLeft: "auto", display: "flex", gap: 4, alignItems: "center" }}>
+              {[0, 1, 2].map((i) => (
+                <span key={i} style={{
+                  width: 5, height: 5, borderRadius: "50%", background: C.warmGold,
+                  animation: `dotPulse 1.2s ${i * 0.2}s infinite`,
+                }} />
+              ))}
+            </span>
+          )}
+        </div>
+
+        {/* Results table (always rendered, opacity controlled) */}
+        <div style={{
+          background: isAfter("streaming") ? "rgba(var(--sand-100-rgb),0.04)" : "transparent",
+          border: isAfter("streaming") ? "1px solid rgba(var(--sand-100-rgb),0.08)" : "1px solid transparent",
+          borderRadius: 10, overflow: "hidden", position: "relative", zIndex: 1,
+          opacity: isAfter("streaming") ? 1 : 0,
+          transition: "opacity 0.4s ease, background 0.4s ease, border-color 0.4s ease",
+          animation: allDone ? "glowPulse 2s ease-in-out" : undefined,
+        }}>
+          {/* Column headers */}
+          <div style={{
+            display: "grid", gridTemplateColumns: "32px 1.2fr 1.4fr 1fr 1.1fr",
+            padding: "9px 14px", borderBottom: "1px solid rgba(var(--sand-100-rgb),0.06)",
+            background: "rgba(var(--sand-100-rgb),0.02)",
+          }}>
+            <span />
+            {FIELDS.map((col) => (
+              <span key={col} style={{
+                fontFamily: "'JetBrains Mono', monospace", fontSize: 10, fontWeight: 500,
+                color: "rgba(var(--sand-100-rgb),0.20)", textTransform: "uppercase", letterSpacing: "0.08em",
+              }}>{col}</span>
+            ))}
+          </div>
+
+          {/* Data rows */}
+          {ROWS.map((row, rowIdx) => {
+            const state = rowStates[rowIdx];
+            const isVisible = state !== "hidden";
+            const isScanning = state === "scanning";
+            const progress = scanProgress[rowIdx];
+
+            return (
+              <div key={rowIdx} style={{
+                display: "grid", gridTemplateColumns: "32px 1.2fr 1.4fr 1fr 1.1fr",
+                padding: "10px 14px",
+                borderBottom: rowIdx < ROWS.length - 1 ? "1px solid rgba(var(--sand-100-rgb),0.04)" : "none",
+                opacity: isVisible ? 1 : 0,
+                transform: isVisible ? "translateX(0)" : "translateX(-6px)",
+                transition: "opacity 0.3s ease, transform 0.3s ease",
+                position: "relative",
+                background: isScanning ? "rgba(var(--warm-gold-rgb),0.04)" : "transparent",
+              }}>
+                {/* Scan line */}
+                {isScanning && progress >= 0 && (
+                  <div style={{
+                    position: "absolute", top: 0, left: `${progress * 100}%`,
+                    width: 2, height: "100%", background: C.warmGold,
+                    boxShadow: "0 0 12px 3px rgba(var(--warm-gold-rgb),0.3), -20px 0 30px 8px rgba(var(--warm-gold-rgb),0.08)",
+                    zIndex: 3, transition: "left 23ms linear",
+                  }} />
+                )}
+                {/* Scan glow trail */}
+                {isScanning && progress >= 0 && (
+                  <div style={{
+                    position: "absolute", top: 0, left: 0, width: `${progress * 100}%`, height: "100%",
+                    background: "linear-gradient(90deg, transparent 60%, rgba(var(--warm-gold-rgb),0.05) 100%)",
+                    zIndex: 2, pointerEvents: "none",
+                  }} />
+                )}
+
+                {/* Avatar */}
+                <div style={{
+                  width: 22, height: 22, borderRadius: "50%", background: "rgba(var(--sand-100-rgb),0.06)",
+                  display: "flex", alignItems: "center", justifyContent: "center",
+                  fontFamily: "'DM Sans', sans-serif", fontSize: 8, fontWeight: 600,
+                  color: "rgba(var(--sand-100-rgb),0.30)", zIndex: 4,
+                }}>{row.avatar}</div>
+
+                {/* Data cells */}
+                {FIELDS.map((field) => {
+                  const cellKey = `${rowIdx}-${field}`;
+                  const isMasked = maskedCells.has(cellKey);
+                  const showDetection = detections.has(cellKey);
+
+                  return (
+                    <div key={field} style={{
+                      display: "flex", alignItems: "center", minHeight: 22,
+                      overflow: "visible", position: "relative", zIndex: 4,
+                    }}>
+                      {isMasked ? (
+                        <span style={{
+                          fontFamily: "'JetBrains Mono', monospace", fontSize: 11.5,
+                          fontWeight: 600, color: C.warmGold,
+                          animation: "maskFlip 0.35s ease-out forwards",
+                          display: "inline-block", whiteSpace: "nowrap",
+                        }}>{MASK_LABELS[field]}</span>
+                      ) : (
+                        <span style={{
+                          fontFamily: "'JetBrains Mono', monospace", fontSize: 11.5,
+                          fontWeight: 400,
+                          color: state === "raw" ? "rgba(var(--sand-100-rgb),0.35)" : "rgba(var(--sand-100-rgb),0.55)",
+                          whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis",
+                          transition: "color 0.2s ease",
+                        }}>{row[field]}</span>
+                      )}
+
+                      {/* Detection label */}
+                      {showDetection && (
+                        <span style={{
+                          position: "absolute", top: -18, left: 0,
+                          fontFamily: "'DM Sans', sans-serif", fontSize: 9, fontWeight: 600,
+                          color: C.warmGold, background: "rgba(var(--espresso-rgb),0.92)",
+                          border: "1px solid rgba(var(--warm-gold-rgb),0.25)",
+                          padding: "1px 7px", borderRadius: 4, whiteSpace: "nowrap",
+                          animation: `detectionFloat ${DETECTION_DURATION}ms ease-out forwards`,
+                          zIndex: 10, pointerEvents: "none", letterSpacing: "0.02em",
+                        }}>{DETECTION_LABELS[field]}</span>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            );
+          })}
+
+          {/* Footer */}
+          <div style={{
+            padding: "9px 14px", borderTop: "1px solid rgba(var(--sand-100-rgb),0.06)",
+            display: "flex", alignItems: "center", justifyContent: "space-between", minHeight: 32,
+          }}>
+            <span style={{
+              fontFamily: "'DM Sans', sans-serif", fontSize: 11, color: "rgba(var(--sand-100-rgb),0.20)",
+            }}>
+              {allDone ? "4 rows returned, 16 fields masked"
+                : phase === "streaming" ? "Intercepting results..."
+                : "\u00A0"}
+            </span>
+            {phase === "streaming" && !allDone && (
+              <span style={{
+                fontFamily: "'JetBrains Mono', monospace", fontSize: 10,
+                color: C.warmGold, animation: "statusPulse 1s infinite",
+              }}>In-transit masking</span>
+            )}
+            {allDone && (
+              <span style={{
+                fontFamily: "'JetBrains Mono', monospace", fontSize: 10, fontWeight: 500,
+                color: C.warmGold, display: "flex", alignItems: "center", gap: 5,
+              }}>
+                <svg width="10" height="10" viewBox="0 0 16 16" fill="none">
+                  <path d="M3 8.5L6.5 12L13 4" stroke={C.warmGold} strokeWidth="2"
+                    strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+                Zero-config protection
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Compliance tags (always rendered) */}
+        <div style={{
+          display: "flex", gap: 8, marginTop: 12, position: "relative", zIndex: 1,
+          opacity: allDone ? 1 : 0, transform: allDone ? "translateY(0)" : "translateY(4px)",
+          transition: "opacity 0.5s ease, transform 0.5s ease", height: 20,
+        }}>
+          {["No schema required", "GDPR", "HIPAA", "PCI DSS"].map((tag) => (
+            <span key={tag} style={{
+              fontFamily: "'DM Sans', sans-serif", fontSize: 10, fontWeight: 600,
+              textTransform: "uppercase", color: "rgba(var(--sand-100-rgb),0.25)",
+              background: "rgba(var(--sand-100-rgb),0.04)", padding: "2px 8px",
+              borderRadius: 99, letterSpacing: "0.04em",
+            }}>{tag}</span>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/snippets/annimations/datamaskingshield.jsx
+++ b/snippets/annimations/datamaskingshield.jsx
@@ -1,0 +1,403 @@
+export const PipelineFlow = () => {
+  const FONTS_URL =
+    "https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;0,9..40,800&family=JetBrains+Mono:wght@400;500&family=Sora:wght@600;700;800&display=swap";
+
+  const C = {
+    espresso: "var(--gradient-dark-mid)",
+    warmGold: "var(--warm-gold)",
+    sand100: "var(--sand-100)",
+    sand300: "var(--sand-300)",
+    sand500: "var(--sand-500)",
+  };
+
+  const PACKETS = [
+    { raw: "Sarah Chen, sarah.chen@acme.io, 284-19-7653", masked: "[PERSON], [EMAIL], [SSN]", label: "PII + Gov. ID" },
+    { raw: "Marcus Webb, m.webb@globex.com, 531-77-0294", masked: "[PERSON], [EMAIL], [SSN]", label: "PII + Gov. ID" },
+    { raw: "Elena Ruiz, eruiz@initech.co, 719-42-8106", masked: "[PERSON], [EMAIL], [SSN]", label: "PII + Gov. ID" },
+    { raw: "James Okafor, j.okafor@stark.dev, 603-88-1542", masked: "[PERSON], [EMAIL], [SSN]", label: "PII + Gov. ID" },
+  ];
+
+  const PACKET_DELAY = 900;
+
+  function ZoneLabel({ children, icon, center, right }) {
+    const icons = {
+      db: (
+        <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
+          <ellipse cx="8" cy="4" rx="5.5" ry="2.5" stroke="rgba(var(--sand-100-rgb),0.25)" strokeWidth="1" />
+          <path d="M2.5 4v8c0 1.38 2.46 2.5 5.5 2.5s5.5-1.12 5.5-2.5V4" stroke="rgba(var(--sand-100-rgb),0.25)" strokeWidth="1" />
+          <path d="M2.5 8c0 1.38 2.46 2.5 5.5 2.5s5.5-1.12 5.5-2.5" stroke="rgba(var(--sand-100-rgb),0.15)" strokeWidth="1" />
+        </svg>
+      ),
+      shield: (
+        <svg width="12" height="12" viewBox="0 0 20 20" fill="none">
+          <path d="M10 2L3 5.5V10C3 14.5 6 17.5 10 19C14 17.5 17 14.5 17 10V5.5L10 2Z"
+            stroke="var(--warm-gold)" strokeWidth="1.2" fill="none" />
+        </svg>
+      ),
+      user: (
+        <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
+          <circle cx="8" cy="5" r="3" stroke="rgba(var(--sand-100-rgb),0.25)" strokeWidth="1" />
+          <path d="M2 14c0-2.76 2.69-5 6-5s6 2.24 6 5" stroke="rgba(var(--sand-100-rgb),0.25)" strokeWidth="1" />
+        </svg>
+      ),
+    };
+
+    return (
+      <div style={{
+        display: "flex", alignItems: "center", gap: 5,
+        justifyContent: center ? "center" : right ? "flex-end" : "flex-start",
+      }}>
+        {icons[icon]}
+        <span style={{
+          fontFamily: "'JetBrains Mono', monospace", fontSize: 9, fontWeight: 500,
+          color: icon === "shield" ? "rgba(var(--warm-gold-rgb),0.5)" : "rgba(var(--sand-100-rgb),0.25)",
+          textTransform: "uppercase", letterSpacing: "0.08em",
+        }}>{children}</span>
+      </div>
+    );
+  }
+
+  function ShieldIcon({ active, done }) {
+    return (
+      <svg width="18" height="18" viewBox="0 0 20 20" fill="none" style={{
+        animation: done ? "shieldIn 0.5s ease-out" : undefined,
+        opacity: active ? 1 : 0.3, transition: "opacity 0.4s ease",
+      }}>
+        <path d="M10 2L3 5.5V10C3 14.5 6 17.5 10 19C14 17.5 17 14.5 17 10V5.5L10 2Z"
+          fill={done ? "rgba(var(--warm-gold-rgb),0.15)" : "rgba(var(--sand-100-rgb),0.05)"}
+          stroke={done ? "var(--warm-gold)" : "rgba(var(--sand-100-rgb),0.15)"} strokeWidth="1.2" />
+        {done && (
+          <path d="M7 10.5L9 12.5L13 8" stroke="var(--warm-gold)" strokeWidth="1.5"
+            strokeLinecap="round" strokeLinejoin="round" />
+        )}
+      </svg>
+    );
+  }
+
+  // Per-packet: "hidden" | "lane1" | "gateway" | "lane2" | "arrived"
+  const [packetStates, setPacketStates] = useState(PACKETS.map(() => "hidden"));
+  const [gatewayFlash, setGatewayFlash] = useState(-1);
+  const [allDone, setAllDone] = useState(false);
+  const [detectionLabel, setDetectionLabel] = useState("");
+  const timeouts = useRef([]);
+
+  const clearAll = useCallback(() => {
+    timeouts.current.forEach(clearTimeout);
+    timeouts.current = [];
+  }, []);
+
+  const later = useCallback((fn, ms) => {
+    const id = setTimeout(fn, ms);
+    timeouts.current.push(id);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const cycle = () => {
+      if (cancelled) return;
+      setPacketStates(PACKETS.map(() => "hidden"));
+      setGatewayFlash(-1);
+      setAllDone(false);
+      setDetectionLabel("");
+
+      PACKETS.forEach((pkt, i) => {
+        const t0 = 600 + i * PACKET_DELAY;
+
+        // Packet enters lane 1 (raw, traveling toward gateway)
+        later(() => {
+          if (cancelled) return;
+          setPacketStates(p => { const n = [...p]; n[i] = "lane1"; return n; });
+        }, t0);
+
+        // Packet hits gateway (transform moment)
+        later(() => {
+          if (cancelled) return;
+          setPacketStates(p => { const n = [...p]; n[i] = "gateway"; return n; });
+          setGatewayFlash(i);
+          setDetectionLabel(pkt.label);
+        }, t0 + 600);
+
+        // Packet exits gateway into lane 2 (masked)
+        later(() => {
+          if (cancelled) return;
+          setPacketStates(p => { const n = [...p]; n[i] = "lane2"; return n; });
+          setDetectionLabel("");
+        }, t0 + 1100);
+
+        // Packet arrives
+        later(() => {
+          if (cancelled) return;
+          setPacketStates(p => { const n = [...p]; n[i] = "arrived"; return n; });
+          setGatewayFlash(-1);
+        }, t0 + 1600);
+      });
+
+      const total = 600 + (PACKETS.length - 1) * PACKET_DELAY + 1800;
+      later(() => { if (!cancelled) setAllDone(true); }, total);
+      later(() => { if (!cancelled) cycle(); }, total + 3000);
+    };
+
+    cycle();
+    return () => { cancelled = true; clearAll(); };
+  }, [later, clearAll]);
+
+  const anyActive = packetStates.some(s => s !== "hidden");
+
+  return (
+    <>
+      <link rel="stylesheet" href={FONTS_URL} />
+      <style>{`
+        @keyframes slideRight {
+          from { opacity: 0; transform: translateX(-20px); }
+          to { opacity: 1; transform: translateX(0); }
+        }
+        @keyframes gatewayPulse {
+          0% { box-shadow: 0 0 0 0 rgba(var(--warm-gold-rgb),0); }
+          50% { box-shadow: 0 0 20px 6px rgba(var(--warm-gold-rgb),0.25); }
+          100% { box-shadow: 0 0 0 0 rgba(var(--warm-gold-rgb),0); }
+        }
+        @keyframes packetGlow {
+          0% { opacity: 0; transform: scale(0.8); }
+          40% { opacity: 1; transform: scale(1.05); }
+          100% { opacity: 1; transform: scale(1); }
+        }
+        @keyframes detectionPop {
+          0% { opacity: 0; transform: translateY(6px) scale(0.85); }
+          30% { opacity: 1; transform: translateY(0) scale(1); }
+          80% { opacity: 1; transform: translateY(0) scale(1); }
+          100% { opacity: 0; transform: translateY(-4px) scale(0.95); }
+        }
+        @keyframes shieldIn {
+          0% { opacity:0; transform:scale(0.6); }
+          60% { opacity:1; transform:scale(1.08); }
+          100% { opacity:1; transform:scale(1); }
+        }
+        @keyframes dotTravel {
+          0% { opacity: 0; }
+          20% { opacity: 0.6; }
+          80% { opacity: 0.6; }
+          100% { opacity: 0; }
+        }
+      `}</style>
+
+      <div style={{
+        background: "linear-gradient(135deg, var(--gradient-dark-start) 0%, var(--gradient-dark-mid) 35%, var(--gradient-dark-end) 70%, var(--bronze) 100%)",
+        borderRadius: 14, padding: "32px 32px 28px",
+        fontFamily: "'DM Sans', system-ui, sans-serif",
+        position: "relative", overflow: "hidden", maxWidth: 760, margin: "0 auto",
+      }}>
+        <div style={{
+          position: "absolute", top: "-30%", right: "-10%", width: "60%", height: "160%",
+          background: "radial-gradient(ellipse at center, rgba(var(--warm-gold-rgb),0.12) 0%, transparent 70%)",
+          pointerEvents: "none",
+        }} />
+
+        {/* Header */}
+        <div style={{
+          display: "flex", alignItems: "center", gap: 10,
+          marginBottom: 24, position: "relative", zIndex: 1,
+        }}>
+          <ShieldIcon done={allDone} active={anyActive} />
+          <span style={{
+            fontFamily: "'Sora', sans-serif", fontSize: 14, fontWeight: 600,
+            color: C.sand100, letterSpacing: "-0.01em",
+          }}>Live Data Masking</span>
+          <span style={{
+            fontFamily: "'DM Sans', sans-serif", fontSize: 10, fontWeight: 600,
+            textTransform: "uppercase", letterSpacing: "0.06em",
+            color: allDone ? C.warmGold : anyActive ? C.warmGold : "rgba(var(--sand-100-rgb),0.18)",
+            background: allDone ? "rgba(var(--warm-gold-rgb),0.10)" : anyActive ? "rgba(var(--warm-gold-rgb),0.10)" : "rgba(var(--sand-100-rgb),0.04)",
+            padding: "2px 8px", borderRadius: 99, transition: "all 0.3s ease",
+          }}>{allDone ? "Protected" : anyActive ? "Intercepting" : "Ready"}</span>
+        </div>
+
+        {/* Pipeline visualization */}
+        <div style={{ position: "relative", zIndex: 1 }}>
+
+          {/* Three zone headers */}
+          <div style={{
+            display: "grid", gridTemplateColumns: "1fr 100px 1fr", gap: 0,
+            marginBottom: 12,
+          }}>
+            <ZoneLabel icon="db">Database</ZoneLabel>
+            <ZoneLabel icon="shield" center>Hoop Gateway</ZoneLabel>
+            <ZoneLabel icon="user" right>User terminal</ZoneLabel>
+          </div>
+
+          {/* Pipeline lanes */}
+          <div style={{
+            display: "grid", gridTemplateColumns: "1fr 100px 1fr", gap: 0,
+            minHeight: 240,
+          }}>
+            {/* Left lane: raw packets */}
+            <div style={{
+              background: "rgba(var(--sand-100-rgb),0.03)",
+              border: "1px solid rgba(var(--sand-100-rgb),0.06)",
+              borderRadius: "8px 0 0 8px",
+              borderRight: "none",
+              padding: "8px 10px",
+              display: "flex", flexDirection: "column", gap: 6,
+            }}>
+              {PACKETS.map((pkt, i) => {
+                const st = packetStates[i];
+                const show = st === "lane1";
+                const faded = st === "gateway" || st === "lane2" || st === "arrived";
+                return (
+                  <div key={i} style={{
+                    background: show ? "rgba(var(--sand-100-rgb),0.04)" : "transparent",
+                    border: show ? "1px solid rgba(var(--sand-100-rgb),0.08)" : "1px solid transparent",
+                    borderRadius: 6, padding: "7px 10px", minHeight: 48,
+                    opacity: show ? 1 : faded ? 0.1 : 0,
+                    transform: show ? "translateX(0)" : faded ? "translateX(0)" : "translateX(-12px)",
+                    transition: "all 0.35s ease",
+                  }}>
+                    <div style={{
+                      fontFamily: "'JetBrains Mono', monospace", fontSize: 10.5,
+                      color: "rgba(var(--sand-100-rgb),0.50)", whiteSpace: "nowrap",
+                      overflow: "hidden", textOverflow: "ellipsis",
+                    }}>{pkt.raw}</div>
+                    <div style={{
+                      fontFamily: "'DM Sans', sans-serif", fontSize: 9,
+                      color: "rgba(var(--sand-100-rgb),0.20)", marginTop: 3,
+                    }}>Unmasked row {i + 1}</div>
+                  </div>
+                );
+              })}
+            </div>
+
+            {/* Center: gateway */}
+            <div style={{
+              background: "rgba(var(--sand-100-rgb),0.02)",
+              borderTop: "1px solid rgba(var(--sand-100-rgb),0.06)",
+              borderBottom: "1px solid rgba(var(--sand-100-rgb),0.06)",
+              display: "flex", flexDirection: "column",
+              alignItems: "center", justifyContent: "center",
+              position: "relative",
+            }}>
+              {/* Gateway core */}
+              <div style={{
+                width: 52, height: 52, borderRadius: 12,
+                background: gatewayFlash >= 0
+                  ? "rgba(var(--warm-gold-rgb),0.12)"
+                  : "rgba(var(--sand-100-rgb),0.04)",
+                border: `1.5px solid ${gatewayFlash >= 0 ? C.warmGold : "rgba(var(--sand-100-rgb),0.10)"}`,
+                display: "flex", alignItems: "center", justifyContent: "center",
+                transition: "all 0.2s ease",
+                animation: gatewayFlash >= 0 ? "gatewayPulse 0.5s ease-out" : undefined,
+              }}>
+                <svg width="22" height="22" viewBox="0 0 20 20" fill="none">
+                  <path d="M10 2L3 5.5V10C3 14.5 6 17.5 10 19C14 17.5 17 14.5 17 10V5.5L10 2Z"
+                    fill={gatewayFlash >= 0 ? "rgba(var(--warm-gold-rgb),0.25)" : "rgba(var(--sand-100-rgb),0.06)"}
+                    stroke={gatewayFlash >= 0 ? C.warmGold : "rgba(var(--sand-100-rgb),0.20)"}
+                    strokeWidth="1.2" />
+                  {gatewayFlash >= 0 && (
+                    <path d="M7 10.5L9 12.5L13 8" stroke={C.warmGold} strokeWidth="1.5"
+                      strokeLinecap="round" strokeLinejoin="round" />
+                  )}
+                </svg>
+              </div>
+
+              {/* Detection label */}
+              <div style={{
+                marginTop: 8, minHeight: 20,
+                display: "flex", alignItems: "center", justifyContent: "center",
+              }}>
+                {detectionLabel && (
+                  <span style={{
+                    fontFamily: "'DM Sans', sans-serif", fontSize: 9, fontWeight: 600,
+                    color: C.warmGold, background: "rgba(var(--espresso-rgb),0.95)",
+                    border: "1px solid rgba(var(--warm-gold-rgb),0.3)",
+                    padding: "2px 8px", borderRadius: 4, whiteSpace: "nowrap",
+                    animation: "detectionPop 0.8s ease-out forwards",
+                  }}>{detectionLabel}</span>
+                )}
+              </div>
+
+              {/* Connector dots (left) */}
+              <div style={{
+                position: "absolute", left: -6, top: "50%", transform: "translateY(-50%)",
+                display: "flex", flexDirection: "column", gap: 4,
+              }}>
+                {[0, 1, 2].map(j => (
+                  <div key={j} style={{
+                    width: 4, height: 4, borderRadius: "50%",
+                    background: gatewayFlash >= 0 ? C.warmGold : "rgba(var(--sand-100-rgb),0.15)",
+                    transition: "background 0.2s ease",
+                    opacity: gatewayFlash >= 0 ? 1 : 0.5,
+                  }} />
+                ))}
+              </div>
+              {/* Connector dots (right) */}
+              <div style={{
+                position: "absolute", right: -6, top: "50%", transform: "translateY(-50%)",
+                display: "flex", flexDirection: "column", gap: 4,
+              }}>
+                {[0, 1, 2].map(j => (
+                  <div key={j} style={{
+                    width: 4, height: 4, borderRadius: "50%",
+                    background: gatewayFlash >= 0 ? C.warmGold : "rgba(var(--sand-100-rgb),0.15)",
+                    transition: "background 0.2s ease",
+                    opacity: gatewayFlash >= 0 ? 1 : 0.5,
+                  }} />
+                ))}
+              </div>
+            </div>
+
+            {/* Right lane: masked packets */}
+            <div style={{
+              background: "rgba(var(--sand-100-rgb),0.03)",
+              border: "1px solid rgba(var(--sand-100-rgb),0.06)",
+              borderRadius: "0 8px 8px 0",
+              borderLeft: "none",
+              padding: "8px 10px",
+              display: "flex", flexDirection: "column", gap: 6,
+            }}>
+              {PACKETS.map((pkt, i) => {
+                const st = packetStates[i];
+                const show = st === "lane2" || st === "arrived";
+                return (
+                  <div key={i} style={{
+                    background: show ? "rgba(var(--warm-gold-rgb),0.06)" : "transparent",
+                    border: show ? "1px solid rgba(var(--warm-gold-rgb),0.12)" : "1px solid transparent",
+                    borderRadius: 6, padding: "7px 10px", minHeight: 48,
+                    opacity: show ? 1 : 0,
+                    transform: show ? "translateX(0)" : "translateX(12px)",
+                    transition: "all 0.4s ease",
+                  }}>
+                    <div style={{
+                      fontFamily: "'JetBrains Mono', monospace", fontSize: 10.5,
+                      fontWeight: 600, color: C.warmGold, whiteSpace: "nowrap",
+                      overflow: "hidden", textOverflow: "ellipsis",
+                      animation: show ? "packetGlow 0.4s ease-out" : undefined,
+                    }}>{pkt.masked}</div>
+                    <div style={{
+                      fontFamily: "'DM Sans', sans-serif", fontSize: 9,
+                      color: "rgba(var(--sand-100-rgb),0.20)", marginTop: 3,
+                    }}>Masked row {i + 1}</div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+
+        {/* Footer tags */}
+        <div style={{
+          display: "flex", gap: 8, marginTop: 16, position: "relative", zIndex: 1,
+          opacity: allDone ? 1 : 0, transform: allDone ? "translateY(0)" : "translateY(4px)",
+          transition: "opacity 0.5s ease, transform 0.5s ease", height: 20,
+        }}>
+          {["In-transit proxy", "No schema required", "GDPR", "HIPAA", "PCI DSS"].map((tag) => (
+            <span key={tag} style={{
+              fontFamily: "'DM Sans', sans-serif", fontSize: 10, fontWeight: 600,
+              textTransform: "uppercase", color: "rgba(var(--sand-100-rgb),0.25)",
+              background: "rgba(var(--sand-100-rgb),0.04)", padding: "2px 8px",
+              borderRadius: 99, letterSpacing: "0.04em",
+            }}>{tag}</span>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/snippets/annimations/guardrails.jsx
+++ b/snippets/annimations/guardrails.jsx
@@ -1,0 +1,386 @@
+export const GuardrailsAnimation = () => {
+  const QUERIES = [
+    { sql: "UPDATE users SET status = 'inactive'", blocked: true, rule: "Missing WHERE clause", type: "UPDATE" },
+    { sql: "SELECT * FROM orders LIMIT 50", blocked: false, rule: null, type: "SELECT" },
+    { sql: "DROP TABLE customers", blocked: true, rule: "Destructive DDL blocked", type: "DROP" },
+    { sql: "SELECT id, email FROM users WHERE active = true", blocked: false, rule: null, type: "SELECT" },
+    { sql: "DELETE FROM logs", blocked: true, rule: "Missing WHERE clause", type: "DELETE" },
+    { sql: "SELECT * FROM events", blocked: true, rule: "Missing LIMIT on large table", type: "SELECT" },
+    { sql: "INSERT INTO audit_log VALUES (...)", blocked: false, rule: null, type: "INSERT" },
+    { sql: "SELECT * FROM salaries", blocked: true, rule: "Restricted table access", type: "SELECT" },
+    { sql: "ALTER TABLE users DROP COLUMN ssn", blocked: true, rule: "Destructive DDL blocked", type: "ALTER" },
+    { sql: "SELECT name, role FROM team WHERE dept = 'eng'", blocked: false, rule: null, type: "SELECT" },
+  ];
+
+  const FONT_URL = "https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700&family=JetBrains+Mono:wght@400;500&family=Sora:wght@600;700;800&display=swap";
+
+  const animationStyles = `
+    @keyframes slideIn {
+      from { opacity: 0; transform: translateX(-40px); }
+      to { opacity: 1; transform: translateX(0); }
+    }
+    @keyframes slideThrough {
+      0% { opacity: 0; transform: translateX(-20px); }
+      15% { opacity: 1; transform: translateX(0); }
+      85% { opacity: 1; transform: translateX(0); }
+      100% { opacity: 0; transform: translateX(20px); }
+    }
+    @keyframes pulseShield {
+      0%, 100% { transform: scale(1); filter: drop-shadow(0 0 0px rgba(var(--bronze-rgb),0)); }
+      50% { transform: scale(1.08); filter: drop-shadow(0 0 12px rgba(var(--bronze-rgb),0.4)); }
+    }
+    @keyframes pulseShieldBlock {
+      0% { transform: scale(1); filter: drop-shadow(0 0 0px rgba(180,60,60,0)); }
+      30% { transform: scale(1.15); filter: drop-shadow(0 0 16px rgba(180,60,60,0.5)); }
+      100% { transform: scale(1); filter: drop-shadow(0 0 0px rgba(180,60,60,0)); }
+    }
+    @keyframes resultSlide {
+      from { opacity: 0; transform: translateY(8px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+    @keyframes flowDot {
+      0% { offset-distance: 0%; opacity: 0; }
+      10% { opacity: 1; }
+      90% { opacity: 1; }
+      100% { offset-distance: 100%; opacity: 0; }
+    }
+    @keyframes fadeInUp {
+      from { opacity: 0; transform: translateY(12px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+    @keyframes scanLine {
+      0% { top: 0%; opacity: 0; }
+      10% { opacity: 1; }
+      90% { opacity: 1; }
+      100% { top: 100%; opacity: 0; }
+    }
+  `;
+
+  const ShieldIcon = ({ state, size = 48 }) => {
+    const color = state === "block" ? "#B43C3C" : state === "pass" ? "#4A7C59" : "var(--bronze)";
+    const anim = state === "block" ? "pulseShieldBlock 0.5s ease-out" : state === "pass" ? "pulseShield 0.6s ease-out" : "none";
+    return (
+      <svg width={size} height={size} viewBox="0 0 48 48" style={{ animation: anim }}>
+        <path
+          d="M24 4L6 12v12c0 11.1 7.7 21.5 18 24 10.3-2.5 18-12.9 18-24V12L24 4z"
+          fill="none"
+          stroke={color}
+          strokeWidth="2.5"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M24 8L10 14.5v9.5c0 9.2 6.4 17.8 14 20 7.6-2.2 14-10.8 14-20v-9.5L24 8z"
+          fill={color}
+          fillOpacity="0.08"
+        />
+        {state === "block" && (
+          <g stroke="#B43C3C" strokeWidth="3" strokeLinecap="round">
+            <line x1="18" y1="18" x2="30" y2="30" />
+            <line x1="30" y1="18" x2="18" y2="30" />
+          </g>
+        )}
+        {state === "pass" && (
+          <polyline
+            points="16,24 22,30 32,18"
+            fill="none"
+            stroke="#4A7C59"
+            strokeWidth="3"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        )}
+        {state === "idle" && (
+          <g>
+            <rect x="19" y="15" width="10" height="3" rx="1.5" fill="var(--bronze)" fillOpacity="0.5" />
+            <rect x="17" y="21" width="14" height="3" rx="1.5" fill="var(--bronze)" fillOpacity="0.35" />
+            <rect x="19" y="27" width="10" height="3" rx="1.5" fill="var(--bronze)" fillOpacity="0.2" />
+          </g>
+        )}
+      </svg>
+    );
+  };
+
+  const QueryTag = ({ type }) => {
+    const colors = {
+      SELECT: { bg: "rgba(var(--bronze-rgb),0.08)", text: "var(--bronze)" },
+      UPDATE: { bg: "rgba(180,120,60,0.1)", text: "var(--bronze)" },
+      DELETE: { bg: "rgba(180,60,60,0.08)", text: "#B43C3C" },
+      DROP: { bg: "rgba(180,60,60,0.08)", text: "#B43C3C" },
+      INSERT: { bg: "rgba(74,124,89,0.08)", text: "#4A7C59" },
+      ALTER: { bg: "rgba(180,60,60,0.08)", text: "#B43C3C" },
+    };
+    const c = colors[type] || colors.SELECT;
+    return (
+      <span style={{
+        fontFamily: "'JetBrains Mono', monospace",
+        fontSize: 10,
+        fontWeight: 500,
+        color: c.text,
+        background: c.bg,
+        padding: "2px 8px",
+        borderRadius: 4,
+        letterSpacing: "0.04em",
+        textTransform: "uppercase",
+        whiteSpace: "nowrap",
+      }}>{type}</span>
+    );
+  };
+
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const [phase, setPhase] = useState("idle"); // idle | scanning | result
+  const [results, setResults] = useState([]);
+  const [stats, setStats] = useState({ blocked: 0, allowed: 0 });
+  const timerRef = useRef(null);
+  const indexRef = useRef(0);
+
+  const processNext = useCallback(() => {
+    const idx = indexRef.current % QUERIES.length;
+    const q = QUERIES[idx];
+    indexRef.current += 1;
+
+    setActiveIndex(idx);
+    setPhase("scanning");
+
+    timerRef.current = setTimeout(() => {
+      setPhase("result");
+      setResults(prev => {
+        const next = [{ ...q, ts: Date.now() }, ...prev];
+        return next.slice(0, 6);
+      });
+      setStats(prev => ({
+        blocked: prev.blocked + (q.blocked ? 1 : 0),
+        allowed: prev.allowed + (q.blocked ? 0 : 1),
+      }));
+
+      timerRef.current = setTimeout(() => {
+        setPhase("idle");
+        timerRef.current = setTimeout(() => {
+          processNext();
+        }, 600);
+      }, 1400);
+    }, 900);
+  }, []);
+
+  useEffect(() => {
+    timerRef.current = setTimeout(() => processNext(), 800);
+    return () => clearTimeout(timerRef.current);
+  }, []);
+
+  const currentQuery = activeIndex >= 0 ? QUERIES[activeIndex] : null;
+  const shieldState = phase === "result" && currentQuery
+    ? (currentQuery.blocked ? "block" : "pass")
+    : phase === "scanning" ? "idle" : "idle";
+
+  return (
+    <div style={{
+      fontFamily: "'DM Sans', system-ui, sans-serif",
+      borderRadius: 12,
+      padding: "20px 24px 16px",
+      position: "relative",
+      overflow: "hidden",
+      width: "100%",
+      color: "var(--sand-100)",
+    }}>
+      <style>{animationStyles}</style>
+
+      {/* Radial glow */}
+      <div style={{
+        position: "absolute", top: "-30%", right: "-10%", width: "60%", height: "160%",
+        background: "radial-gradient(ellipse at center, rgba(var(--warm-gold-rgb),0.12) 0%, transparent 70%)",
+        pointerEvents: "none",
+      }} />
+
+      {/* Main animation area */}
+      <div style={{
+        display: "grid",
+        gridTemplateColumns: "1fr auto 1fr",
+        gap: 24,
+        alignItems: "start",
+        position: "relative",
+        height: 320,
+      }}>
+        {/* Left: incoming query */}
+        <div style={{
+          background: "rgba(var(--sand-100-rgb),0.04)",
+          border: "1px solid rgba(var(--sand-100-rgb),0.08)",
+          borderRadius: 10,
+          padding: 20,
+          height: 300,
+          overflow: "hidden",
+        }}>
+          <div style={{
+            fontSize: 10, fontWeight: 600, color: "rgba(var(--sand-100-rgb),0.25)",
+            textTransform: "uppercase", letterSpacing: "0.08em", marginBottom: 14,
+          }}>Incoming Query</div>
+
+          {currentQuery && phase !== "idle" ? (
+            <div key={indexRef.current} style={{ animation: "slideIn 0.35s ease-out" }}>
+              <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 10 }}>
+                <QueryTag type={currentQuery.type} />
+                <span style={{ fontSize: 11, color: "rgba(var(--sand-100-rgb),0.3)" }}>
+                  via CLI
+                </span>
+              </div>
+              <div style={{
+                fontFamily: "'JetBrains Mono', monospace",
+                fontSize: 13, lineHeight: 1.7,
+                color: "var(--sand-300)",
+                background: "rgba(var(--sand-100-rgb),0.03)",
+                padding: "14px 16px",
+                borderRadius: 8,
+                border: "1px solid rgba(var(--sand-100-rgb),0.06)",
+                wordBreak: "break-all",
+                position: "relative",
+                overflow: "hidden",
+              }}>
+                {currentQuery.sql}
+                {phase === "scanning" && (
+                  <div style={{
+                    position: "absolute",
+                    left: 0, width: "100%", height: 2,
+                    background: "linear-gradient(90deg, transparent, var(--warm-gold), transparent)",
+                    animation: "scanLine 0.8s ease-in-out",
+                  }} />
+                )}
+              </div>
+
+              {phase === "scanning" && (
+                <div style={{
+                  marginTop: 14, fontSize: 12, color: "var(--warm-gold)",
+                  display: "flex", alignItems: "center", gap: 6,
+                  animation: "fadeInUp 0.3s ease-out",
+                }}>
+                  <span style={{
+                    width: 6, height: 6, borderRadius: "50%",
+                    background: "var(--warm-gold)",
+                    display: "inline-block",
+                    animation: "pulseShield 1s ease-in-out infinite",
+                  }} />
+                  Evaluating rules...
+                </div>
+              )}
+
+              {phase === "result" && (
+                <div style={{
+                  marginTop: 14,
+                  animation: "fadeInUp 0.3s ease-out",
+                  display: "flex", alignItems: "center", gap: 8,
+                }}>
+                  <span style={{
+                    width: 8, height: 8, borderRadius: "50%",
+                    background: currentQuery.blocked ? "#B43C3C" : "#4A7C59",
+                    display: "inline-block",
+                  }} />
+                  <span style={{
+                    fontSize: 12, fontWeight: 500,
+                    color: currentQuery.blocked ? "#D4726A" : "#7CB88A",
+                  }}>
+                    {currentQuery.blocked ? "Blocked" : "Allowed"}
+                  </span>
+                  {currentQuery.rule && (
+                    <span style={{ fontSize: 11, color: "rgba(var(--sand-100-rgb),0.3)" }}>
+                      {currentQuery.rule}
+                    </span>
+                  )}
+                </div>
+              )}
+            </div>
+          ) : (
+            <div style={{
+              color: "rgba(var(--sand-100-rgb),0.15)",
+              fontSize: 13, fontStyle: "italic",
+              paddingTop: 20,
+            }}>Waiting for next query...</div>
+          )}
+        </div>
+
+        {/* Center: shield */}
+        <div style={{
+          display: "flex", flexDirection: "column",
+          alignItems: "center", justifyContent: "center",
+          paddingTop: 40, gap: 12, minWidth: 72,
+        }}>
+          <ShieldIcon state={shieldState} size={56} />
+          <div style={{
+            fontSize: 10, fontWeight: 600, color: "rgba(var(--sand-100-rgb),0.2)",
+            textTransform: "uppercase", letterSpacing: "0.08em",
+            textAlign: "center",
+          }}>
+            {phase === "scanning" ? "Checking..." :
+             phase === "result" ? (currentQuery?.blocked ? "Denied" : "Clear") :
+             "Ready"}
+          </div>
+        </div>
+
+        {/* Right: results log */}
+        <div style={{
+          background: "rgba(var(--sand-100-rgb),0.04)",
+          border: "1px solid rgba(var(--sand-100-rgb),0.08)",
+          borderRadius: 10,
+          padding: 20,
+          height: 300,
+          overflow: "hidden",
+        }}>
+          <div style={{
+            fontSize: 10, fontWeight: 600, color: "rgba(var(--sand-100-rgb),0.25)",
+            textTransform: "uppercase", letterSpacing: "0.08em", marginBottom: 14,
+          }}>Session Log</div>
+
+          <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+            {results.length === 0 && (
+              <div style={{ color: "rgba(var(--sand-100-rgb),0.15)", fontSize: 12, fontStyle: "italic" }}>
+                No sessions yet
+              </div>
+            )}
+            {results.map((r, i) => (
+              <div key={r.ts} style={{
+                display: "flex", alignItems: "center", gap: 8,
+                padding: "8px 10px",
+                background: i === 0 ? "rgba(var(--sand-100-rgb),0.03)" : "transparent",
+                borderRadius: 6,
+                border: i === 0 ? "1px solid rgba(var(--sand-100-rgb),0.06)" : "1px solid transparent",
+                animation: i === 0 ? "resultSlide 0.3s ease-out" : "none",
+                opacity: 1 - (i * 0.12),
+              }}>
+                <span style={{
+                  width: 6, height: 6, borderRadius: "50%", flexShrink: 0,
+                  background: r.blocked ? "#B43C3C" : "#4A7C59",
+                }} />
+                <span style={{
+                  fontFamily: "'JetBrains Mono', monospace",
+                  fontSize: 11, color: "rgba(var(--sand-100-rgb),0.5)",
+                  overflow: "hidden", textOverflow: "ellipsis",
+                  whiteSpace: "nowrap", flex: 1,
+                }}>
+                  {r.sql.length > 32 ? r.sql.slice(0, 32) + "..." : r.sql}
+                </span>
+                <span style={{
+                  fontSize: 10, fontWeight: 500, flexShrink: 0,
+                  color: r.blocked ? "#D4726A" : "#7CB88A",
+                }}>{r.blocked ? "BLOCKED" : "OK"}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Status bar */}
+      <div style={{
+        display: "flex", alignItems: "center", gap: 20,
+        marginTop: 16, paddingTop: 12,
+        borderTop: "1px solid rgba(var(--sand-100-rgb),0.06)",
+        position: "relative",
+      }}>
+        <span style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: 11, color: "rgba(var(--sand-100-rgb),0.25)" }}>
+          {stats.blocked} blocked
+        </span>
+        <span style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: 11, color: "rgba(var(--sand-100-rgb),0.25)" }}>
+          {stats.allowed} allowed
+        </span>
+        <span style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: 11, color: "var(--warm-gold)" }}>
+          &lt;5ms latency
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/snippets/annimations/layeredaccess.jsx
+++ b/snippets/annimations/layeredaccess.jsx
@@ -1,0 +1,508 @@
+export const LayeredAccess = () => {
+  const TOTAL = 7;
+  const CX = 230, CY = 250, VB_W = 820, VB_H = 500;
+  const OUTER_R = 200, INNER_R = 30, GAP = 3;
+
+  const COLORS = [
+    { s: 'var(--warm-gold)', f: 'rgba(var(--warm-gold-rgb),0.06)', g: 'rgba(var(--warm-gold-rgb),0.14)' },
+    { s: '#C49558', f: 'rgba(196,149,88,0.05)',  g: 'rgba(196,149,88,0.12)' },
+    { s: '#B08348', f: 'rgba(176,131,72,0.05)',  g: 'rgba(176,131,72,0.12)' },
+    { s: 'var(--bronze)', f: 'rgba(var(--bronze-rgb),0.05)',   g: 'rgba(var(--bronze-rgb),0.12)' },
+    { s: '#7A5030', f: 'rgba(122,80,48,0.05)',   g: 'rgba(122,80,48,0.10)' },
+    { s: 'var(--bronze-dark)', f: 'rgba(var(--bronze-dark-rgb),0.06)',   g: 'rgba(var(--bronze-dark-rgb),0.12)' },
+    { s: 'var(--sand-500)', f: 'rgba(var(--sand-500-rgb),0.05)', g: 'rgba(var(--sand-500-rgb),0.12)' },
+  ];
+
+  const LAYERS = [
+    { title: 'Read + Masking',    desc: 'Sensitive fields hidden. No approval needed.' },
+    { title: 'Read Unmasked',     desc: 'Raw data, peer approval, time-bounded.' },
+    { title: 'Sensitive Read',    desc: 'Justification + full audit trail.' },
+    { title: 'Standard Write',    desc: 'Leader approval, guardrails active.' },
+    { title: 'Sensitive Write',   desc: 'AI risk analysis on every query.' },
+    { title: 'Structural Change', desc: 'Only pre-approved CI/CD actions.' },
+    { title: 'Runbook Only',      desc: 'No manual sessions. Automation only.' },
+  ];
+
+  const GATES = [
+    { id: 'masking',   name: 'AI Data Masking',       tag: 'Automatic',  at: 0 },
+    { id: 'jit',       name: 'Just-in-time sessions', tag: 'Time-bound', at: 1 },
+    { id: 'peer',      name: 'Peer approval',         tag: 'Required',   at: 1 },
+    { id: 'justify',   name: 'Written justification', tag: 'Mandatory',  at: 2 },
+    { id: 'leader',    name: 'Leader / DBA approval', tag: 'Multi-step', at: 3 },
+    { id: 'guardrail', name: 'Query guardrails',      tag: 'Active',     at: 3 },
+    { id: 'ai',        name: 'AI session analysis',   tag: 'Scanning',   at: 4 },
+    { id: 'runbook',   name: 'Runbook-only mode',     tag: 'Enforced',   at: 6 },
+  ];
+
+  const ICONS = {
+    masking: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+        <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+        <line x1="2" y1="2" x2="22" y2="22" />
+      </svg>
+    ),
+    jit: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+        <circle cx="12" cy="12" r="10" />
+        <polyline points="12 6 12 12 16 14" />
+      </svg>
+    ),
+    peer: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+        <path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2" />
+        <circle cx="9" cy="7" r="4" />
+        <path d="M23 21v-2a4 4 0 00-3-3.87" />
+        <path d="M16 3.13a4 4 0 010 7.75" />
+      </svg>
+    ),
+    justify: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+        <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" />
+        <polyline points="14 2 14 8 20 8" />
+        <line x1="16" y1="13" x2="8" y2="13" />
+        <line x1="16" y1="17" x2="8" y2="17" />
+      </svg>
+    ),
+    leader: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+        <path d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2" />
+        <circle cx="12" cy="7" r="4" />
+      </svg>
+    ),
+    guardrail: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+        <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+      </svg>
+    ),
+    ai: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+        <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+      </svg>
+    ),
+    runbook: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+        <polyline points="16 18 22 12 16 6" />
+        <polyline points="8 6 2 12 8 18" />
+      </svg>
+    ),
+  };
+
+  function ringRadius(i) {
+    return OUTER_R - i * ((OUTER_R - INNER_R) / TOTAL);
+  }
+
+  // Pre-compute label Y positions
+  const LABEL_X = 520;
+  const LABEL_DOT_X = 508;
+  const labelsTop = CY - OUTER_R + 20;
+  const labelsBot = CY + OUTER_R - 20;
+  const labelYs = Array.from({ length: TOTAL }, (_, i) =>
+    labelsTop + i * ((labelsBot - labelsTop) / (TOTAL - 1))
+  );
+
+  const [currentLayer, setCurrentLayer] = useState(0);
+  const [prevLayer, setPrevLayer] = useState(-1);
+  const timerRef = useRef(null);
+
+  const goTo = useCallback((index) => {
+    setCurrentLayer((prev) => {
+      setPrevLayer(prev);
+      return index;
+    });
+  }, []);
+
+  const resetAuto = useCallback(() => {
+    clearInterval(timerRef.current);
+    timerRef.current = setInterval(() => {
+      setCurrentLayer((prev) => {
+        setPrevLayer(prev);
+        return (prev + 1) % TOTAL;
+      });
+    }, 4000);
+  }, []);
+
+  useEffect(() => {
+    resetAuto();
+    return () => clearInterval(timerRef.current);
+  }, [resetAuto]);
+
+  const handlePipClick = (i) => {
+    goTo(i);
+    resetAuto();
+  };
+
+  const handleRingClick = (i) => {
+    goTo(i);
+    resetAuto();
+  };
+
+  const trans = { transition: 'all 0.45s ease' };
+
+  return (
+    <div style={{ position: 'relative' }}>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '280px 1fr',
+          gap: 48,
+          alignItems: 'center',
+        }}
+        className="layered-access-grid"
+      >
+        {/* ── LEFT: cumulative feature list ── */}
+        <div style={{ maxWidth: 280, width: '100%' }}>
+          <div
+            style={{
+              fontFamily: 'var(--sans)',
+              fontSize: 11,
+              fontWeight: 600,
+              letterSpacing: '0.1em',
+              textTransform: 'uppercase',
+              color: 'var(--warm-gold)',
+              marginBottom: 20,
+            }}
+          >
+            Active controls
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
+            {GATES.map((gate) => {
+              const on = gate.at <= currentLayer;
+              return (
+                <div
+                  key={gate.id}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 12,
+                    padding: '11px 0',
+                    borderBottom: '1px solid rgba(var(--sand-100-rgb),0.06)',
+                    ...trans,
+                  }}
+                >
+                  {/* Icon */}
+                  <div
+                    style={{
+                      width: 28,
+                      height: 28,
+                      borderRadius: 7,
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      flexShrink: 0,
+                      background: 'rgba(var(--warm-gold-rgb),0.08)',
+                      color: 'var(--warm-gold)',
+                      opacity: on ? 1 : 0.15,
+                      ...trans,
+                    }}
+                  >
+                    <div style={{ width: 15, height: 15 }}>{ICONS[gate.id]}</div>
+                  </div>
+                  {/* Name */}
+                  <span
+                    style={{
+                      flex: 1,
+                      fontSize: 13,
+                      fontWeight: 500,
+                      fontFamily: 'var(--sans)',
+                      color: on ? 'var(--sand-100)' : 'var(--sand-500)',
+                      opacity: on ? 1 : 0.15,
+                      ...trans,
+                    }}
+                  >
+                    {gate.name}
+                  </span>
+                  {/* Tag */}
+                  <span
+                    style={{
+                      fontFamily: 'var(--sans)',
+                      fontSize: 10,
+                      fontWeight: 600,
+                      padding: '2px 8px',
+                      borderRadius: 100,
+                      whiteSpace: 'nowrap',
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.04em',
+                      background: on ? 'rgba(var(--warm-gold-rgb),0.08)' : 'rgba(var(--sand-100-rgb),0.03)',
+                      color: on ? 'var(--warm-gold)' : 'var(--sand-500)',
+                      opacity: on ? 1 : 0.15,
+                      ...trans,
+                    }}
+                  >
+                    {gate.tag}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* ── RIGHT: SVG diagram + pips ── */}
+        <div style={{ position: 'relative', width: '100%' }}>
+          <div
+            style={{
+              position: 'relative',
+              width: '100%',
+              maxWidth: 820,
+              margin: '0 auto',
+              aspectRatio: '820 / 500',
+            }}
+          >
+            <svg
+              viewBox={`0 0 ${VB_W} ${VB_H}`}
+              preserveAspectRatio="xMidYMid meet"
+              style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }}
+            >
+              {/* Glow filters */}
+              <defs>
+                {COLORS.map((_, i) => (
+                  <filter
+                    key={i}
+                    id={`glow-${i}`}
+                    x="-50%"
+                    y="-50%"
+                    width="200%"
+                    height="200%"
+                  >
+                    <feGaussianBlur stdDeviation="4" result="b" />
+                    <feMerge>
+                      <feMergeNode in="b" />
+                      <feMergeNode in="SourceGraphic" />
+                    </feMerge>
+                  </filter>
+                ))}
+              </defs>
+
+              {/* Rings */}
+              {Array.from({ length: TOTAL }, (_, i) => {
+                const r = ringRadius(i);
+                const ir = ringRadius(i + 1) + GAP / 2;
+                const mid = (r + ir) / 2;
+                const c = COLORS[i];
+                const isActive = i === currentLayer;
+                const isOuter = i < currentLayer;
+
+                // Leader line
+                const labelY = labelYs[i];
+                const dy = labelY - CY;
+                let startX, startY;
+                if (Math.abs(dy) < r) {
+                  startX = CX + Math.sqrt(r * r - dy * dy);
+                  startY = labelY;
+                } else {
+                  startX = CX + r;
+                  startY = CY;
+                }
+                const linePath =
+                  Math.abs(startY - labelY) < 1
+                    ? `M${startX},${startY} L${LABEL_DOT_X},${labelY}`
+                    : `M${startX},${startY} C${Math.max(startX + 12, 470)},${startY} ${Math.max(startX + 12, 470)},${labelY} ${LABEL_DOT_X},${labelY}`;
+
+                // Lock pips on ring
+                const cnt = i + 1;
+                const spread = Math.PI * 1.4;
+                const start = Math.PI * 0.3;
+                const pips = Array.from({ length: cnt }, (_, j) => {
+                  const a = cnt === 1 ? Math.PI * 0.8 : start + (j / (cnt - 1)) * spread;
+                  return { cx: CX + Math.cos(a) * mid, cy: CY + Math.sin(a) * mid };
+                });
+
+                return (
+                  <g
+                    key={i}
+                    style={{ cursor: 'pointer' }}
+                    onClick={() => handleRingClick(i)}
+                  >
+                    {/* Band */}
+                    <circle
+                      cx={CX}
+                      cy={CY}
+                      r={mid}
+                      fill="none"
+                      stroke={isActive ? c.g : isOuter ? c.f : 'rgba(var(--sand-100-rgb),0.015)'}
+                      strokeWidth={r - ir - GAP}
+                      style={trans}
+                    />
+                    {/* Edge */}
+                    <circle
+                      cx={CX}
+                      cy={CY}
+                      r={r}
+                      fill="none"
+                      stroke={c.s}
+                      strokeWidth={isActive ? 2 : 1}
+                      opacity={isActive ? 0.5 : isOuter ? 0.15 : 0.06}
+                      filter={isActive ? `url(#glow-${i})` : undefined}
+                      style={trans}
+                    />
+                    {/* Lock pips */}
+                    {pips.map((p, j) => (
+                      <circle
+                        key={j}
+                        cx={p.cx}
+                        cy={p.cy}
+                        r={isActive ? 3 : 2}
+                        fill={c.s}
+                        opacity={isActive ? 0.4 : isOuter ? 0.1 : 0.04}
+                        style={trans}
+                      />
+                    ))}
+                    {/* Leader line */}
+                    <path
+                      d={linePath}
+                      fill="none"
+                      stroke={c.s}
+                      strokeWidth={isActive ? 1.2 : 0.75}
+                      opacity={isActive ? 0.5 : isOuter ? 0.12 : 0.04}
+                      style={trans}
+                    />
+                    {/* Label dot */}
+                    <circle
+                      cx={LABEL_DOT_X}
+                      cy={labelY}
+                      r={isActive ? 4 : isOuter ? 2.5 : 2}
+                      fill={c.s}
+                      opacity={isActive ? 0.8 : isOuter ? 0.2 : 0.06}
+                      style={trans}
+                    />
+                    {/* Title */}
+                    <text
+                      x={LABEL_X}
+                      y={labelY - 2}
+                      fontFamily="Sora, DM Sans, sans-serif"
+                      fontSize={isActive ? 14 : 13}
+                      fontWeight="600"
+                      fill={isActive ? 'var(--warm-gold)' : 'var(--sand-100)'}
+                      opacity={isActive ? 1 : isOuter ? 0.4 : 0.15}
+                      dominantBaseline="auto"
+                      style={trans}
+                    >
+                      {LAYERS[i].title}
+                    </text>
+                    {/* Description */}
+                    <text
+                      x={LABEL_X}
+                      y={labelY + 14}
+                      fontFamily="DM Sans, sans-serif"
+                      fontSize="11"
+                      fontWeight="400"
+                      fill="rgba(var(--sand-100-rgb),0.3)"
+                      opacity={isActive ? 0.7 : 0}
+                      dominantBaseline="auto"
+                      style={trans}
+                    >
+                      {LAYERS[i].desc}
+                    </text>
+                  </g>
+                );
+              })}
+
+              {/* Core circle */}
+              <circle
+                cx={CX}
+                cy={CY}
+                r={INNER_R}
+                fill={currentLayer >= 5 ? 'rgba(var(--warm-gold-rgb),0.08)' : 'rgba(var(--warm-gold-rgb),0.04)'}
+                stroke={currentLayer >= 5 ? 'rgba(var(--warm-gold-rgb),0.25)' : 'rgba(var(--warm-gold-rgb),0.10)'}
+                strokeWidth="1"
+                style={{ transition: 'all 0.5s ease' }}
+              />
+              <text
+                x={CX}
+                y={CY - 5}
+                textAnchor="middle"
+                fontFamily="Sora"
+                fontSize="8"
+                fontWeight="700"
+                letterSpacing="0.1em"
+                fill="rgba(var(--warm-gold-rgb),0.35)"
+              >
+                CRITICAL
+              </text>
+              <text
+                x={CX}
+                y={CY + 8}
+                textAnchor="middle"
+                fontFamily="Sora"
+                fontSize="8"
+                fontWeight="700"
+                letterSpacing="0.1em"
+                fill="rgba(var(--warm-gold-rgb),0.35)"
+              >
+                DATA
+              </text>
+            </svg>
+          </div>
+
+          {/* Pips */}
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'center',
+              gap: 5,
+              marginTop: 12,
+              maxWidth: 820,
+              marginLeft: 'auto',
+              marginRight: 'auto',
+              paddingRight: 360,
+            }}
+            className="layered-access-pips"
+          >
+            {Array.from({ length: TOTAL }, (_, i) => (
+              <button
+                key={i}
+                onClick={() => handlePipClick(i)}
+                style={{
+                  width: 32,
+                  height: 32,
+                  borderRadius: 8,
+                  border: i === currentLayer
+                    ? '1px solid var(--warm-gold)'
+                    : '1px solid rgba(var(--sand-100-rgb),0.12)',
+                  background: i === currentLayer
+                    ? 'var(--warm-gold)'
+                    : 'rgba(var(--sand-100-rgb),0.03)',
+                  color: i === currentLayer
+                    ? 'var(--gradient-dark-mid)'
+                    : 'rgba(var(--sand-100-rgb),0.3)',
+                  fontFamily: 'var(--sans)',
+                  fontSize: 12,
+                  fontWeight: 600,
+                  cursor: 'pointer',
+                  transition: 'all 0.3s ease',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  boxShadow: i === currentLayer
+                    ? '0 2px 16px rgba(var(--warm-gold-rgb),0.25)'
+                    : 'none',
+                }}
+              >
+                {i + 1}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Responsive overrides */}
+      <style>{`
+        @media (max-width: 900px) {
+          .layered-access-grid {
+            grid-template-columns: 1fr !important;
+            gap: 32px !important;
+          }
+          .layered-access-grid > div:first-child {
+            max-width: 100% !important;
+            order: 2;
+          }
+          .layered-access-grid > div:last-child {
+            order: 1;
+          }
+          .layered-access-pips {
+            padding-right: 0 !important;
+          }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/snippets/annimations/livedatamasking.jsx
+++ b/snippets/annimations/livedatamasking.jsx
@@ -1,0 +1,312 @@
+export const ProxyMembrane = () => {
+  const FONTS_URL =
+    "https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;0,9..40,800&family=JetBrains+Mono:wght@400;500&family=Sora:wght@600;700;800&display=swap";
+
+  const C = {
+    espresso: "var(--gradient-dark-mid)",
+    warmGold: "var(--warm-gold)",
+    sand100: "var(--sand-100)",
+    sand300: "var(--sand-300)",
+    sand500: "var(--sand-500)",
+  };
+
+  const ROWS = [
+    { raw: ["Sarah Chen", "sarah.chen@acme.io", "284-19-7653", "+1 415-892-3041"], masked: ["[PERSON]", "[EMAIL]", "[SSN]", "[PHONE]"] },
+    { raw: ["Marcus Webb", "m.webb@globex.com", "531-77-0294", "+1 212-555-8817"], masked: ["[PERSON]", "[EMAIL]", "[SSN]", "[PHONE]"] },
+    { raw: ["Elena Ruiz", "eruiz@initech.co", "719-42-8106", "+44 20-7946-0958"], masked: ["[PERSON]", "[EMAIL]", "[SSN]", "[PHONE]"] },
+    { raw: ["James Okafor", "j.okafor@stark.dev", "603-88-1542", "+1 650-331-7720"], masked: ["[PERSON]", "[EMAIL]", "[SSN]", "[PHONE]"] },
+  ];
+
+  const ROW_DELAY = 800;
+  const CROSS_DURATION = 600;
+  const HOLD = 3000;
+
+  function ShieldIcon({ active, done }) {
+    return (
+      <svg width="18" height="18" viewBox="0 0 20 20" fill="none" style={{
+        animation: done ? "shieldIn 0.5s ease-out" : undefined,
+        opacity: active ? 1 : 0.3, transition: "opacity 0.4s ease",
+      }}>
+        <path d="M10 2L3 5.5V10C3 14.5 6 17.5 10 19C14 17.5 17 14.5 17 10V5.5L10 2Z"
+          fill={done ? "rgba(var(--warm-gold-rgb),0.15)" : "rgba(var(--sand-100-rgb),0.05)"}
+          stroke={done ? "var(--warm-gold)" : "rgba(var(--sand-100-rgb),0.15)"} strokeWidth="1.2" />
+        {done && (
+          <path d="M7 10.5L9 12.5L13 8" stroke="var(--warm-gold)" strokeWidth="1.5"
+            strokeLinecap="round" strokeLinejoin="round" />
+        )}
+      </svg>
+    );
+  }
+
+  const [rowPhases, setRowPhases] = useState(ROWS.map(() => "hidden"));
+  const [allDone, setAllDone] = useState(false);
+  const [membraneActive, setMembraneActive] = useState(false);
+  const [membraneGlow, setMembraneGlow] = useState(false);
+  const timeouts = useRef([]);
+
+  const clearAll = useCallback(() => {
+    timeouts.current.forEach(clearTimeout);
+    timeouts.current = [];
+  }, []);
+
+  const later = useCallback((fn, ms) => {
+    const id = setTimeout(fn, ms);
+    timeouts.current.push(id);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const cycle = () => {
+      if (cancelled) return;
+      setRowPhases(ROWS.map(() => "hidden"));
+      setAllDone(false);
+      setMembraneActive(false);
+      setMembraneGlow(false);
+
+      later(() => {
+        if (cancelled) return;
+        setMembraneActive(true);
+      }, 400);
+
+      ROWS.forEach((_, i) => {
+        const t0 = 700 + i * ROW_DELAY;
+
+        later(() => {
+          if (cancelled) return;
+          setRowPhases(p => { const n = [...p]; n[i] = "approaching"; return n; });
+        }, t0);
+
+        later(() => {
+          if (cancelled) return;
+          setRowPhases(p => { const n = [...p]; n[i] = "crossing"; return n; });
+          setMembraneGlow(true);
+          later(() => { if (!cancelled) setMembraneGlow(false); }, 300);
+        }, t0 + 400);
+
+        later(() => {
+          if (cancelled) return;
+          setRowPhases(p => { const n = [...p]; n[i] = "through"; return n; });
+        }, t0 + 400 + CROSS_DURATION);
+      });
+
+      const total = 700 + (ROWS.length - 1) * ROW_DELAY + 400 + CROSS_DURATION + 300;
+      later(() => { if (!cancelled) setAllDone(true); }, total);
+      later(() => { if (!cancelled) cycle(); }, total + HOLD);
+    };
+
+    cycle();
+    return () => { cancelled = true; clearAll(); };
+  }, [later, clearAll]);
+
+  return (
+    <>
+      <link rel="stylesheet" href={FONTS_URL} />
+      <style>{`
+        @keyframes approachSlide {
+          from { opacity: 0; transform: translateX(-30px); }
+          to { opacity: 1; transform: translateX(0); }
+        }
+        @keyframes crossFlash {
+          0% { opacity: 1; filter: blur(0); }
+          30% { opacity: 0.3; filter: blur(4px); transform: scaleY(0.8); }
+          60% { opacity: 0.6; filter: blur(2px); transform: scaleY(1.05); }
+          100% { opacity: 1; filter: blur(0); transform: scaleY(1); }
+        }
+        @keyframes throughSlide {
+          from { opacity: 0; transform: translateX(0); }
+          to { opacity: 1; transform: translateX(0); }
+        }
+        @keyframes membranePulse {
+          0%, 100% { box-shadow: 0 0 8px 0 rgba(var(--warm-gold-rgb),0.1); }
+          50% { box-shadow: 0 0 24px 4px rgba(var(--warm-gold-rgb),0.3); }
+        }
+        @keyframes membraneFlash {
+          0% { background: rgba(var(--warm-gold-rgb),0.15); }
+          100% { background: rgba(var(--warm-gold-rgb),0.06); }
+        }
+        @keyframes shieldIn {
+          0% { opacity:0; transform:scale(0.6); }
+          60% { opacity:1; transform:scale(1.08); }
+          100% { opacity:1; transform:scale(1); }
+        }
+      `}</style>
+
+      <div style={{
+        background: "linear-gradient(135deg, var(--gradient-dark-start) 0%, var(--gradient-dark-mid) 35%, var(--gradient-dark-end) 70%, var(--bronze) 100%)",
+        borderRadius: 14, padding: "32px 28px 28px",
+        fontFamily: "'DM Sans', system-ui, sans-serif",
+        position: "relative", overflow: "hidden", maxWidth: 760, margin: "0 auto",
+        height: 420,
+      }}>
+        {/* Radial glow */}
+        <div style={{
+          position: "absolute", top: "-30%", right: "-10%", width: "60%", height: "160%",
+          background: "radial-gradient(ellipse at center, rgba(var(--warm-gold-rgb),0.12) 0%, transparent 70%)",
+          pointerEvents: "none",
+        }} />
+
+        {/* Header */}
+        <div style={{
+          display: "flex", alignItems: "center", gap: 10,
+          marginBottom: 24, position: "relative", zIndex: 1,
+        }}>
+          <ShieldIcon done={allDone} active={membraneActive} />
+          <span style={{
+            fontFamily: "'Sora', sans-serif", fontSize: 14, fontWeight: 600,
+            color: C.sand100, letterSpacing: "-0.01em",
+          }}>Live Data Masking</span>
+          <span style={{
+            fontFamily: "'DM Sans', sans-serif", fontSize: 10, fontWeight: 600,
+            textTransform: "uppercase", letterSpacing: "0.06em",
+            color: allDone ? C.warmGold : "rgba(var(--sand-100-rgb),0.18)",
+            background: allDone ? "rgba(var(--warm-gold-rgb),0.10)" : "rgba(var(--sand-100-rgb),0.04)",
+            padding: "2px 8px", borderRadius: 99, transition: "all 0.3s ease",
+          }}>{allDone ? "Protected" : membraneActive ? "Active" : "Ready"}</span>
+        </div>
+
+        {/* Three-zone layout: Raw | Membrane | Masked */}
+        <div style={{
+          display: "grid", gridTemplateColumns: "1fr 48px 1fr",
+          gap: 0, position: "relative", zIndex: 1, minHeight: 220,
+        }}>
+          {/* Left: raw data zone */}
+          <div style={{ position: "relative" }}>
+            <div style={{
+              fontFamily: "'JetBrains Mono', monospace", fontSize: 9, fontWeight: 500,
+              color: "rgba(var(--sand-100-rgb),0.20)", textTransform: "uppercase",
+              letterSpacing: "0.1em", marginBottom: 10, paddingLeft: 2,
+            }}>Database response</div>
+
+            <div style={{
+              background: "rgba(var(--sand-100-rgb),0.03)", border: "1px solid rgba(var(--sand-100-rgb),0.06)",
+              borderRadius: 8, overflow: "hidden",
+            }}>
+              {ROWS.map((row, i) => {
+                const phase = rowPhases[i];
+                const show = phase === "approaching" || phase === "crossing";
+                return (
+                  <div key={i} style={{
+                    padding: "8px 12px",
+                    borderBottom: i < ROWS.length - 1 ? "1px solid rgba(var(--sand-100-rgb),0.04)" : "none",
+                    opacity: show ? 1 : phase === "through" ? 0.15 : 0,
+                    transform: show ? "translateX(0)" : "translateX(-10px)",
+                    transition: phase === "through" ? "opacity 0.4s ease" : "opacity 0.3s ease, transform 0.3s ease",
+                    minHeight: 36, display: "flex", flexDirection: "column", justifyContent: "center", gap: 2,
+                  }}>
+                    <div style={{
+                      fontFamily: "'JetBrains Mono', monospace", fontSize: 11,
+                      color: "rgba(var(--sand-100-rgb),0.50)", whiteSpace: "nowrap", overflow: "hidden",
+                      textOverflow: "ellipsis",
+                    }}>{row.raw[0]} , {row.raw[1]}</div>
+                    <div style={{
+                      fontFamily: "'JetBrains Mono', monospace", fontSize: 10,
+                      color: "rgba(var(--sand-100-rgb),0.30)", whiteSpace: "nowrap",
+                    }}>{row.raw[2]} , {row.raw[3]}</div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Center: membrane barrier */}
+          <div style={{
+            display: "flex", alignItems: "center", justifyContent: "center",
+            position: "relative",
+          }}>
+            <div style={{
+              width: 3, height: "calc(100% - 20px)", marginTop: 20,
+              background: membraneActive
+                ? `linear-gradient(180deg, transparent 0%, ${C.warmGold} 20%, ${C.warmGold} 80%, transparent 100%)`
+                : "rgba(var(--sand-100-rgb),0.08)",
+              borderRadius: 2, position: "relative",
+              transition: "background 0.6s ease",
+              animation: membraneGlow ? "membranePulse 0.4s ease-out" : undefined,
+              boxShadow: membraneActive ? "0 0 12px 2px rgba(var(--warm-gold-rgb),0.15)" : "none",
+            }}>
+              {/* Shield icon on membrane */}
+              <div style={{
+                position: "absolute", top: "50%", left: "50%",
+                transform: "translate(-50%, -50%)",
+                width: 28, height: 28, borderRadius: "50%",
+                background: "rgba(var(--espresso-rgb),0.95)",
+                border: `1.5px solid ${membraneActive ? C.warmGold : "rgba(var(--sand-100-rgb),0.12)"}`,
+                display: "flex", alignItems: "center", justifyContent: "center",
+                transition: "border-color 0.4s ease",
+                zIndex: 5,
+              }}>
+                <svg width="14" height="14" viewBox="0 0 20 20" fill="none">
+                  <path d="M10 2L3 5.5V10C3 14.5 6 17.5 10 19C14 17.5 17 14.5 17 10V5.5L10 2Z"
+                    fill={membraneActive ? "rgba(var(--warm-gold-rgb),0.2)" : "rgba(var(--sand-100-rgb),0.05)"}
+                    stroke={membraneActive ? C.warmGold : "rgba(var(--sand-100-rgb),0.15)"} strokeWidth="1.2" />
+                </svg>
+              </div>
+            </div>
+          </div>
+
+          {/* Right: masked data zone */}
+          <div style={{ position: "relative" }}>
+            <div style={{
+              fontFamily: "'JetBrains Mono', monospace", fontSize: 9, fontWeight: 500,
+              color: "rgba(var(--sand-100-rgb),0.20)", textTransform: "uppercase",
+              letterSpacing: "0.1em", marginBottom: 10, paddingLeft: 2,
+            }}>Delivered to user</div>
+
+            <div style={{
+              background: "rgba(var(--sand-100-rgb),0.03)", border: "1px solid rgba(var(--sand-100-rgb),0.06)",
+              borderRadius: 8, overflow: "hidden",
+            }}>
+              {ROWS.map((row, i) => {
+                const phase = rowPhases[i];
+                const show = phase === "through";
+                return (
+                  <div key={i} style={{
+                    padding: "8px 12px",
+                    borderBottom: i < ROWS.length - 1 ? "1px solid rgba(var(--sand-100-rgb),0.04)" : "none",
+                    opacity: show ? 1 : 0,
+                    transform: show ? "translateX(0)" : "translateX(10px)",
+                    transition: "opacity 0.4s ease, transform 0.4s ease",
+                    minHeight: 36, display: "flex", flexDirection: "column", justifyContent: "center", gap: 2,
+                  }}>
+                    <div style={{ display: "flex", gap: 8 }}>
+                      {row.masked.slice(0, 2).map((m, j) => (
+                        <span key={j} style={{
+                          fontFamily: "'JetBrains Mono', monospace", fontSize: 11,
+                          fontWeight: 600, color: C.warmGold,
+                        }}>{m}</span>
+                      ))}
+                    </div>
+                    <div style={{ display: "flex", gap: 8 }}>
+                      {row.masked.slice(2).map((m, j) => (
+                        <span key={j} style={{
+                          fontFamily: "'JetBrains Mono', monospace", fontSize: 10,
+                          fontWeight: 600, color: C.warmGold, opacity: 0.7,
+                        }}>{m}</span>
+                      ))}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+
+        {/* Bottom tags */}
+        <div style={{
+          display: "flex", gap: 8, marginTop: 16, position: "relative", zIndex: 1,
+          opacity: allDone ? 1 : 0, transform: allDone ? "translateY(0)" : "translateY(4px)",
+          transition: "opacity 0.5s ease, transform 0.5s ease", height: 20,
+        }}>
+          {["No schema required", "Zero-config proxy", "GDPR", "HIPAA"].map((tag) => (
+            <span key={tag} style={{
+              fontFamily: "'DM Sans', sans-serif", fontSize: 10, fontWeight: 600,
+              textTransform: "uppercase", color: "rgba(var(--sand-100-rgb),0.25)",
+              background: "rgba(var(--sand-100-rgb),0.04)", padding: "2px 8px",
+              borderRadius: 99, letterSpacing: "0.04em",
+            }}>{tag}</span>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/snippets/annimations/recording.jsx
+++ b/snippets/annimations/recording.jsx
@@ -1,0 +1,441 @@
+export const SessionRecording = () => {
+  const COLORS = {
+    espresso: "var(--gradient-dark-mid)",
+    bronzeDark: "var(--bronze-dark)",
+    bronze: "var(--bronze)",
+    warmGold: "var(--warm-gold)",
+    sand100: "var(--sand-100)",
+    sand200: "var(--sand-200)",
+    sand300: "var(--sand-300)",
+    sand400: "var(--sand-400)",
+    sand500: "var(--sand-500)",
+    nearBlack: "#111111",
+    strong: "#333333",
+    body: "#555555",
+    secondary: "#777777",
+    muted: "#999999",
+  };
+
+  const SESSION_LINES = [
+    { type: "prompt", text: "maria@prod-db-01:~$", cmd: " SELECT * FROM users WHERE role = 'admin';" },
+    { type: "output", lines: [
+      "  id  | name            | role   | last_login",
+      " -----+-----------------+--------+---------------------",
+      "  142 | sarah.chen       | admin  | 2026-03-21 09:14:22",
+      "  287 | james.walker     | admin  | 2026-03-20 18:47:01",
+      "  391 | alex.kumar       | admin  | 2026-03-21 11:02:55",
+      " (3 rows)",
+    ]},
+    { type: "prompt", text: "maria@prod-db-01:~$", cmd: " UPDATE users SET mfa_enabled = true WHERE role = 'admin';" },
+    { type: "output", lines: ["UPDATE 3"] },
+    { type: "prompt", text: "maria@prod-db-01:~$", cmd: " \\q" },
+    { type: "output", lines: ["Connection closed."] },
+  ];
+
+  const SESSION_META = {
+    user: "Maria Oliveira",
+    email: "maria@acme.com",
+    connection: "prod-db-01 (PostgreSQL)",
+    started: "Mar 21, 2026 · 11:02 UTC",
+    duration: "2m 34s",
+    status: "Completed",
+  };
+
+  function useTypewriter(text, speed = 32, startDelay = 0, active = false) {
+    const [displayed, setDisplayed] = useState("");
+    const [done, setDone] = useState(false);
+    const timerRef = useRef(null);
+    const intervalRef = useRef(null);
+
+    useEffect(() => {
+      if (!active) {
+        if (!done) { setDisplayed(""); setDone(false); }
+        return;
+      }
+      setDisplayed(""); setDone(false);
+      let i = 0;
+      timerRef.current = setTimeout(() => {
+        intervalRef.current = setInterval(() => {
+          i++;
+          setDisplayed(text.slice(0, i));
+          if (i >= text.length) {
+            clearInterval(intervalRef.current);
+            setDone(true);
+          }
+        }, speed);
+      }, startDelay);
+      return () => {
+        clearTimeout(timerRef.current);
+        clearInterval(intervalRef.current);
+      };
+    }, [text, speed, startDelay, active]);
+
+    return { displayed, done };
+  }
+
+  function PlaybackBar({ progress, elapsed, total }) {
+    return (
+      <div style={{
+        display: "flex", alignItems: "center", gap: 10,
+        padding: "10px 18px",
+        background: "rgba(0,0,0,0.25)",
+        borderTop: "1px solid rgba(var(--sand-100-rgb),0.06)",
+        fontFamily: "'JetBrains Mono', monospace",
+        fontSize: 11,
+      }}>
+        <svg width="12" height="14" viewBox="0 0 12 14" fill="none">
+          <path d="M1.5 1v12l9.5-6L1.5 1z" fill={COLORS.warmGold} opacity={0.6} />
+        </svg>
+        <span style={{ color: "rgba(var(--sand-100-rgb),0.35)", minWidth: 38 }}>{elapsed}</span>
+        <div style={{
+          flex: 1, height: 3, borderRadius: 2,
+          background: "rgba(var(--sand-100-rgb),0.08)",
+          overflow: "hidden",
+        }}>
+          <div style={{
+            width: `${progress}%`, height: "100%",
+            background: `linear-gradient(90deg, ${COLORS.warmGold}, ${COLORS.bronze})`,
+            borderRadius: 2, transition: "width 0.4s linear",
+          }} />
+        </div>
+        <span style={{ color: "rgba(var(--sand-100-rgb),0.2)", minWidth: 38, textAlign: "right" }}>{total}</span>
+      </div>
+    );
+  }
+
+  function MetaPanel({ visible }) {
+    const rows = [
+      { label: "USER", value: SESSION_META.user, sub: SESSION_META.email },
+      { label: "CONNECTION", value: SESSION_META.connection },
+      { label: "STARTED", value: SESSION_META.started },
+      { label: "DURATION", value: SESSION_META.duration },
+      { label: "STATUS", value: SESSION_META.status, badge: true },
+    ];
+    return (
+      <div style={{
+        width: 210, flexShrink: 0,
+        background: "rgba(0,0,0,0.18)",
+        borderLeft: "1px solid rgba(var(--sand-100-rgb),0.06)",
+        padding: "18px 16px",
+        display: "flex", flexDirection: "column", gap: 14,
+        opacity: visible ? 1 : 0,
+        transform: visible ? "translateX(0)" : "translateX(16px)",
+        transition: "opacity 0.6s ease, transform 0.6s ease",
+        fontFamily: "'DM Sans', sans-serif",
+        overflow: "hidden",
+      }}>
+        <div style={{
+          fontSize: 10, fontWeight: 600, letterSpacing: "0.1em",
+          color: COLORS.warmGold, textTransform: "uppercase",
+          paddingBottom: 6,
+          borderBottom: "1px solid rgba(var(--sand-100-rgb),0.06)",
+        }}>Session Details</div>
+        {rows.map((r, i) => (
+          <div key={i} style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+            <span style={{
+              fontSize: 9, fontWeight: 600, letterSpacing: "0.08em",
+              color: "rgba(var(--sand-100-rgb),0.25)", textTransform: "uppercase",
+            }}>{r.label}</span>
+            {r.badge ? (
+              <span style={{
+                display: "inline-block", width: "fit-content",
+                fontSize: 10, fontWeight: 600,
+                padding: "2px 8px", borderRadius: 99,
+                background: "rgba(var(--warm-gold-rgb),0.15)",
+                color: COLORS.warmGold,
+              }}>{r.value}</span>
+            ) : (
+              <span style={{ fontSize: 12, color: "rgba(var(--sand-100-rgb),0.6)", lineHeight: 1.4 }}>
+                {r.value}
+              </span>
+            )}
+            {r.sub && (
+              <span style={{ fontSize: 11, color: "rgba(var(--sand-100-rgb),0.3)" }}>{r.sub}</span>
+            )}
+          </div>
+        ))}
+        <div style={{ display: "flex", flexDirection: "column", gap: 5, marginTop: 2 }}>
+          <span style={{
+            fontSize: 9, fontWeight: 600, letterSpacing: "0.08em",
+            color: "rgba(var(--sand-100-rgb),0.25)", textTransform: "uppercase",
+          }}>TAGS</span>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
+            {["production", "database", "mfa-update"].map(tag => (
+              <span key={tag} style={{
+                fontSize: 10, padding: "2px 7px", borderRadius: 4,
+                background: "rgba(var(--sand-100-rgb),0.06)",
+                color: "rgba(var(--sand-100-rgb),0.3)",
+                border: "1px solid rgba(var(--sand-100-rgb),0.08)",
+              }}>{tag}</span>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  function RecordingDot({ active }) {
+    return (
+      <div style={{
+        display: "flex", alignItems: "center", gap: 6,
+        opacity: active ? 1 : 0.3, transition: "opacity 0.4s ease",
+      }}>
+        <div style={{
+          width: 7, height: 7, borderRadius: "50%",
+          background: active ? "#E05A47" : "rgba(var(--sand-100-rgb),0.2)",
+          boxShadow: active ? "0 0 8px rgba(224,90,71,0.4)" : "none",
+          animation: active ? "recPulse 1.4s ease-in-out infinite" : "none",
+        }} />
+        <span style={{
+          fontSize: 10, fontWeight: 600, letterSpacing: "0.06em",
+          color: active ? "rgba(var(--sand-100-rgb),0.45)" : "rgba(var(--sand-100-rgb),0.15)",
+          textTransform: "uppercase", fontFamily: "'DM Sans', sans-serif",
+        }}>REC</span>
+      </div>
+    );
+  }
+
+  function TermLine({ item, animate, onDone, delay = 0 }) {
+    const [showOutput, setShowOutput] = useState(false);
+    const [outputCount, setOutputCount] = useState(0);
+
+    const { displayed: cmdText, done: cmdDone } = useTypewriter(
+      item.type === "prompt" ? item.cmd : "", 32, delay,
+      animate && item.type === "prompt"
+    );
+
+    useEffect(() => {
+      if (item.type === "prompt" && cmdDone) {
+        const t = setTimeout(() => onDone?.(), 250);
+        return () => clearTimeout(t);
+      }
+    }, [cmdDone]);
+
+    useEffect(() => {
+      if (item.type === "output" && animate) {
+        const t = setTimeout(() => {
+          setShowOutput(true);
+          let i = 0;
+          const interval = setInterval(() => {
+            i++;
+            setOutputCount(i);
+            if (i >= item.lines.length) {
+              clearInterval(interval);
+              setTimeout(() => onDone?.(), 350);
+            }
+          }, 100);
+        }, delay);
+        return () => clearTimeout(t);
+      }
+    }, [animate]);
+
+    if (item.type === "prompt") {
+      return (
+        <div style={{ display: "flex", lineHeight: 2.0, whiteSpace: "pre" }}>
+          <span style={{ color: COLORS.warmGold, opacity: 0.7 }}>{item.text}</span>
+          <span style={{ color: COLORS.sand100, opacity: 0.85 }}>{cmdText}</span>
+          {animate && !cmdDone && (
+            <span style={{
+              display: "inline-block", width: 7, height: 15,
+              background: COLORS.warmGold, marginLeft: 1,
+              animation: "blink 0.7s step-end infinite",
+              verticalAlign: "middle", marginTop: 5,
+              borderRadius: 1,
+            }} />
+          )}
+        </div>
+      );
+    }
+
+    if (!showOutput) return null;
+    return (
+      <div style={{ marginBottom: 4 }}>
+        {item.lines.slice(0, outputCount).map((line, i) => (
+          <div key={i} style={{
+            color: "rgba(var(--sand-100-rgb),0.45)", lineHeight: 1.8,
+            whiteSpace: "pre", opacity: 0,
+            animation: "fadeInLine 0.25s ease forwards",
+            animationDelay: `${i * 50}ms`,
+          }}>{line}</div>
+        ))}
+      </div>
+    );
+  }
+
+  const [phase, setPhase] = useState(0);
+  const [metaVisible, setMetaVisible] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [cycle, setCycle] = useState(0);
+  const termRef = useRef(null);
+  const totalSteps = SESSION_LINES.length;
+
+  const handleLineDone = useCallback(() => {
+    setPhase(p => {
+      const next = p + 1;
+      setProgress((next / totalSteps) * 100);
+      return next;
+    });
+  }, [totalSteps]);
+
+  useEffect(() => {
+    const t = setTimeout(() => setMetaVisible(true), 900);
+    return () => clearTimeout(t);
+  }, [cycle]);
+
+  useEffect(() => {
+    if (termRef.current) {
+      termRef.current.scrollTop = termRef.current.scrollHeight;
+    }
+  }, [phase]);
+
+  useEffect(() => {
+    if (phase >= totalSteps) {
+      const t = setTimeout(() => {
+        setPhase(0);
+        setProgress(0);
+        setMetaVisible(false);
+        setCycle(c => c + 1);
+      }, 5000);
+      return () => clearTimeout(t);
+    }
+  }, [phase, totalSteps]);
+
+  const fmtTime = (pct) => {
+    const s = Math.round((pct / 100) * 154);
+    return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, "0")}`;
+  };
+
+  return (
+    <div style={{ width: "100%", maxWidth: 860, margin: "0 auto" }}>
+      <style>{`
+        @import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&family=Sora:wght@600;700;800&display=swap');
+        @keyframes blink { 0%,100%{opacity:1} 50%{opacity:0} }
+        @keyframes recPulse { 0%,100%{opacity:1;transform:scale(1)} 50%{opacity:0.3;transform:scale(0.85)} }
+        @keyframes fadeInLine { from{opacity:0;transform:translateY(2px)} to{opacity:1;transform:translateY(0)} }
+        @keyframes slideUp { from{opacity:0;transform:translateY(8px)} to{opacity:1;transform:translateY(0)} }
+      `}</style>
+
+      {/* Outer frame: self-contained dark gradient */}
+      <div style={{
+        background: "linear-gradient(135deg, var(--gradient-dark-start) 0%, var(--gradient-dark-mid) 35%, var(--gradient-dark-end) 70%, var(--bronze) 100%)",
+        borderRadius: 12,
+        position: "relative",
+        overflow: "hidden",
+        boxShadow: "0 4px 32px rgba(0,0,0,0.3), 0 1px 4px rgba(0,0,0,0.2)",
+      }}>
+        {/* Radial glow overlay */}
+        <div style={{
+          position: "absolute", top: "-30%", right: "-10%",
+          width: "60%", height: "160%",
+          background: "radial-gradient(ellipse at center, rgba(var(--warm-gold-rgb),0.12) 0%, transparent 70%)",
+          pointerEvents: "none", zIndex: 0,
+        }} />
+
+        <div style={{
+          position: "relative", zIndex: 1,
+          fontFamily: "'JetBrains Mono', monospace", fontSize: 13,
+        }}>
+          {/* Toolbar */}
+          <div style={{
+            display: "flex", alignItems: "center", justifyContent: "space-between",
+            padding: "11px 18px",
+            background: "rgba(0,0,0,0.2)",
+            borderBottom: "1px solid rgba(var(--sand-100-rgb),0.06)",
+          }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 7 }}>
+              <div style={{ width: 9, height: 9, borderRadius: "50%", background: "rgba(var(--sand-100-rgb),0.12)" }} />
+              <div style={{ width: 9, height: 9, borderRadius: "50%", background: "rgba(var(--sand-100-rgb),0.12)" }} />
+              <div style={{ width: 9, height: 9, borderRadius: "50%", background: "rgba(var(--sand-100-rgb),0.12)" }} />
+            </div>
+            <div style={{
+              display: "flex", alignItems: "center", gap: 8,
+              padding: "4px 14px", borderRadius: 5,
+              background: "rgba(0,0,0,0.15)",
+              border: "1px solid rgba(var(--sand-100-rgb),0.04)",
+              fontSize: 11, color: "rgba(var(--sand-100-rgb),0.25)",
+              fontFamily: "'DM Sans', sans-serif",
+            }}>
+              <svg width="10" height="10" viewBox="0 0 16 16" fill="none">
+                <rect x="2" y="7" width="12" height="2" rx="1" fill="rgba(var(--sand-100-rgb),0.15)" />
+                <rect x="7" y="2" width="2" height="12" rx="1" fill="rgba(var(--sand-100-rgb),0.15)" />
+              </svg>
+              app.hoop.dev/sessions/rec-3f8a2e
+            </div>
+            <RecordingDot active={phase < totalSteps} />
+          </div>
+
+          {/* Tabs */}
+          <div style={{
+            display: "flex", gap: 0,
+            background: "rgba(0,0,0,0.12)",
+            borderBottom: "1px solid rgba(var(--sand-100-rgb),0.06)",
+            fontFamily: "'DM Sans', sans-serif", fontSize: 12,
+          }}>
+            {["Terminal", "Logs", "Video"].map((tab, i) => (
+              <div key={tab} style={{
+                padding: "9px 20px",
+                color: i === 0 ? "rgba(var(--sand-100-rgb),0.75)" : "rgba(var(--sand-100-rgb),0.2)",
+                borderBottom: i === 0 ? `2px solid ${COLORS.warmGold}` : "2px solid transparent",
+                background: i === 0 ? "rgba(var(--sand-100-rgb),0.02)" : "transparent",
+                cursor: "default",
+              }}>{tab}</div>
+            ))}
+          </div>
+
+          {/* Main content */}
+          <div style={{
+            display: "flex",
+            background: "rgba(0,0,0,0.10)",
+            minHeight: 340,
+          }}>
+            {/* Terminal */}
+            <div
+              ref={termRef}
+              style={{
+                flex: 1, padding: "20px 22px",
+                overflowY: "auto", overflowX: "hidden",
+                maxHeight: 340, scrollbarWidth: "none",
+              }}
+            >
+              {SESSION_LINES.filter((_, i) => i <= phase).map((item, i) => (
+                <TermLine
+                  key={`${cycle}-${i}`}
+                  item={item}
+                  animate={phase === i}
+                  onDone={handleLineDone}
+                  delay={i === 0 ? 700 : 200}
+                />
+              ))}
+
+              {phase >= totalSteps && (
+                <div style={{
+                  marginTop: 18, padding: "10px 14px",
+                  borderRadius: 6,
+                  background: "rgba(var(--warm-gold-rgb),0.08)",
+                  border: "1px solid rgba(var(--warm-gold-rgb),0.15)",
+                  display: "flex", alignItems: "center", gap: 8,
+                  animation: "slideUp 0.5s ease forwards",
+                }}>
+                  <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+                    <circle cx="7" cy="7" r="5.5" stroke={COLORS.warmGold} strokeWidth="1" opacity={0.5} />
+                    <path d="M4.5 7l1.8 1.8L9.5 5.5" stroke={COLORS.warmGold} strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" fill="none" />
+                  </svg>
+                  <span style={{
+                    fontSize: 12, color: COLORS.warmGold, opacity: 0.8,
+                    fontFamily: "'DM Sans', sans-serif",
+                  }}>Session recorded. 6 events captured.</span>
+                </div>
+              )}
+            </div>
+
+            {/* Sidebar */}
+            <MetaPanel visible={metaVisible} />
+          </div>
+
+          {/* Playback */}
+          <PlaybackBar progress={progress} elapsed={fmtTime(progress)} total="2:34" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/snippets/annimations/runbookminiflow.jsx
+++ b/snippets/annimations/runbookminiflow.jsx
@@ -1,0 +1,1019 @@
+export const RunbooksAnimation = () => {
+  const BRONZE = "var(--bronze)";
+  const BRONZE_DARK = "var(--bronze-dark)";
+  const ESPRESSO = "var(--gradient-dark-mid)";
+  const WARM_GOLD = "var(--warm-gold)";
+  const SAND_100 = "var(--sand-100)";
+  const SAND_200 = "var(--sand-200)";
+  const SAND_300 = "var(--sand-300)";
+  const SAND_400 = "var(--sand-400)";
+  const SAND_500 = "var(--sand-500)";
+  const TEXT_PRIMARY = "#111111";
+  const TEXT_STRONG = "#333333";
+  const TEXT_BODY = "#555555";
+  const TEXT_SECONDARY = "#777777";
+  const TEXT_MUTED = "#999999";
+
+  const FONTS = `@import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;0,9..40,800&family=JetBrains+Mono:wght@400;500&family=Sora:wght@600;700;800&display=swap');`;
+
+  const PHASES = [
+    { id: "git-sync", label: "Git Sync", duration: 5000 },
+    { id: "select", label: "Select Runbook", duration: 4200 },
+    { id: "fill-params", label: "Fill Parameters", duration: 5200 },
+    { id: "approval", label: "Approval", duration: 4800 },
+    { id: "execute", label: "Execute", duration: 6000 },
+    { id: "audit", label: "Audit Trail", duration: 5000 },
+  ];
+
+  const TOTAL_DURATION = PHASES.reduce((a, p) => a + p.duration, 0);
+
+  function easeOut(t) {
+    return 1 - Math.pow(1 - Math.min(1, Math.max(0, t)), 3);
+  }
+  function easeInOut(t) {
+    t = Math.min(1, Math.max(0, t));
+    return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
+  }
+
+  function HoopDots({ size = 14, color = SAND_500 }) {
+    const r = size * 0.145;
+    const g = size * 0.29;
+    return (
+      <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+        <circle cx={size / 2 - g} cy={size / 2 - g} r={r} fill={color} />
+        <circle cx={size / 2 + g} cy={size / 2 - g} r={r} fill={color} />
+        <circle cx={size / 2 - g} cy={size / 2 + g} r={r} fill={color} />
+        <circle cx={size / 2 + g} cy={size / 2 + g} r={r} fill={color} />
+      </svg>
+    );
+  }
+
+  function MockFrame({ children, title = "hoop.dev", phase }) {
+    return (
+      <div
+        style={{
+          background: "rgba(var(--sand-100-rgb),0.04)",
+          border: "1px solid rgba(var(--sand-100-rgb),0.08)",
+          borderRadius: 12,
+          overflow: "hidden",
+          width: "100%",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            padding: "10px 16px",
+            background: "rgba(var(--sand-100-rgb),0.03)",
+            borderBottom: "1px solid rgba(var(--sand-100-rgb),0.06)",
+          }}
+        >
+          <div style={{ display: "flex", gap: 5 }}>
+            {[0, 1, 2].map((i) => (
+              <div
+                key={i}
+                style={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: "50%",
+                  background: `rgba(var(--sand-100-rgb),0.10)`,
+                }}
+              />
+            ))}
+          </div>
+          <div
+            style={{
+              flex: 1,
+              background: "rgba(var(--sand-100-rgb),0.04)",
+              borderRadius: 5,
+              padding: "4px 12px",
+              fontFamily: "'JetBrains Mono', monospace",
+              fontSize: 11,
+              color: "rgba(var(--sand-100-rgb),0.20)",
+              letterSpacing: "0.02em",
+            }}
+          >
+            {title}
+          </div>
+        </div>
+        <div style={{ padding: "20px 24px", height: 300, overflow: "hidden" }}>{children}</div>
+      </div>
+    );
+  }
+
+  function GitSyncScene({ progress }) {
+    const showBranch = progress > 0.1;
+    const showFiles = progress > 0.3;
+    const syncPulse = progress > 0.55;
+    const synced = progress > 0.8;
+
+    const files = [
+      "team/dba/ops/restart-service.runbook.sh",
+      "team/finops/sql/fetch-customer.runbook.sql",
+      "team/sre/k8s/rollout-deploy.runbook.sh",
+    ];
+
+    return (
+      <div>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            marginBottom: 20,
+            opacity: easeOut(progress * 3),
+          }}
+        >
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+            <circle cx="8" cy="3" r="2" stroke={WARM_GOLD} strokeWidth="1.2" fill="none" />
+            <circle cx="8" cy="13" r="2" stroke={WARM_GOLD} strokeWidth="1.2" fill="none" />
+            <line x1="8" y1="5" x2="8" y2="11" stroke={WARM_GOLD} strokeWidth="1.2" />
+            {showBranch && (
+              <>
+                <circle cx="13" cy="8" r="2" stroke="rgba(var(--sand-100-rgb),0.3)" strokeWidth="1.2" fill="none" />
+                <path d="M8 7 Q10 7 13 6" stroke="rgba(var(--sand-100-rgb),0.3)" strokeWidth="1.2" fill="none" />
+              </>
+            )}
+          </svg>
+          <span
+            style={{
+              fontFamily: "'JetBrains Mono', monospace",
+              fontSize: 12,
+              color: "rgba(var(--sand-100-rgb),0.5)",
+            }}
+          >
+            main
+          </span>
+          {syncPulse && (
+            <span
+              style={{
+                fontFamily: "'DM Sans', sans-serif",
+                fontSize: 10,
+                fontWeight: 600,
+                textTransform: "uppercase",
+                letterSpacing: "0.1em",
+                color: synced ? WARM_GOLD : "rgba(var(--sand-100-rgb),0.25)",
+                background: synced
+                  ? "rgba(var(--warm-gold-rgb),0.12)"
+                  : "rgba(var(--sand-100-rgb),0.04)",
+                padding: "2px 8px",
+                borderRadius: 20,
+                transition: "all 0.5s ease",
+              }}
+            >
+              {synced ? "synced" : "syncing..."}
+            </span>
+          )}
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          {files.map((f, i) => {
+            const fileProgress = Math.max(
+              0,
+              Math.min(1, (progress - 0.3 - i * 0.12) * 5)
+            );
+            return (
+              <div
+                key={f}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 10,
+                  opacity: easeOut(fileProgress),
+                  transform: `translateX(${(1 - easeOut(fileProgress)) * 20}px)`,
+                  transition: "transform 0.3s ease",
+                }}
+              >
+                <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+                  <rect
+                    x="2"
+                    y="1"
+                    width="10"
+                    height="12"
+                    rx="1.5"
+                    stroke="rgba(var(--sand-100-rgb),0.2)"
+                    strokeWidth="1"
+                    fill="none"
+                  />
+                  <line
+                    x1="4.5"
+                    y1="5"
+                    x2="9.5"
+                    y2="5"
+                    stroke="rgba(var(--sand-100-rgb),0.12)"
+                    strokeWidth="0.8"
+                  />
+                  <line
+                    x1="4.5"
+                    y1="7.5"
+                    x2="8"
+                    y2="7.5"
+                    stroke="rgba(var(--sand-100-rgb),0.12)"
+                    strokeWidth="0.8"
+                  />
+                </svg>
+                <span
+                  style={{
+                    fontFamily: "'JetBrains Mono', monospace",
+                    fontSize: 11,
+                    color: "rgba(var(--sand-100-rgb),0.5)",
+                  }}
+                >
+                  {f}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+
+        {synced && (
+          <div
+            style={{
+              marginTop: 20,
+              padding: "10px 14px",
+              background: "rgba(var(--sand-100-rgb),0.03)",
+              borderRadius: 6,
+              border: "1px solid rgba(var(--sand-100-rgb),0.06)",
+              opacity: easeOut((progress - 0.8) * 5),
+            }}
+          >
+            <span
+              style={{
+                fontFamily: "'JetBrains Mono', monospace",
+                fontSize: 11,
+                color: WARM_GOLD,
+              }}
+            >
+              a3f8c2e
+            </span>
+            <span
+              style={{
+                fontFamily: "'DM Sans', sans-serif",
+                fontSize: 12,
+                color: "rgba(var(--sand-100-rgb),0.35)",
+                marginLeft: 10,
+              }}
+            >
+              add k8s rollout runbook
+            </span>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  function SelectScene({ progress }) {
+    const runbooks = [
+      { name: "fetch-customer.runbook.sql", team: "finops", selected: false },
+      { name: "restart-service.runbook.sh", team: "dba", selected: true },
+      { name: "rollout-deploy.runbook.sh", team: "sre", selected: false },
+    ];
+    const selectProgress = easeInOut(Math.max(0, (progress - 0.4) * 2.5));
+
+    return (
+      <div>
+        <div
+          style={{
+            fontFamily: "'DM Sans', sans-serif",
+            fontSize: 11,
+            fontWeight: 600,
+            textTransform: "uppercase",
+            letterSpacing: "0.1em",
+            color: WARM_GOLD,
+            marginBottom: 14,
+            opacity: easeOut(progress * 3),
+          }}
+        >
+          Select Runbook
+        </div>
+        <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+          {runbooks.map((rb, i) => {
+            const rowOpacity = easeOut(Math.max(0, (progress - i * 0.1) * 4));
+            const isHighlighted = rb.selected && selectProgress > 0;
+            return (
+              <div
+                key={rb.name}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  padding: "10px 14px",
+                  borderRadius: 6,
+                  background: isHighlighted
+                    ? `rgba(var(--warm-gold-rgb),${0.08 * selectProgress})`
+                    : "rgba(var(--sand-100-rgb),0.02)",
+                  border: `1px solid ${
+                    isHighlighted
+                      ? `rgba(var(--warm-gold-rgb),${0.2 * selectProgress})`
+                      : "rgba(var(--sand-100-rgb),0.04)"
+                  }`,
+                  opacity: rowOpacity,
+                  transform: `translateY(${(1 - rowOpacity) * 8}px)`,
+                  transition: "background 0.4s, border-color 0.4s",
+                }}
+              >
+                <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                  <span
+                    style={{
+                      fontFamily: "'JetBrains Mono', monospace",
+                      fontSize: 11,
+                      color: isHighlighted
+                        ? WARM_GOLD
+                        : "rgba(var(--sand-100-rgb),0.5)",
+                      transition: "color 0.4s",
+                    }}
+                  >
+                    {rb.name}
+                  </span>
+                </div>
+                <span
+                  style={{
+                    fontFamily: "'DM Sans', sans-serif",
+                    fontSize: 10,
+                    fontWeight: 600,
+                    textTransform: "uppercase",
+                    letterSpacing: "0.08em",
+                    color: "rgba(var(--sand-100-rgb),0.2)",
+                    background: "rgba(var(--sand-100-rgb),0.04)",
+                    padding: "2px 8px",
+                    borderRadius: 20,
+                  }}
+                >
+                  {rb.team}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+        {selectProgress > 0.5 && (
+          <div
+            style={{
+              marginTop: 16,
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
+              opacity: easeOut((selectProgress - 0.5) * 2),
+            }}
+          >
+            <svg width="10" height="10" viewBox="0 0 10 10" fill={WARM_GOLD}>
+              <polygon points="2,1 8,5 2,9" />
+            </svg>
+            <span
+              style={{
+                fontFamily: "'DM Sans', sans-serif",
+                fontSize: 12,
+                color: "rgba(var(--sand-100-rgb),0.4)",
+              }}
+            >
+              Connection: <span style={{ color: "rgba(var(--sand-100-rgb),0.6)" }}>prod-postgres</span>
+            </span>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  function FillParamsScene({ progress }) {
+    const typingProgress = easeOut(Math.max(0, (progress - 0.2) * 1.8));
+    const typedText = "1040".slice(0, Math.floor(typingProgress * 4));
+    const cursorVisible = progress < 0.85 && Math.floor(progress * 10) % 2 === 0;
+    const templateShown = progress > 0.6;
+
+    return (
+      <div>
+        <div
+          style={{
+            fontFamily: "'DM Sans', sans-serif",
+            fontSize: 11,
+            fontWeight: 600,
+            textTransform: "uppercase",
+            letterSpacing: "0.1em",
+            color: WARM_GOLD,
+            marginBottom: 14,
+            opacity: easeOut(progress * 4),
+          }}
+        >
+          restart-service.runbook.sh
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+          <div style={{ opacity: easeOut(progress * 3) }}>
+            <div
+              style={{
+                fontFamily: "'DM Sans', sans-serif",
+                fontSize: 11,
+                color: "rgba(var(--sand-100-rgb),0.3)",
+                marginBottom: 4,
+              }}
+            >
+              service_name <span style={{ color: "rgba(var(--warm-gold-rgb),0.5)", fontSize: 9 }}>required</span>
+            </div>
+            <div
+              style={{
+                padding: "8px 12px",
+                background: "rgba(var(--sand-100-rgb),0.04)",
+                border: "1px solid rgba(var(--sand-100-rgb),0.08)",
+                borderRadius: 5,
+                fontFamily: "'JetBrains Mono', monospace",
+                fontSize: 12,
+                color: "rgba(var(--sand-100-rgb),0.6)",
+              }}
+            >
+              payment-api
+            </div>
+          </div>
+
+          <div style={{ opacity: easeOut(Math.max(0, (progress - 0.1) * 3)) }}>
+            <div
+              style={{
+                fontFamily: "'DM Sans', sans-serif",
+                fontSize: 11,
+                color: "rgba(var(--sand-100-rgb),0.3)",
+                marginBottom: 4,
+              }}
+            >
+              namespace
+            </div>
+            <div
+              style={{
+                padding: "8px 12px",
+                background: "rgba(var(--sand-100-rgb),0.04)",
+                border: `1px solid ${
+                  typingProgress > 0 && typingProgress < 1
+                    ? "rgba(var(--warm-gold-rgb),0.3)"
+                    : "rgba(var(--sand-100-rgb),0.08)"
+                }`,
+                borderRadius: 5,
+                fontFamily: "'JetBrains Mono', monospace",
+                fontSize: 12,
+                color: "rgba(var(--sand-100-rgb),0.6)",
+                transition: "border-color 0.3s",
+              }}
+            >
+              production
+            </div>
+          </div>
+
+          <div style={{ opacity: easeOut(Math.max(0, (progress - 0.15) * 3)) }}>
+            <div
+              style={{
+                fontFamily: "'DM Sans', sans-serif",
+                fontSize: 11,
+                color: "rgba(var(--sand-100-rgb),0.3)",
+                marginBottom: 4,
+              }}
+            >
+              replicas <span style={{ color: "rgba(var(--sand-100-rgb),0.15)", fontSize: 9 }}>default: 2</span>
+            </div>
+            <div
+              style={{
+                padding: "8px 12px",
+                background: "rgba(var(--sand-100-rgb),0.04)",
+                border: "1px solid rgba(var(--sand-100-rgb),0.08)",
+                borderRadius: 5,
+                fontFamily: "'JetBrains Mono', monospace",
+                fontSize: 12,
+                color: "rgba(var(--sand-100-rgb),0.35)",
+              }}
+            >
+              3{cursorVisible && typingProgress < 1 ? "" : ""}
+            </div>
+          </div>
+        </div>
+
+        {templateShown && (
+          <div
+            style={{
+              marginTop: 16,
+              padding: "10px 14px",
+              background: ESPRESSO,
+              borderRadius: 6,
+              opacity: easeOut((progress - 0.6) * 2.5),
+            }}
+          >
+            <div
+              style={{
+                fontFamily: "'JetBrains Mono', monospace",
+                fontSize: 11,
+                lineHeight: 2,
+              }}
+            >
+              <span style={{ color: "var(--prompt)" }}>$</span>{" "}
+              <span style={{ color: "var(--sand-300)" }}>kubectl rollout restart</span>{" "}
+              <span style={{ color: WARM_GOLD }}>payment-api</span>{" "}
+              <span style={{ color: "var(--sand-300)" }}>-n</span>{" "}
+              <span style={{ color: WARM_GOLD }}>production</span>
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  function ApprovalScene({ progress }) {
+    const requestSent = progress > 0.15;
+    const reviewerAppears = progress > 0.35;
+    const approved = progress > 0.7;
+
+    return (
+      <div>
+        <div
+          style={{
+            fontFamily: "'DM Sans', sans-serif",
+            fontSize: 11,
+            fontWeight: 600,
+            textTransform: "uppercase",
+            letterSpacing: "0.1em",
+            color: WARM_GOLD,
+            marginBottom: 14,
+            opacity: easeOut(progress * 4),
+          }}
+        >
+          Just-in-Time Review
+        </div>
+
+        <div
+          style={{
+            padding: "14px 16px",
+            background: "rgba(var(--sand-100-rgb),0.03)",
+            border: "1px solid rgba(var(--sand-100-rgb),0.06)",
+            borderRadius: 8,
+            marginBottom: 12,
+            opacity: easeOut(Math.max(0, (progress - 0.05) * 4)),
+          }}
+        >
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 8 }}>
+            <span style={{ fontFamily: "'DM Sans', sans-serif", fontSize: 13, fontWeight: 500, color: SAND_100 }}>
+              restart-service.runbook.sh
+            </span>
+            <span
+              style={{
+                fontFamily: "'DM Sans', sans-serif",
+                fontSize: 10,
+                fontWeight: 600,
+                textTransform: "uppercase",
+                letterSpacing: "0.08em",
+                color: requestSent
+                  ? approved
+                    ? WARM_GOLD
+                    : "rgba(var(--sand-100-rgb),0.4)"
+                  : "rgba(var(--sand-100-rgb),0.2)",
+                background: approved
+                  ? "rgba(var(--warm-gold-rgb),0.12)"
+                  : "rgba(var(--sand-100-rgb),0.04)",
+                padding: "2px 8px",
+                borderRadius: 20,
+                transition: "all 0.5s ease",
+              }}
+            >
+              {approved ? "approved" : requestSent ? "pending" : "draft"}
+            </span>
+          </div>
+          <div
+            style={{
+              fontFamily: "'DM Sans', sans-serif",
+              fontSize: 11,
+              color: "rgba(var(--sand-100-rgb),0.3)",
+            }}
+          >
+            Requested by <span style={{ color: "rgba(var(--sand-100-rgb),0.5)" }}>ana@company.com</span>
+            {" · "}prod-postgres
+          </div>
+        </div>
+
+        {reviewerAppears && (
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 10,
+              padding: "10px 14px",
+              opacity: easeOut((progress - 0.35) * 3),
+              transform: `translateY(${(1 - easeOut((progress - 0.35) * 3)) * 10}px)`,
+            }}
+          >
+            <div
+              style={{
+                width: 28,
+                height: 28,
+                borderRadius: "50%",
+                background: "rgba(var(--sand-100-rgb),0.06)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                fontFamily: "'DM Sans', sans-serif",
+                fontSize: 11,
+                fontWeight: 600,
+                color: "rgba(var(--sand-100-rgb),0.3)",
+              }}
+            >
+              MP
+            </div>
+            <div>
+              <div
+                style={{
+                  fontFamily: "'DM Sans', sans-serif",
+                  fontSize: 12,
+                  color: "rgba(var(--sand-100-rgb),0.5)",
+                }}
+              >
+                marcos@company.com
+              </div>
+              <div
+                style={{
+                  fontFamily: "'DM Sans', sans-serif",
+                  fontSize: 10,
+                  color: approved ? WARM_GOLD : "rgba(var(--sand-100-rgb),0.2)",
+                  transition: "color 0.5s",
+                }}
+              >
+                {approved ? "Approved" : "Reviewing..."}
+              </div>
+            </div>
+            {approved && (
+              <svg
+                width="18"
+                height="18"
+                viewBox="0 0 18 18"
+                style={{
+                  marginLeft: "auto",
+                  opacity: easeOut((progress - 0.7) * 3),
+                }}
+              >
+                <circle cx="9" cy="9" r="8" fill="rgba(var(--warm-gold-rgb),0.15)" />
+                <polyline
+                  points="5.5,9.5 8,12 12.5,6.5"
+                  stroke={WARM_GOLD}
+                  strokeWidth="1.5"
+                  fill="none"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  function ExecuteScene({ progress }) {
+    const lines = [
+      { type: "prompt", text: "$ kubectl rollout restart payment-api -n production" },
+      { type: "output", text: "deployment.apps/payment-api restarted" },
+      { type: "output", text: "Waiting for rollout to finish: 0 of 3 updated..." },
+      { type: "output", text: "Waiting for rollout to finish: 1 of 3 updated..." },
+      { type: "output", text: "Waiting for rollout to finish: 2 of 3 updated..." },
+      { type: "success", text: "deployment \"payment-api\" successfully rolled out" },
+    ];
+
+    const visibleLines = Math.floor(progress * (lines.length + 1));
+
+    return (
+      <div
+        style={{
+          background: ESPRESSO,
+          borderRadius: 8,
+          padding: "18px 20px",
+          fontFamily: "'JetBrains Mono', monospace",
+          fontSize: 11,
+          lineHeight: 2.2,
+        }}
+      >
+        {lines.slice(0, visibleLines).map((line, i) => {
+          const lineProgress = easeOut(
+            Math.max(0, (progress - (i / lines.length) * 0.85) * 4)
+          );
+          return (
+            <div
+              key={i}
+              style={{
+                opacity: lineProgress,
+                transform: `translateY(${(1 - lineProgress) * 6}px)`,
+              }}
+            >
+              {line.type === "prompt" && (
+                <>
+                  <span style={{ color: "var(--prompt)" }}>$ </span>
+                  <span style={{ color: "var(--sand-300)" }}>{line.text.slice(2)}</span>
+                </>
+              )}
+              {line.type === "output" && (
+                <span style={{ color: "rgba(232,221,208,0.45)" }}>{line.text}</span>
+              )}
+              {line.type === "success" && (
+                <span style={{ color: WARM_GOLD, fontWeight: 500 }}>
+                  {line.text}
+                </span>
+              )}
+            </div>
+          );
+        })}
+        {visibleLines <= lines.length && (
+          <span
+            style={{
+              display: "inline-block",
+              width: 7,
+              height: 14,
+              background: "rgba(var(--sand-100-rgb),0.3)",
+              animation: "blink 1s step-end infinite",
+              verticalAlign: "middle",
+              marginTop: 2,
+            }}
+          />
+        )}
+      </div>
+    );
+  }
+
+  function AuditScene({ progress }) {
+    const events = [
+      { time: "14:32:01", action: "Runbook selected", user: "ana@company.com", icon: "file" },
+      { time: "14:32:08", action: "Parameters filled", user: "ana@company.com", icon: "edit" },
+      { time: "14:32:15", action: "Review requested", user: "ana@company.com", icon: "clock" },
+      { time: "14:33:42", action: "Approved", user: "marcos@company.com", icon: "check" },
+      { time: "14:33:44", action: "Executed", user: "system", icon: "play" },
+      { time: "14:34:12", action: "Session recorded", user: "system", icon: "record" },
+    ];
+
+    return (
+      <div>
+        <div
+          style={{
+            fontFamily: "'DM Sans', sans-serif",
+            fontSize: 11,
+            fontWeight: 600,
+            textTransform: "uppercase",
+            letterSpacing: "0.1em",
+            color: WARM_GOLD,
+            marginBottom: 14,
+            opacity: easeOut(progress * 4),
+          }}
+        >
+          Audit Trail
+        </div>
+        <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+          {events.map((evt, i) => {
+            const evtProgress = easeOut(Math.max(0, (progress - i * 0.1) * 3));
+            return (
+              <div
+                key={i}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 12,
+                  padding: "7px 12px",
+                  opacity: evtProgress,
+                  transform: `translateY(${(1 - evtProgress) * 8}px)`,
+                  borderLeft: `2px solid ${
+                    i === events.length - 1 && progress > 0.8
+                      ? WARM_GOLD
+                      : "rgba(var(--sand-100-rgb),0.06)"
+                  }`,
+                  transition: "border-color 0.5s",
+                }}
+              >
+                <span
+                  style={{
+                    fontFamily: "'JetBrains Mono', monospace",
+                    fontSize: 10,
+                    color: "rgba(var(--sand-100-rgb),0.2)",
+                    minWidth: 56,
+                  }}
+                >
+                  {evt.time}
+                </span>
+                <span
+                  style={{
+                    fontFamily: "'DM Sans', sans-serif",
+                    fontSize: 12,
+                    color: "rgba(var(--sand-100-rgb),0.55)",
+                    flex: 1,
+                  }}
+                >
+                  {evt.action}
+                </span>
+                <span
+                  style={{
+                    fontFamily: "'JetBrains Mono', monospace",
+                    fontSize: 10,
+                    color: "rgba(var(--sand-100-rgb),0.2)",
+                  }}
+                >
+                  {evt.user}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+
+  function Timeline({ currentPhaseIndex, phaseProgress }) {
+    return (
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 0,
+          width: "100%",
+          padding: "0 4px",
+        }}
+      >
+        {PHASES.map((phase, i) => {
+          const isActive = i === currentPhaseIndex;
+          const isPast = i < currentPhaseIndex;
+          return (
+            <div
+              key={phase.id}
+              style={{
+                flex: 1,
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                gap: 8,
+              }}
+            >
+              <div
+                style={{
+                  width: "100%",
+                  height: 2,
+                  background: "rgba(var(--sand-100-rgb),0.06)",
+                  borderRadius: 1,
+                  overflow: "hidden",
+                }}
+              >
+                <div
+                  style={{
+                    height: "100%",
+                    width: `${isPast ? 100 : isActive ? phaseProgress * 100 : 0}%`,
+                    background: isPast || isActive ? WARM_GOLD : "transparent",
+                    borderRadius: 1,
+                    transition: isPast ? "none" : "width 0.1s linear",
+                  }}
+                />
+              </div>
+              <span
+                style={{
+                  fontFamily: "'DM Sans', sans-serif",
+                  fontSize: 9,
+                  fontWeight: isActive ? 600 : 400,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.08em",
+                  color: isActive
+                    ? WARM_GOLD
+                    : isPast
+                    ? "rgba(var(--sand-100-rgb),0.3)"
+                    : "rgba(var(--sand-100-rgb),0.12)",
+                  transition: "color 0.3s",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {phase.label}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
+  function useAnimationClock() {
+    const [elapsed, setElapsed] = useState(0);
+    const rafRef = useRef();
+    const startRef = useRef();
+
+    useEffect(() => {
+      startRef.current = performance.now();
+      const tick = (now) => {
+        const e = now - startRef.current;
+        setElapsed(e % TOTAL_DURATION);
+        rafRef.current = requestAnimationFrame(tick);
+      };
+      rafRef.current = requestAnimationFrame(tick);
+      return () => cancelAnimationFrame(rafRef.current);
+    }, []);
+
+    let cumulative = 0;
+    let currentPhaseIndex = 0;
+    let phaseProgress = 0;
+    for (let i = 0; i < PHASES.length; i++) {
+      if (elapsed < cumulative + PHASES[i].duration) {
+        currentPhaseIndex = i;
+        phaseProgress = (elapsed - cumulative) / PHASES[i].duration;
+        break;
+      }
+      cumulative += PHASES[i].duration;
+    }
+
+    return { elapsed, currentPhaseIndex, phaseProgress };
+  }
+
+  const { currentPhaseIndex, phaseProgress } = useAnimationClock();
+
+  const scenes = [
+    GitSyncScene,
+    SelectScene,
+    FillParamsScene,
+    ApprovalScene,
+    ExecuteScene,
+    AuditScene,
+  ];
+  const CurrentScene = scenes[currentPhaseIndex];
+
+  return (
+    <>
+      <style>{FONTS}</style>
+      <style>{`
+        @keyframes blink {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0; }
+        }
+      `}</style>
+      <div
+        style={{
+          width: "100%",
+          maxWidth: 620,
+          margin: "0 auto",
+          fontFamily: "'DM Sans', system-ui, sans-serif",
+        }}
+      >
+        <div
+          style={{
+            background:
+              "linear-gradient(135deg, var(--gradient-dark-start) 0%, var(--gradient-dark-mid) 35%, var(--gradient-dark-end) 70%, var(--bronze) 100%)",
+            borderRadius: 14,
+            padding: "28px 28px 24px",
+            position: "relative",
+            overflow: "hidden",
+          }}
+        >
+          <div
+            style={{
+              position: "absolute",
+              top: "-30%",
+              right: "-10%",
+              width: "60%",
+              height: "160%",
+              background:
+                "radial-gradient(ellipse at center, rgba(var(--warm-gold-rgb),0.12) 0%, transparent 70%)",
+              pointerEvents: "none",
+            }}
+          />
+
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              marginBottom: 20,
+              position: "relative",
+              zIndex: 1,
+            }}
+          >
+            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+              <HoopDots size={14} color={SAND_100} />
+              <span
+                style={{
+                  fontFamily: "'DM Sans', sans-serif",
+                  fontSize: 13,
+                  fontWeight: 700,
+                  color: SAND_100,
+                  letterSpacing: "0.01em",
+                }}
+              >
+                hoop.dev
+              </span>
+            </div>
+            <span
+              style={{
+                fontFamily: "'Sora', sans-serif",
+                fontSize: 13,
+                fontWeight: 600,
+                color: WARM_GOLD,
+                letterSpacing: "-0.01em",
+              }}
+            >
+              Runbooks
+            </span>
+          </div>
+
+          <div style={{ position: "relative", zIndex: 1, marginBottom: 20 }}>
+            <MockFrame title="app.hoop.dev/runbooks" phase={currentPhaseIndex}>
+              <CurrentScene progress={phaseProgress} />
+            </MockFrame>
+          </div>
+
+          <div style={{ position: "relative", zIndex: 1 }}>
+            <Timeline
+              currentPhaseIndex={currentPhaseIndex}
+              phaseProgress={phaseProgress}
+            />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/snippets/annimations/runbookparalellmode.jsx
+++ b/snippets/annimations/runbookparalellmode.jsx
@@ -1,0 +1,673 @@
+export const RunbooksAnimation = () => {
+  const COLORS = {
+    nearBlack: "#111111",
+    strong: "#333333",
+    body: "#555555",
+    secondary: "#777777",
+    muted: "#999999",
+    bronze: "var(--bronze)",
+    bronzeDark: "var(--bronze-dark)",
+    espresso: "var(--gradient-dark-mid)",
+    warmGold: "var(--warm-gold)",
+    sand100: "var(--sand-100)",
+    sand200: "var(--sand-200)",
+    sand300: "var(--sand-300)",
+    sand400: "var(--sand-400)",
+    sand500: "var(--sand-500)",
+  };
+
+  const icons = {
+    key: (color) => (
+      <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke={color} strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
+        <circle cx="10.5" cy="5.5" r="3" />
+        <path d="M8.2 7.8L3 13l0-2.5L5.5 13" />
+        <path d="M5.5 10.5l2-2" />
+      </svg>
+    ),
+    scale: (color) => (
+      <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke={color} strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M2 8h12M8 2v12M4 4l8 8M12 4l-8 8" />
+      </svg>
+    ),
+    restart: (color) => (
+      <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke={color} strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M3 8a5 5 0 0 1 9-3" />
+        <path d="M13 8a5 5 0 0 1-9 3" />
+        <polyline points="12 2 12 5 9 5" />
+        <polyline points="4 14 4 11 7 11" />
+      </svg>
+    ),
+    cache: (color) => (
+      <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke={color} strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
+        <ellipse cx="8" cy="4" rx="5.5" ry="2" />
+        <path d="M2.5 4v4c0 1.1 2.5 2 5.5 2s5.5-.9 5.5-2V4" />
+        <path d="M2.5 8v4c0 1.1 2.5 2 5.5 2s5.5-.9 5.5-2V8" />
+      </svg>
+    ),
+    spinner: (color) => (
+      <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke={color} strokeWidth="1.5" strokeLinecap="round" style={{ animation: "spin 1s linear infinite" }}>
+        <path d="M8 2a6 6 0 0 1 6 6" />
+      </svg>
+    ),
+  };
+
+  const RUNBOOKS = [
+    { name: "Rotate DB Credentials", icon: "key", tag: "security" },
+    { name: "Scale Production Pods", icon: "scale", tag: "kubernetes" },
+    { name: "Restart Service Fleet", icon: "restart", tag: "operations" },
+    { name: "Flush Redis Cache", icon: "cache", tag: "database" },
+  ];
+
+  const RESOURCES = [
+    { name: "prod-api-east-1", type: "server" },
+    { name: "prod-api-east-2", type: "server" },
+    { name: "prod-api-west-1", type: "server" },
+    { name: "prod-db-primary", type: "database" },
+    { name: "prod-db-replica-1", type: "database" },
+    { name: "k8s-cluster-east", type: "kubernetes" },
+  ];
+
+  const PARAMS = [
+    { label: "Replicas", value: "5" },
+    { label: "Namespace", value: "production" },
+    { label: "Timeout", value: "120s" },
+  ];
+
+  const PHASES = {
+    IDLE: 0,
+    SELECT_RUNBOOK: 1,
+    FILL_PARAMS: 2,
+    SELECT_RESOURCES: 3,
+    EXECUTING: 4,
+    RESULTS: 5,
+    PAUSE: 6,
+  };
+
+  const PHASE_DURATION = {
+    [PHASES.IDLE]: 1200,
+    [PHASES.SELECT_RUNBOOK]: 2200,
+    [PHASES.FILL_PARAMS]: 2400,
+    [PHASES.SELECT_RESOURCES]: 2800,
+    [PHASES.EXECUTING]: 3200,
+    [PHASES.RESULTS]: 3000,
+    [PHASES.PAUSE]: 1500,
+  };
+
+  const frosted = (opacity = 0.04, borderOpacity = 0.08) => ({
+    background: `rgba(var(--sand-100-rgb),${opacity})`,
+    border: `1px solid rgba(var(--sand-100-rgb),${borderOpacity})`,
+  });
+
+  function PhaseIndicator({ phase }) {
+    const labels = ["", "Selecting runbook", "Configuring parameters", "Choosing targets", "Running commands", "Complete", ""];
+    const label = labels[phase] || "";
+
+    return (
+      <div
+        style={{
+          position: "absolute",
+          top: 12,
+          right: 20,
+          fontSize: 9,
+          fontWeight: 500,
+          color: phase === PHASES.RESULTS ? COLORS.warmGold : "rgba(var(--sand-100-rgb),0.25)",
+          letterSpacing: "0.04em",
+          textTransform: "uppercase",
+          transition: "all 0.3s ease",
+          opacity: label ? 1 : 0,
+          height: 14,
+        }}
+      >
+        {label}
+      </div>
+    );
+  }
+
+  const [phase, setPhase] = useState(PHASES.IDLE);
+  const [selectedRunbook, setSelectedRunbook] = useState(-1);
+  const [filledParams, setFilledParams] = useState(0);
+  const [selectedResources, setSelectedResources] = useState([]);
+  const [executingIdx, setExecutingIdx] = useState(-1);
+  const [completedResources, setCompletedResources] = useState([]);
+  const timersRef = useRef([]);
+
+  const clearAllTimers = useCallback(() => {
+    timersRef.current.forEach(clearTimeout);
+    timersRef.current = [];
+  }, []);
+
+  const addTimer = useCallback((fn, ms) => {
+    const id = setTimeout(fn, ms);
+    timersRef.current.push(id);
+    return id;
+  }, []);
+
+  const resetState = useCallback(() => {
+    setSelectedRunbook(-1);
+    setFilledParams(0);
+    setSelectedResources([]);
+    setExecutingIdx(-1);
+    setCompletedResources([]);
+  }, []);
+
+  useEffect(() => {
+    clearAllTimers();
+
+    if (phase === PHASES.IDLE) {
+      resetState();
+      addTimer(() => setPhase(PHASES.SELECT_RUNBOOK), PHASE_DURATION[PHASES.IDLE]);
+    }
+
+    if (phase === PHASES.SELECT_RUNBOOK) {
+      addTimer(() => setSelectedRunbook(1), 800);
+      addTimer(() => setPhase(PHASES.FILL_PARAMS), PHASE_DURATION[PHASES.SELECT_RUNBOOK]);
+    }
+
+    if (phase === PHASES.FILL_PARAMS) {
+      PARAMS.forEach((_, i) => addTimer(() => setFilledParams(i + 1), 500 + i * 600));
+      addTimer(() => setPhase(PHASES.SELECT_RESOURCES), PHASE_DURATION[PHASES.FILL_PARAMS]);
+    }
+
+    if (phase === PHASES.SELECT_RESOURCES) {
+      const targets = [0, 1, 2, 5];
+      targets.forEach((idx, i) => addTimer(() => setSelectedResources((prev) => [...prev, idx]), 400 + i * 500));
+      addTimer(() => setPhase(PHASES.EXECUTING), PHASE_DURATION[PHASES.SELECT_RESOURCES]);
+    }
+
+    if (phase === PHASES.EXECUTING) {
+      const targets = [0, 1, 2, 5];
+      targets.forEach((idx, i) => {
+        addTimer(() => setExecutingIdx(idx), 200 + i * 400);
+        addTimer(() => setCompletedResources((prev) => [...prev, idx]), 800 + i * 500);
+      });
+      addTimer(() => setPhase(PHASES.RESULTS), PHASE_DURATION[PHASES.EXECUTING]);
+    }
+
+    if (phase === PHASES.RESULTS) {
+      addTimer(() => setPhase(PHASES.PAUSE), PHASE_DURATION[PHASES.RESULTS]);
+    }
+
+    if (phase === PHASES.PAUSE) {
+      addTimer(() => setPhase(PHASES.IDLE), PHASE_DURATION[PHASES.PAUSE]);
+    }
+
+    return clearAllTimers;
+  }, [phase, resetState, clearAllTimers, addTimer]);
+
+  const isResourceSelected = (i) => selectedResources.includes(i);
+  const isResourceComplete = (i) => completedResources.includes(i);
+  const isResourceExecuting = (i) => executingIdx === i && !isResourceComplete(i);
+
+  const show = (fromPhase) => ({
+    opacity: phase >= fromPhase ? 1 : 0,
+    transform: phase >= fromPhase ? "translateY(0)" : "translateY(6px)",
+    transition: "opacity 0.5s ease, transform 0.5s ease",
+    pointerEvents: phase >= fromPhase ? "auto" : "none",
+  });
+
+  return (
+    <div
+      style={{
+        width: "100%",
+        maxWidth: 720,
+        margin: "0 auto",
+        fontFamily: "'DM Sans', system-ui, -apple-system, sans-serif",
+      }}
+    >
+      <link
+        href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=Sora:wght@600;700;800&family=JetBrains+Mono:wght@400;500&display=swap"
+        rel="stylesheet"
+      />
+
+      <div
+        style={{
+          background: "linear-gradient(135deg, var(--gradient-dark-start) 0%, var(--gradient-dark-mid) 35%, var(--gradient-dark-end) 70%, var(--bronze) 100%)",
+          borderRadius: 14,
+          padding: "28px 32px 32px",
+          position: "relative",
+          overflow: "hidden",
+        }}
+      >
+        {/* Radial glow */}
+        <div
+          style={{
+            position: "absolute",
+            top: "-30%",
+            right: "-10%",
+            width: "60%",
+            height: "160%",
+            background: "radial-gradient(ellipse at center, rgba(var(--warm-gold-rgb),0.12) 0%, transparent 70%)",
+            pointerEvents: "none",
+          }}
+        />
+
+        {/* Toolbar */}
+        <div
+          style={{
+            ...frosted(0.03, 0.06),
+            borderRadius: "10px 10px 0 0",
+            padding: "10px 16px",
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            position: "relative",
+            zIndex: 2,
+          }}
+        >
+          <div style={{ display: "flex", gap: 6 }}>
+            {[0.12, 0.10, 0.10].map((op, i) => (
+              <div key={i} style={{ width: 8, height: 8, borderRadius: "50%", background: `rgba(var(--sand-100-rgb),${op})` }} />
+            ))}
+          </div>
+          <div
+            style={{
+              ...frosted(0.04, 0.06),
+              borderRadius: 5,
+              padding: "4px 12px",
+              marginLeft: 12,
+              flex: 1,
+            }}
+          >
+            <span style={{ color: "rgba(var(--sand-100-rgb),0.2)", fontSize: 11, fontFamily: "'JetBrains Mono', monospace" }}>
+              app.hoop.dev/runbooks
+            </span>
+          </div>
+          <div
+            style={{
+              padding: "3px 10px",
+              borderRadius: 4,
+              background: "rgba(var(--sand-100-rgb),0.04)",
+              border: "1px solid rgba(var(--sand-100-rgb),0.08)",
+              fontSize: 10,
+              fontWeight: 600,
+              color: COLORS.warmGold,
+              letterSpacing: "0.06em",
+              textTransform: "uppercase",
+            }}
+          >
+            Parallel
+          </div>
+        </div>
+
+        {/* Main content, fixed height */}
+        <div
+          style={{
+            ...frosted(0.04, 0.08),
+            borderRadius: "0 0 10px 10px",
+            borderTop: "none",
+            display: "flex",
+            position: "relative",
+            zIndex: 2,
+            height: 460,
+            overflow: "hidden",
+          }}
+        >
+          {/* Sidebar */}
+          <div
+            style={{
+              width: 200,
+              flexShrink: 0,
+              borderRight: "1px solid rgba(var(--sand-100-rgb),0.06)",
+              padding: "16px 0",
+            }}
+          >
+            <div
+              style={{
+                padding: "0 16px 12px",
+                fontSize: 10,
+                fontWeight: 600,
+                color: COLORS.warmGold,
+                letterSpacing: "0.1em",
+                textTransform: "uppercase",
+              }}
+            >
+              Runbooks
+            </div>
+
+            {RUNBOOKS.map((rb, i) => {
+              const isSelected = selectedRunbook === i;
+              const iconColor = isSelected ? COLORS.warmGold : "rgba(var(--sand-100-rgb),0.25)";
+              return (
+                <div
+                  key={i}
+                  style={{
+                    padding: "10px 16px",
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 10,
+                    background: isSelected ? "rgba(var(--sand-100-rgb),0.06)" : "transparent",
+                    borderLeft: isSelected ? `2px solid ${COLORS.warmGold}` : "2px solid transparent",
+                    transition: "all 0.4s ease",
+                    cursor: "default",
+                  }}
+                >
+                  <div style={{ width: 14, height: 14, flexShrink: 0, transition: "all 0.3s ease" }}>
+                    {icons[rb.icon](iconColor)}
+                  </div>
+                  <div>
+                    <div
+                      style={{
+                        fontSize: 12,
+                        fontWeight: isSelected ? 600 : 400,
+                        color: isSelected ? COLORS.sand100 : "rgba(var(--sand-100-rgb),0.5)",
+                        transition: "all 0.3s ease",
+                      }}
+                    >
+                      {rb.name}
+                    </div>
+                    <div style={{ fontSize: 10, color: "rgba(var(--sand-100-rgb),0.2)", marginTop: 2 }}>
+                      {rb.tag}
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Right panel */}
+          <div style={{ flex: 1, padding: 20, position: "relative", overflow: "hidden" }}>
+            <PhaseIndicator phase={phase} />
+
+            {/* Runbook header */}
+            <div style={{ ...show(PHASES.SELECT_RUNBOOK), marginBottom: 20 }}>
+              <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 6 }}>
+                <div style={{ width: 14, height: 14, flexShrink: 0 }}>
+                  {selectedRunbook >= 0
+                    ? icons[RUNBOOKS[selectedRunbook].icon](COLORS.warmGold)
+                    : icons.scale("rgba(var(--sand-100-rgb),0.15)")}
+                </div>
+                <span
+                  style={{
+                    fontFamily: "'Sora', sans-serif",
+                    fontSize: 16,
+                    fontWeight: 700,
+                    color: COLORS.sand100,
+                    letterSpacing: "-0.02em",
+                  }}
+                >
+                  {selectedRunbook >= 0 ? RUNBOOKS[selectedRunbook].name : "Select a runbook"}
+                </span>
+              </div>
+              <div style={{ fontSize: 12, color: "rgba(var(--sand-100-rgb),0.4)", marginLeft: 24 }}>
+                Scales deployment replicas across selected resource roles
+              </div>
+            </div>
+
+            {/* Parameters */}
+            <div style={{ ...show(PHASES.FILL_PARAMS), marginBottom: 20 }}>
+              <div
+                style={{
+                  fontSize: 10,
+                  fontWeight: 600,
+                  color: COLORS.warmGold,
+                  letterSpacing: "0.1em",
+                  textTransform: "uppercase",
+                  marginBottom: 10,
+                }}
+              >
+                Parameters
+              </div>
+              <div style={{ display: "flex", gap: 10 }}>
+                {PARAMS.map((p, i) => {
+                  const filled = i < filledParams;
+                  return (
+                    <div
+                      key={i}
+                      style={{
+                        flex: 1,
+                        ...frosted(0.03, 0.06),
+                        borderRadius: 6,
+                        padding: "8px 12px",
+                        opacity: filled ? 1 : 0.4,
+                        transition: "all 0.4s ease",
+                        borderColor: filled ? "rgba(var(--warm-gold-rgb),0.25)" : "rgba(var(--sand-100-rgb),0.06)",
+                      }}
+                    >
+                      <div style={{ fontSize: 9, color: "rgba(var(--sand-100-rgb),0.3)", marginBottom: 4, textTransform: "uppercase", letterSpacing: "0.05em" }}>
+                        {p.label}
+                      </div>
+                      <div
+                        style={{
+                          fontSize: 13,
+                          fontFamily: "'JetBrains Mono', monospace",
+                          fontWeight: 500,
+                          color: filled ? COLORS.sand100 : "transparent",
+                          transition: "color 0.3s ease",
+                          minHeight: 18,
+                        }}
+                      >
+                        {p.value}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+
+            {/* Resources + execution */}
+            <div style={{ ...show(PHASES.SELECT_RESOURCES) }}>
+              <div
+                style={{
+                  fontSize: 10,
+                  fontWeight: 600,
+                  color: COLORS.warmGold,
+                  letterSpacing: "0.1em",
+                  textTransform: "uppercase",
+                  marginBottom: 10,
+                  transition: "all 0.3s ease",
+                }}
+              >
+                {phase >= PHASES.EXECUTING ? "Execution" : "Select Resources"}
+              </div>
+              <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                {RESOURCES.map((r, i) => {
+                  const selected = isResourceSelected(i);
+                  const executing = isResourceExecuting(i);
+                  const complete = isResourceComplete(i);
+                  return (
+                    <div
+                      key={i}
+                      style={{
+                        ...frosted(selected ? 0.05 : 0.02, selected ? 0.1 : 0.04),
+                        borderRadius: 6,
+                        padding: "8px 12px",
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "space-between",
+                        transition: "all 0.35s ease",
+                        borderColor: complete
+                          ? "rgba(var(--warm-gold-rgb),0.3)"
+                          : executing
+                          ? "rgba(var(--warm-gold-rgb),0.15)"
+                          : selected
+                          ? "rgba(var(--sand-100-rgb),0.1)"
+                          : "rgba(var(--sand-100-rgb),0.04)",
+                      }}
+                    >
+                      <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                        <div
+                          style={{
+                            width: 14,
+                            height: 14,
+                            borderRadius: 3,
+                            border: `1.5px solid ${selected ? COLORS.warmGold : "rgba(var(--sand-100-rgb),0.15)"}`,
+                            background: selected ? "rgba(var(--warm-gold-rgb),0.15)" : "transparent",
+                            display: "flex",
+                            alignItems: "center",
+                            justifyContent: "center",
+                            transition: "all 0.3s ease",
+                            flexShrink: 0,
+                          }}
+                        >
+                          {selected && (
+                            <svg width="8" height="8" viewBox="0 0 10 10" fill="none" stroke={COLORS.warmGold} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                              <polyline points="2 5.5 4 7.5 8 3" />
+                            </svg>
+                          )}
+                        </div>
+                        <div
+                          style={{
+                            fontSize: 12,
+                            fontFamily: "'JetBrains Mono', monospace",
+                            fontWeight: 400,
+                            color: selected ? "rgba(var(--sand-100-rgb),0.7)" : "rgba(var(--sand-100-rgb),0.35)",
+                            transition: "color 0.3s ease",
+                          }}
+                        >
+                          {r.name}
+                        </div>
+                        <div
+                          style={{
+                            fontSize: 9,
+                            padding: "1px 6px",
+                            borderRadius: 3,
+                            background: "rgba(var(--sand-100-rgb),0.04)",
+                            color: "rgba(var(--sand-100-rgb),0.25)",
+                            textTransform: "uppercase",
+                            letterSpacing: "0.04em",
+                          }}
+                        >
+                          {r.type}
+                        </div>
+                      </div>
+
+                      <div style={{ display: "flex", alignItems: "center", gap: 6, minWidth: 70, justifyContent: "flex-end" }}>
+                        {phase >= PHASES.EXECUTING && selected && (
+                          complete ? (
+                            <>
+                              <div style={{ width: 6, height: 6, borderRadius: "50%", background: COLORS.warmGold }} />
+                              <span style={{ fontSize: 10, color: COLORS.warmGold, fontWeight: 500 }}>Success</span>
+                            </>
+                          ) : executing ? (
+                            <>
+                              {icons.spinner("rgba(var(--sand-100-rgb),0.4)")}
+                              <span style={{ fontSize: 10, color: "rgba(var(--sand-100-rgb),0.4)" }}>Running</span>
+                            </>
+                          ) : (
+                            <span style={{ fontSize: 10, color: "rgba(var(--sand-100-rgb),0.2)" }}>Queued</span>
+                          )
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+
+              {/* Button/results area, fixed height */}
+              <div style={{ marginTop: 16, height: 54, position: "relative" }}>
+                <div
+                  style={{
+                    opacity: phase >= PHASES.SELECT_RESOURCES && phase < PHASES.RESULTS ? 1 : 0,
+                    transition: "opacity 0.4s ease",
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                  }}
+                >
+                  <div
+                    style={{
+                      background: phase === PHASES.EXECUTING ? "rgba(var(--warm-gold-rgb),0.15)" : COLORS.sand100,
+                      color: phase === PHASES.EXECUTING ? COLORS.warmGold : COLORS.espresso,
+                      padding: "9px 24px",
+                      borderRadius: 6,
+                      fontSize: 13,
+                      fontWeight: 500,
+                      transition: "all 0.4s ease",
+                      display: "inline-flex",
+                      alignItems: "center",
+                      gap: 8,
+                      border: phase === PHASES.EXECUTING ? "1px solid rgba(var(--warm-gold-rgb),0.2)" : "1px solid transparent",
+                    }}
+                  >
+                    {phase === PHASES.EXECUTING ? (
+                      <>
+                        {icons.spinner(COLORS.warmGold)}
+                        Executing on {selectedResources.length} resources...
+                      </>
+                    ) : (
+                      "Execute Runbook"
+                    )}
+                  </div>
+                </div>
+
+                <div
+                  style={{
+                    opacity: phase >= PHASES.RESULTS ? 1 : 0,
+                    transform: phase >= PHASES.RESULTS ? "translateY(0)" : "translateY(6px)",
+                    transition: "all 0.4s ease",
+                    ...frosted(0.04, 0.08),
+                    borderRadius: 8,
+                    padding: "14px 16px",
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    right: 0,
+                    pointerEvents: phase >= PHASES.RESULTS ? "auto" : "none",
+                  }}
+                >
+                  <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+                    <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                      <div style={{ width: 8, height: 8, borderRadius: "50%", background: COLORS.warmGold }} />
+                      <span
+                        style={{
+                          fontFamily: "'Sora', sans-serif",
+                          fontSize: 14,
+                          fontWeight: 600,
+                          color: COLORS.sand100,
+                          letterSpacing: "-0.02em",
+                        }}
+                      >
+                        All resources completed
+                      </span>
+                    </div>
+                    <span style={{ fontSize: 12, fontFamily: "'JetBrains Mono', monospace", color: COLORS.warmGold }}>
+                      4/4
+                    </span>
+                  </div>
+                  <div style={{ fontSize: 11, color: "rgba(var(--sand-100-rgb),0.35)", marginTop: 6, marginLeft: 16 }}>
+                    Scaled to 5 replicas across all selected clusters and servers
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Footer bar */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            padding: "12px 0 0",
+            marginTop: 12,
+            position: "relative",
+            zIndex: 2,
+          }}
+        >
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="rgba(var(--sand-100-rgb),0.2)">
+            <circle cx="7" cy="7" r="3.5" />
+            <circle cx="17" cy="7" r="3.5" />
+            <circle cx="7" cy="17" r="3.5" />
+            <circle cx="17" cy="17" r="3.5" />
+          </svg>
+          <span style={{ fontSize: 12, fontWeight: 700, color: "rgba(var(--sand-100-rgb),0.2)", letterSpacing: "0.01em" }}>
+            hoop.dev
+          </span>
+          <div style={{ flex: 1, height: 1, background: "rgba(var(--sand-100-rgb),0.06)" }} />
+        </div>
+      </div>
+
+      <style>{`
+        @keyframes pulse {
+          0%, 100% { opacity: 0.3; }
+          50% { opacity: 1; }
+        }
+        @keyframes spin {
+          from { transform: rotate(0deg); }
+          to { transform: rotate(360deg); }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/snippets/annimations/runbookslens.jsx
+++ b/snippets/annimations/runbookslens.jsx
@@ -1,0 +1,270 @@
+export const OverlayLens = () => {
+  const WG = "var(--warm-gold)";
+  const S1 = "var(--sand-100)";
+  const S5 = "var(--sand-500)";
+  const GRAD = "linear-gradient(135deg, var(--gradient-dark-start) 0%, var(--gradient-dark-mid) 35%, var(--gradient-dark-end) 70%, var(--bronze) 100%)";
+  const FONT_URL = "https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700&family=JetBrains+Mono:wght@400;500&family=Sora:wght@600;700;800&display=swap";
+  const rgba = (a) => `rgba(var(--sand-100-rgb),${a})`;
+  const mono = "'JetBrains Mono', monospace";
+  const sans = "'DM Sans', sans-serif";
+
+  function useTypewriter(text, active, speed = 65) {
+    const [out, setOut] = useState("");
+    const [done, setDone] = useState(false);
+    useEffect(() => {
+      if (!active) { setOut(""); setDone(false); return; }
+      let i = 0; setOut(""); setDone(false);
+      const iv = setInterval(() => { i++; setOut(text.slice(0, i)); if (i >= text.length) { clearInterval(iv); setDone(true); } }, speed);
+      return () => clearInterval(iv);
+    }, [text, active, speed]);
+    return [out, done];
+  }
+
+  function Overline({ children, style }) {
+    return <div style={{ fontFamily: sans, fontSize: 10, fontWeight: 600, color: WG, textTransform: "uppercase", letterSpacing: "0.1em", marginBottom: 10, ...style }}>{children}</div>;
+  }
+
+  function Check({ checked, label }) {
+    return (
+      <div style={{ display: "flex", alignItems: "center", gap: 7, fontFamily: sans, fontSize: 11.5, color: checked ? rgba(0.55) : rgba(0.25), transition: "color 0.3s" }}>
+        <div style={{ width: 16, height: 16, borderRadius: 3, display: "flex", alignItems: "center", justifyContent: "center", background: checked ? "rgba(var(--warm-gold-rgb),0.12)" : rgba(0.03), border: checked ? "1px solid rgba(var(--warm-gold-rgb),0.3)" : `1px solid ${rgba(0.08)}`, transition: "all 0.4s" }}>
+          {checked
+            ? <svg width="9" height="9" viewBox="0 0 16 16" fill="none"><path d="M3 8.5L6.5 12L13 4" stroke={WG} strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"/></svg>
+            : <div style={{ width: 7, height: 7, borderRadius: "50%", border: `2px solid ${rgba(0.12)}`, borderTopColor: "rgba(var(--warm-gold-rgb),0.4)", animation: "v4Spin 0.8s linear infinite" }}/>}
+        </div>
+        {label}
+      </div>
+    );
+  }
+
+  function Connector({ visible }) {
+    return <div style={{ display: "flex", justifyContent: "center", height: visible ? 16 : 0, overflow: "hidden", transition: "height 0.4s cubic-bezier(.4,0,.2,1)" }}><div style={{ width: 1, height: "100%", background: "linear-gradient(to bottom, rgba(var(--warm-gold-rgb),0.25), transparent)" }}/></div>;
+  }
+
+  const CODE_LINES = [
+    { t: "comment", v: "-- customer-lookup.runbook.sql" },
+    { t: "kw", v: "SELECT" },
+    { t: "f", v: "  customer_id, name, email, status" },
+    { t: "kw", v: "FROM customers" },
+    { t: "kw", v: "WHERE" },
+    { t: "param", v: '  customer_id = {{ .customer_id | required | type "number" }}' },
+  ];
+
+  const PHASES = [
+    { label: "Template", ms: 3000 },
+    { label: "Lens view", ms: 5000 },
+    { label: "Review", ms: 2500 },
+    { label: "Results", ms: 4000 },
+  ];
+
+  const [phase, setPhase] = useState(0);
+  const [checks, setChecks] = useState(0);
+  const [lensPos, setLensPos] = useState(0);
+
+  const [typed, typedDone] = useTypewriter("40192", phase >= 1, 75);
+
+  useEffect(() => {
+    let t;
+    const run = (p) => { t = setTimeout(() => { const n = (p + 1) % 4; setPhase(n); if (n === 0) { setChecks(0); setLensPos(0); } run(n); }, PHASES[p].ms); };
+    run(0); return () => clearTimeout(t);
+  }, []);
+
+  useEffect(() => {
+    if (phase !== 1) return;
+    setLensPos(0);
+    const start = performance.now();
+    const duration = 1800;
+    const animate = (now) => {
+      const elapsed = now - start;
+      const progress = Math.min(elapsed / duration, 1);
+      const eased = 1 - Math.pow(1 - progress, 3);
+      setLensPos(eased * 100);
+      if (progress < 1) requestAnimationFrame(animate);
+    };
+    requestAnimationFrame(animate);
+  }, [phase]);
+
+  useEffect(() => {
+    if (phase !== 2) { setChecks(0); return; }
+    let c = 0;
+    const iv = setInterval(() => { c++; setChecks(c); if (c >= 3) clearInterval(iv); }, 600);
+    return () => clearInterval(iv);
+  }, [phase]);
+
+  const lensActive = phase >= 1;
+  const lensWidth = lensActive ? lensPos : 0;
+
+  return (
+    <>
+      <style>{`@import url('${FONT_URL}');`}</style>
+      <style>{`
+        @keyframes v4Blink{0%,100%{opacity:1}50%{opacity:0}}
+        @keyframes v4Up{from{opacity:0;transform:translateY(6px)}to{opacity:1;transform:translateY(0)}}
+        @keyframes v4Spin{to{transform:rotate(360deg)}}
+        @keyframes v4Pulse{0%,100%{opacity:.12}50%{opacity:.2}}
+      `}</style>
+
+      <div style={{ background: GRAD, borderRadius: 14, overflow: "hidden", position: "relative", fontFamily: sans, maxWidth: 780, margin: "0 auto" }}>
+        <div style={{ position: "absolute", top: "-30%", right: "-10%", width: "60%", height: "160%", background: "radial-gradient(ellipse at center, rgba(var(--warm-gold-rgb),0.12) 0%, transparent 70%)", pointerEvents: "none", animation: "v4Pulse 4s ease-in-out infinite" }}/>
+
+        {/* Top bar */}
+        <div style={{ position: "relative", padding: "14px 22px", display: "flex", justifyContent: "space-between", alignItems: "center", borderBottom: `1px solid ${rgba(0.06)}` }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <svg width="13" height="13" viewBox="0 0 24 24" fill={S1}><circle cx="7" cy="7" r="3.5"/><circle cx="17" cy="7" r="3.5"/><circle cx="7" cy="17" r="3.5"/><circle cx="17" cy="17" r="3.5"/></svg>
+            <span style={{ fontSize: 13, fontWeight: 700, color: S1 }}>Runbooks</span>
+          </div>
+          <div style={{ display: "flex", gap: 6 }}>
+            {PHASES.map((_, i) => (
+              <div key={i} style={{ width: i === phase ? 22 : 7, height: 7, borderRadius: 4, background: i === phase ? WG : i < phase ? "rgba(var(--warm-gold-rgb),0.4)" : rgba(0.1), transition: "all 0.5s cubic-bezier(.4,0,.2,1)" }}/>
+            ))}
+          </div>
+          <div style={{ fontSize: 11, fontWeight: 500, color: rgba(0.3) }}>{PHASES[phase].label}</div>
+        </div>
+
+        {/* Body */}
+        <div style={{ position: "relative", padding: "20px 24px", display: "flex", flexDirection: "column", gap: 0 }}>
+
+          {/* Code + Lens overlay area */}
+          <div style={{ position: "relative", borderRadius: 10, overflow: "hidden", minHeight: 260 }}>
+
+            {/* BOTTOM LAYER: Code */}
+            <div style={{
+              background: rgba(0.04), border: `1px solid ${rgba(0.08)}`,
+              borderRadius: 10, padding: "16px 20px",
+              fontFamily: mono, fontSize: 12.5, lineHeight: 2,
+              position: "relative", zIndex: 1,
+            }}>
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 8 }}>
+                <Overline style={{ marginBottom: 0 }}>Template</Overline>
+                <div style={{ fontFamily: mono, fontSize: 9, color: rgba(0.2) }}>customer-lookup.runbook.sql</div>
+              </div>
+              {CODE_LINES.map((l, i) => {
+                let color = rgba(0.55);
+                if (l.t === "comment") color = S5;
+                if (l.t === "kw") color = WG;
+                if (l.t === "param") color = rgba(0.35);
+                return <div key={i} style={{ color }}>{l.v}</div>;
+              })}
+            </div>
+
+            {/* TOP LAYER: Lens overlay (clips from left) */}
+            <div style={{
+              position: "absolute", top: 0, left: 0, bottom: 0,
+              width: `${lensWidth}%`,
+              overflow: "hidden",
+              zIndex: 2,
+              borderRadius: 10,
+              transition: phase === 0 ? "width 0.3s" : "none",
+            }}>
+              {/* Lens content: rendered form */}
+              <div style={{
+                background: "rgba(45,30,18,0.92)",
+                backdropFilter: "blur(12px)",
+                WebkitBackdropFilter: "blur(12px)",
+                border: `1px solid rgba(var(--warm-gold-rgb),0.15)`,
+                borderRadius: 10,
+                padding: "16px 20px",
+                minWidth: 700,
+                height: "100%",
+                boxSizing: "border-box",
+                display: "flex",
+                flexDirection: "column",
+              }}>
+                <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 14 }}>
+                  <Overline style={{ marginBottom: 0 }}>Customer Lookup</Overline>
+                  <div style={{ fontFamily: sans, fontSize: 9, color: rgba(0.25), display: "flex", alignItems: "center", gap: 4 }}>
+                    <div style={{ width: 5, height: 5, borderRadius: "50%", background: WG }}/>
+                    Form view
+                  </div>
+                </div>
+
+                <div style={{ marginBottom: 14 }}>
+                  <div style={{ fontSize: 12, fontFamily: sans, fontWeight: 500, color: rgba(0.5), marginBottom: 5 }}>
+                    Customer ID <span style={{ fontSize: 9, color: "rgba(var(--warm-gold-rgb),0.5)", fontStyle: "italic" }}>required · number</span>
+                  </div>
+                  <div style={{
+                    background: rgba(0.03), border: typedDone ? "1px solid rgba(var(--warm-gold-rgb),0.35)" : `1px solid ${rgba(0.1)}`,
+                    borderRadius: 6, padding: "9px 12px", fontFamily: mono, fontSize: 13, color: S1,
+                    minHeight: 18, transition: "border-color 0.3s", display: "flex", alignItems: "center",
+                  }}>
+                    {typed}
+                    {phase === 1 && !typedDone && <span style={{ display: "inline-block", width: 2, height: 15, background: WG, marginLeft: 1, animation: "v4Blink 1s step-end infinite" }}/>}
+                  </div>
+                </div>
+
+                <div style={{ marginBottom: 14 }}>
+                  <div style={{ fontSize: 12, fontFamily: sans, fontWeight: 500, color: rgba(0.5), marginBottom: 5 }}>Output columns</div>
+                  <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+                    {["customer_id", "name", "email", "status"].map(f => (
+                      <span key={f} style={{ background: rgba(0.04), border: `1px solid ${rgba(0.08)}`, borderRadius: 4, padding: "3px 8px", fontFamily: mono, fontSize: 10, color: rgba(0.3) }}>{f}</span>
+                    ))}
+                  </div>
+                </div>
+
+                {typedDone && (
+                  <div style={{ display: "inline-flex", alignItems: "center", gap: 5, background: "rgba(var(--warm-gold-rgb),0.08)", border: "1px solid rgba(var(--warm-gold-rgb),0.2)", borderRadius: 14, padding: "4px 10px", fontSize: 10, fontWeight: 500, color: WG, animation: "v4Up 0.3s ease-out" }}>
+                    <svg width="10" height="10" viewBox="0 0 16 16" fill="none"><path d="M3 8.5L6.5 12L13 4" stroke={WG} strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"/></svg>
+                    Ready to execute
+                  </div>
+                )}
+              </div>
+
+              {/* Lens edge glow */}
+              {lensActive && lensWidth < 100 && (
+                <div style={{
+                  position: "absolute", top: 0, right: -1, bottom: 0, width: 3,
+                  background: `linear-gradient(to bottom, rgba(var(--warm-gold-rgb),0.5), rgba(var(--warm-gold-rgb),0.1))`,
+                  borderRadius: 2,
+                  boxShadow: "0 0 12px rgba(var(--warm-gold-rgb),0.3)",
+                }}/>
+              )}
+            </div>
+          </div>
+
+          <Connector visible={phase >= 2} />
+
+          {/* Review */}
+          <div style={{
+            background: rgba(0.04), border: `1px solid ${rgba(0.08)}`, borderRadius: 10, padding: "14px 18px",
+            opacity: phase >= 2 ? 1 : 0, maxHeight: phase >= 2 ? 160 : 0, overflow: "hidden",
+            transition: "opacity 0.4s 0.1s, max-height 0.4s cubic-bezier(.4,0,.2,1)",
+          }}>
+            <Overline>Access Review</Overline>
+            <div style={{ display: "flex", flexDirection: "column", gap: 7 }}>
+              <Check checked={checks >= 1} label="Guardrails passed" />
+              <Check checked={checks >= 2} label="Data masking enabled" />
+              <Check checked={checks >= 3} label="Approved by policy" />
+            </div>
+          </div>
+
+          <Connector visible={phase >= 3} />
+
+          {/* Results */}
+          <div style={{
+            background: rgba(0.04), border: `1px solid ${rgba(0.08)}`, borderRadius: 10, padding: 0, overflow: "hidden",
+            opacity: phase >= 3 ? 1 : 0, maxHeight: phase >= 3 ? 200 : 0,
+            transition: "opacity 0.4s 0.1s, max-height 0.4s cubic-bezier(.4,0,.2,1)",
+          }}>
+            <div style={{ background: rgba(0.03), borderBottom: `1px solid ${rgba(0.06)}`, padding: "8px 14px", display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+              <Overline style={{ marginBottom: 0 }}>Results</Overline>
+              <span style={{ fontFamily: mono, fontSize: 9, color: rgba(0.2) }}>1 row · 42ms</span>
+            </div>
+            <div style={{ padding: "0 14px" }}>
+              <div style={{ display: "grid", gridTemplateColumns: "50px 1fr 1fr 60px", padding: "6px 0", borderBottom: `1px solid ${rgba(0.04)}`, fontFamily: sans, fontSize: 9, fontWeight: 600, color: rgba(0.25), textTransform: "uppercase" }}>
+                <span>ID</span><span>Name</span><span>Email</span><span>Status</span>
+              </div>
+              <div style={{ display: "grid", gridTemplateColumns: "50px 1fr 1fr 60px", padding: "8px 0", fontFamily: mono, fontSize: 11, color: rgba(0.55), animation: phase >= 3 ? "v4Up 0.4s ease-out" : "none" }}>
+                <span>40192</span><span>Acme Corp</span>
+                <span style={{ color: WG, fontWeight: 500 }}>a●●●@acme.io</span>
+                <span><span style={{ background: "rgba(var(--warm-gold-rgb),0.08)", border: "1px solid rgba(var(--warm-gold-rgb),0.2)", borderRadius: 10, padding: "1px 6px", fontSize: 8.5, fontFamily: sans, fontWeight: 600, color: WG, textTransform: "uppercase" }}>active</span></span>
+              </div>
+            </div>
+            <div style={{ borderTop: `1px solid ${rgba(0.04)}`, padding: "7px 14px", display: "flex", gap: 10, fontSize: 9, color: rgba(0.18) }}>
+              <span>Recorded</span><span>·</span><span>Audited</span><span>·</span><span>Masked</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/snippets/annimations/runbookspersonas.jsx
+++ b/snippets/annimations/runbookspersonas.jsx
@@ -1,0 +1,265 @@
+export const TwoPersonas = () => {
+  const WG = "var(--warm-gold)";
+  const S1 = "var(--sand-100)";
+  const S5 = "var(--sand-500)";
+  const GRAD = "linear-gradient(135deg, var(--gradient-dark-start) 0%, var(--gradient-dark-mid) 35%, var(--gradient-dark-end) 70%, var(--bronze) 100%)";
+  const FONT_URL = "https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700&family=JetBrains+Mono:wght@400;500&family=Sora:wght@600;700;800&display=swap";
+  const rgba = (a) => `rgba(var(--sand-100-rgb),${a})`;
+  const mono = "'JetBrains Mono', monospace";
+  const sans = "'DM Sans', sans-serif";
+
+  function useTypewriter(text, active, speed = 65) {
+    const [out, setOut] = useState("");
+    const [done, setDone] = useState(false);
+    useEffect(() => {
+      if (!active) { setOut(""); setDone(false); return; }
+      let i = 0; setOut(""); setDone(false);
+      const iv = setInterval(() => { i++; setOut(text.slice(0, i)); if (i >= text.length) { clearInterval(iv); setDone(true); } }, speed);
+      return () => clearInterval(iv);
+    }, [text, active, speed]);
+    return [out, done];
+  }
+
+  function Overline({ children, style }) {
+    return <div style={{ fontFamily: sans, fontSize: 10, fontWeight: 600, color: WG, textTransform: "uppercase", letterSpacing: "0.1em", marginBottom: 10, ...style }}>{children}</div>;
+  }
+
+  function Check({ checked, label }) {
+    return (
+      <div style={{ display: "flex", alignItems: "center", gap: 7, fontFamily: sans, fontSize: 11, color: checked ? rgba(0.55) : rgba(0.25), transition: "color 0.3s" }}>
+        <div style={{ width: 16, height: 16, borderRadius: 3, display: "flex", alignItems: "center", justifyContent: "center", background: checked ? "rgba(var(--warm-gold-rgb),0.12)" : rgba(0.03), border: checked ? "1px solid rgba(var(--warm-gold-rgb),0.3)" : `1px solid ${rgba(0.08)}`, transition: "all 0.4s" }}>
+          {checked
+            ? <svg width="9" height="9" viewBox="0 0 16 16" fill="none"><path d="M3 8.5L6.5 12L13 4" stroke={WG} strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"/></svg>
+            : <div style={{ width: 7, height: 7, borderRadius: "50%", border: `2px solid ${rgba(0.12)}`, borderTopColor: "rgba(var(--warm-gold-rgb),0.4)", animation: "v5Spin 0.8s linear infinite" }}/>}
+        </div>
+        {label}
+      </div>
+    );
+  }
+
+  const PHASES = [
+    { label: "Template", ms: 3000 },
+    { label: "Parameters", ms: 4500 },
+    { label: "Review", ms: 2500 },
+    { label: "Results", ms: 4000 },
+  ];
+
+  const CODE_LINES = [
+    { t: "comment", v: "-- customer-lookup.runbook.sql" },
+    { t: "kw", v: "SELECT customer_id, name, email, status" },
+    { t: "kw", v: "FROM customers" },
+    { t: "kw", v: "WHERE" },
+    { t: "param", v: '  customer_id = {{ .customer_id | required | type "number" }}' },
+  ];
+
+  function ArrowDown({ visible, label }) {
+    return (
+      <div style={{
+        display: "flex", flexDirection: "column", alignItems: "center", gap: 0,
+        height: visible ? 44 : 0, overflow: "hidden",
+        transition: "height 0.5s cubic-bezier(.4,0,.2,1)",
+      }}>
+        <div style={{ width: 1, height: 16, background: "linear-gradient(to bottom, rgba(var(--warm-gold-rgb),0.35), rgba(var(--warm-gold-rgb),0.15))" }}/>
+        {label && (
+          <div style={{
+            fontFamily: sans, fontSize: 9, fontWeight: 600, color: WG,
+            textTransform: "uppercase", letterSpacing: "0.08em",
+            background: "rgba(var(--warm-gold-rgb),0.08)", border: "1px solid rgba(var(--warm-gold-rgb),0.15)",
+            borderRadius: 10, padding: "2px 10px",
+          }}>
+            {label}
+          </div>
+        )}
+        <div style={{ width: 1, height: 8, background: "linear-gradient(to bottom, rgba(var(--warm-gold-rgb),0.15), transparent)" }}/>
+        <svg width="8" height="6" viewBox="0 0 8 6" fill="none" style={{ marginTop: -1 }}>
+          <path d="M0 0L4 6L8 0" fill="rgba(var(--warm-gold-rgb),0.3)" />
+        </svg>
+      </div>
+    );
+  }
+
+  function Connector({ visible }) {
+    return <div style={{ display: "flex", justifyContent: "center", height: visible ? 16 : 0, overflow: "hidden", transition: "height 0.4s cubic-bezier(.4,0,.2,1)" }}><div style={{ width: 1, height: "100%", background: "linear-gradient(to bottom, rgba(var(--warm-gold-rgb),0.25), transparent)" }}/></div>;
+  }
+
+  const [phase, setPhase] = useState(0);
+  const [checks, setChecks] = useState(0);
+  const [typed, typedDone] = useTypewriter("40192", phase >= 1, 75);
+
+  useEffect(() => {
+    let t;
+    const run = (p) => { t = setTimeout(() => { const n = (p + 1) % 4; setPhase(n); if (n === 0) setChecks(0); run(n); }, PHASES[p].ms); };
+    run(0); return () => clearTimeout(t);
+  }, []);
+
+  useEffect(() => {
+    if (phase !== 2) { setChecks(0); return; }
+    let c = 0;
+    const iv = setInterval(() => { c++; setChecks(c); if (c >= 3) clearInterval(iv); }, 600);
+    return () => clearInterval(iv);
+  }, [phase]);
+
+  const paramHighlight = phase >= 1;
+
+  return (
+    <>
+      <style>{`@import url('${FONT_URL}');`}</style>
+      <style>{`
+        @keyframes v5Blink{0%,100%{opacity:1}50%{opacity:0}}
+        @keyframes v5Up{from{opacity:0;transform:translateY(6px)}to{opacity:1;transform:translateY(0)}}
+        @keyframes v5Spin{to{transform:rotate(360deg)}}
+        @keyframes v5Pulse{0%,100%{opacity:.12}50%{opacity:.2}}
+      `}</style>
+
+      <div style={{ background: GRAD, borderRadius: 14, overflow: "hidden", position: "relative", fontFamily: sans, maxWidth: 780, margin: "0 auto" }}>
+        <div style={{ position: "absolute", top: "-30%", right: "-10%", width: "60%", height: "160%", background: "radial-gradient(ellipse at center, rgba(var(--warm-gold-rgb),0.12) 0%, transparent 70%)", pointerEvents: "none", animation: "v5Pulse 4s ease-in-out infinite" }}/>
+
+        {/* Top bar */}
+        <div style={{ position: "relative", padding: "14px 22px", display: "flex", justifyContent: "space-between", alignItems: "center", borderBottom: `1px solid ${rgba(0.06)}` }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <svg width="13" height="13" viewBox="0 0 24 24" fill={S1}><circle cx="7" cy="7" r="3.5"/><circle cx="17" cy="7" r="3.5"/><circle cx="7" cy="17" r="3.5"/><circle cx="17" cy="17" r="3.5"/></svg>
+            <span style={{ fontSize: 13, fontWeight: 700, color: S1 }}>Runbooks</span>
+          </div>
+          <div style={{ display: "flex", gap: 6 }}>
+            {PHASES.map((_, i) => (
+              <div key={i} style={{ width: i === phase ? 22 : 7, height: 7, borderRadius: 4, background: i === phase ? WG : i < phase ? "rgba(var(--warm-gold-rgb),0.4)" : rgba(0.1), transition: "all 0.5s cubic-bezier(.4,0,.2,1)" }}/>
+            ))}
+          </div>
+          <div style={{ fontSize: 11, fontWeight: 500, color: rgba(0.3) }}>{PHASES[phase].label}</div>
+        </div>
+
+        {/* Body — horizontal layout, fixed height */}
+        <div style={{ position: "relative", padding: "20px 24px", display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16, height: 520 }}>
+
+          {/* LEFT: Engineer writes */}
+          <div style={{
+            background: rgba(0.04), border: `1px solid ${rgba(0.08)}`, borderRadius: 10, padding: "14px 18px", overflow: "hidden",
+          }}>
+            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 10 }}>
+              <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                <div style={{ width: 22, height: 22, borderRadius: 5, background: rgba(0.06), display: "flex", alignItems: "center", justifyContent: "center", fontFamily: sans, fontSize: 10, fontWeight: 700, color: rgba(0.35) }}>E</div>
+                <div>
+                  <div style={{ fontFamily: sans, fontSize: 11, fontWeight: 600, color: rgba(0.5) }}>Engineer writes</div>
+                  <div style={{ fontFamily: mono, fontSize: 9, color: rgba(0.2) }}>customer-lookup.runbook.sql</div>
+                </div>
+              </div>
+              <Overline style={{ marginBottom: 0 }}>Template</Overline>
+            </div>
+
+            <div style={{ fontFamily: mono, fontSize: 12, lineHeight: 1.9, padding: "8px 12px", background: rgba(0.03), borderRadius: 6, border: `1px solid ${rgba(0.04)}` }}>
+              {CODE_LINES.map((l, i) => {
+                let color = rgba(0.55);
+                if (l.t === "comment") color = S5;
+                if (l.t === "kw") color = WG;
+                const isP = l.t === "param";
+                return (
+                  <div key={i} style={{ position: "relative" }}>
+                    {isP && <div style={{
+                      position: "absolute", left: -4, right: -4, top: 1, bottom: 1,
+                      background: paramHighlight ? "rgba(var(--warm-gold-rgb),0.08)" : "transparent",
+                      borderRadius: 3, border: paramHighlight ? "1px solid rgba(var(--warm-gold-rgb),0.25)" : "1px solid transparent",
+                      transition: "all 0.5s",
+                    }}/>}
+                    <span style={{ position: "relative", color: isP && paramHighlight ? WG : isP ? rgba(0.3) : color, fontWeight: isP && paramHighlight ? 600 : 400, transition: "all 0.4s" }}>{l.v}</span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* RIGHT: Team runs + Review + Results */}
+          <div style={{ display: "flex", flexDirection: "column", gap: 10, overflow: "hidden" }}>
+
+          {/* Form panel */}
+          <div style={{
+            background: rgba(0.04), border: `1px solid ${rgba(0.08)}`, borderRadius: 10, padding: "14px 18px",
+            opacity: phase >= 1 ? 1 : 0.3,
+            transition: "opacity 0.5s",
+          }}>
+            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 12 }}>
+              <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                <div style={{ width: 22, height: 22, borderRadius: 5, background: "rgba(var(--warm-gold-rgb),0.1)", display: "flex", alignItems: "center", justifyContent: "center", fontFamily: sans, fontSize: 10, fontWeight: 700, color: WG }}>T</div>
+                <div>
+                  <div style={{ fontFamily: sans, fontSize: 11, fontWeight: 600, color: rgba(0.5) }}>Team runs</div>
+                  <div style={{ fontFamily: sans, fontSize: 9, color: rgba(0.2) }}>No SQL knowledge needed</div>
+                </div>
+              </div>
+              <Overline style={{ marginBottom: 0 }}>Form</Overline>
+            </div>
+
+            <div style={{ marginBottom: 14 }}>
+              <div style={{ fontSize: 12, fontFamily: sans, fontWeight: 500, color: rgba(0.5), marginBottom: 5 }}>
+                Customer ID <span style={{ fontSize: 9, color: "rgba(var(--warm-gold-rgb),0.5)", fontStyle: "italic" }}>required · number</span>
+              </div>
+              <div style={{
+                background: rgba(0.03), border: typedDone ? "1px solid rgba(var(--warm-gold-rgb),0.35)" : `1px solid ${rgba(0.1)}`,
+                borderRadius: 6, padding: "9px 12px", fontFamily: mono, fontSize: 13, color: S1,
+                minHeight: 18, transition: "border-color 0.3s", display: "flex", alignItems: "center",
+              }}>
+                {typed}
+                {phase >= 1 && !typedDone && <span style={{ display: "inline-block", width: 2, height: 15, background: WG, marginLeft: 1, animation: "v5Blink 1s step-end infinite" }}/>}
+              </div>
+            </div>
+
+            <div style={{ marginBottom: 14 }}>
+              <div style={{ fontSize: 11, fontFamily: sans, fontWeight: 500, color: rgba(0.4), marginBottom: 5 }}>Returns</div>
+              <div style={{ display: "flex", gap: 5, flexWrap: "wrap" }}>
+                {["customer_id", "name", "email", "status"].map(f => (
+                  <span key={f} style={{ background: rgba(0.04), border: `1px solid ${rgba(0.08)}`, borderRadius: 4, padding: "2px 7px", fontFamily: mono, fontSize: 10, color: rgba(0.3) }}>{f}</span>
+                ))}
+              </div>
+            </div>
+
+            {typedDone && (
+              <div style={{ display: "inline-flex", alignItems: "center", gap: 5, background: "rgba(var(--warm-gold-rgb),0.08)", border: "1px solid rgba(var(--warm-gold-rgb),0.2)", borderRadius: 14, padding: "4px 10px", fontSize: 10, fontWeight: 500, color: WG, animation: "v5Up 0.3s ease-out" }}>
+                <svg width="10" height="10" viewBox="0 0 16 16" fill="none"><path d="M3 8.5L6.5 12L13 4" stroke={WG} strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"/></svg>
+                Ready to execute
+              </div>
+            )}
+          </div>
+
+          {/* Review */}
+          <div style={{
+            background: rgba(0.04), border: `1px solid ${rgba(0.08)}`, borderRadius: 10, padding: "14px 18px",
+            opacity: phase >= 2 ? 1 : 0, maxHeight: phase >= 2 ? 160 : 0, overflow: "hidden",
+            transition: "opacity 0.4s 0.1s, max-height 0.4s cubic-bezier(.4,0,.2,1)",
+          }}>
+            <Overline>Access Review</Overline>
+            <div style={{ display: "flex", flexDirection: "column", gap: 7 }}>
+              <Check checked={checks >= 1} label="Guardrails passed" />
+              <Check checked={checks >= 2} label="Data masking enabled" />
+              <Check checked={checks >= 3} label="Approved by policy" />
+            </div>
+          </div>
+
+          {/* Results */}
+          <div style={{
+            background: rgba(0.04), border: `1px solid ${rgba(0.08)}`, borderRadius: 10, padding: 0, overflow: "hidden",
+            opacity: phase >= 3 ? 1 : 0, maxHeight: phase >= 3 ? 200 : 0,
+            transition: "opacity 0.4s 0.1s, max-height 0.4s cubic-bezier(.4,0,.2,1)",
+          }}>
+            <div style={{ background: rgba(0.03), borderBottom: `1px solid ${rgba(0.06)}`, padding: "8px 14px", display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+              <Overline style={{ marginBottom: 0 }}>Results</Overline>
+              <span style={{ fontFamily: mono, fontSize: 9, color: rgba(0.2) }}>1 row · 42ms</span>
+            </div>
+            <div style={{ padding: "0 14px" }}>
+              <div style={{ display: "grid", gridTemplateColumns: "50px 1fr 1fr 60px", padding: "6px 0", borderBottom: `1px solid ${rgba(0.04)}`, fontFamily: sans, fontSize: 9, fontWeight: 600, color: rgba(0.25), textTransform: "uppercase" }}>
+                <span>ID</span><span>Name</span><span>Email</span><span>Status</span>
+              </div>
+              <div style={{ display: "grid", gridTemplateColumns: "50px 1fr 1fr 60px", padding: "8px 0", fontFamily: mono, fontSize: 11, color: rgba(0.55), animation: phase >= 3 ? "v5Up 0.4s ease-out" : "none" }}>
+                <span>40192</span><span>Acme Corp</span>
+                <span style={{ color: WG, fontWeight: 500 }}>a●●●@acme.io</span>
+                <span><span style={{ background: "rgba(var(--warm-gold-rgb),0.08)", border: "1px solid rgba(var(--warm-gold-rgb),0.2)", borderRadius: 10, padding: "1px 6px", fontSize: 8.5, fontFamily: sans, fontWeight: 600, color: WG, textTransform: "uppercase" }}>active</span></span>
+              </div>
+            </div>
+            <div style={{ borderTop: `1px solid ${rgba(0.04)}`, padding: "7px 14px", display: "flex", gap: 10, fontSize: 9, color: rgba(0.18) }}>
+              <span>Recorded</span><span>·</span><span>Audited</span><span>·</span><span>Masked</span>
+            </div>
+          </div>
+
+          </div>{/* close right column */}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/snippets/annimations/runbookssplit.jsx
+++ b/snippets/annimations/runbookssplit.jsx
@@ -1,0 +1,213 @@
+export const SplitScreen = () => {
+  const WG = "var(--warm-gold)";
+  const S1 = "var(--sand-100)";
+  const S5 = "var(--sand-500)";
+  const GRAD = "linear-gradient(135deg, var(--gradient-dark-start) 0%, var(--gradient-dark-mid) 35%, var(--gradient-dark-end) 70%, var(--bronze) 100%)";
+  const FONT_URL = "https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700&family=JetBrains+Mono:wght@400;500&family=Sora:wght@600;700;800&display=swap";
+  const rgba = (a) => `rgba(var(--sand-100-rgb),${a})`;
+  const mono = "'JetBrains Mono', monospace";
+  const sans = "'DM Sans', sans-serif";
+
+  function useTypewriter(text, active, speed = 65) {
+    const [out, setOut] = useState("");
+    const [done, setDone] = useState(false);
+    useEffect(() => {
+      if (!active) { setOut(""); setDone(false); return; }
+      let i = 0; setOut(""); setDone(false);
+      const iv = setInterval(() => { i++; setOut(text.slice(0, i)); if (i >= text.length) { clearInterval(iv); setDone(true); } }, speed);
+      return () => clearInterval(iv);
+    }, [text, active, speed]);
+    return [out, done];
+  }
+
+  const PHASES = [
+    { label: "Select runbook", ms: 2500 },
+    { label: "Fill parameters", ms: 4000 },
+    { label: "Access review", ms: 2500 },
+    { label: "Execute", ms: 4000 },
+  ];
+
+  function Overline({ children, style }) {
+    return <div style={{ fontFamily: sans, fontSize: 10, fontWeight: 600, color: WG, textTransform: "uppercase", letterSpacing: "0.1em", marginBottom: 10, ...style }}>{children}</div>;
+  }
+
+  function Check({ checked, label }) {
+    return (
+      <div style={{ display: "flex", alignItems: "center", gap: 7, fontFamily: sans, fontSize: 11.5, color: checked ? rgba(0.55) : rgba(0.25), transition: "color 0.3s" }}>
+        <div style={{ width: 16, height: 16, borderRadius: 3, display: "flex", alignItems: "center", justifyContent: "center", background: checked ? "rgba(var(--warm-gold-rgb),0.12)" : rgba(0.03), border: checked ? "1px solid rgba(var(--warm-gold-rgb),0.3)" : `1px solid ${rgba(0.08)}`, transition: "all 0.4s" }}>
+          {checked
+            ? <svg width="9" height="9" viewBox="0 0 16 16" fill="none"><path d="M3 8.5L6.5 12L13 4" stroke={WG} strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"/></svg>
+            : <div style={{ width: 7, height: 7, borderRadius: "50%", border: `2px solid ${rgba(0.12)}`, borderTopColor: "rgba(var(--warm-gold-rgb),0.4)", animation: "v1Spin 0.8s linear infinite" }}/>}
+        </div>
+        {label}
+      </div>
+    );
+  }
+
+  const [phase, setPhase] = useState(0);
+  const [checks, setChecks] = useState(0);
+  const [typed, typedDone] = useTypewriter("40192", phase >= 1, 75);
+
+  useEffect(() => {
+    let t;
+    const run = (p) => { t = setTimeout(() => { const n = (p + 1) % 4; setPhase(n); if (n === 0) setChecks(0); run(n); }, PHASES[p].ms); };
+    run(0); return () => clearTimeout(t);
+  }, []);
+
+  useEffect(() => {
+    if (phase !== 2) { setChecks(0); return; }
+    let c = 0;
+    const iv = setInterval(() => { c++; setChecks(c); if (c >= 3) clearInterval(iv); }, 600);
+    return () => clearInterval(iv);
+  }, [phase]);
+
+  const paramActive = phase >= 1;
+
+  const lines = [
+    { t: "comment", v: "-- customer-lookup.runbook.sql" },
+    { t: "kw", v: "SELECT" },
+    { t: "f", v: "  customer_id, name, email, status" },
+    { t: "kw", v: "FROM customers" },
+    { t: "kw", v: "WHERE" },
+    { t: "param", v: '  customer_id = {{ .customer_id }}' },
+  ];
+
+  return (
+    <>
+      <style>{`@import url('${FONT_URL}');`}</style>
+      <style>{`
+        @keyframes v1Blink{0%,100%{opacity:1}50%{opacity:0}}
+        @keyframes v1Up{from{opacity:0;transform:translateY(6px)}to{opacity:1;transform:translateY(0)}}
+        @keyframes v1Spin{to{transform:rotate(360deg)}}
+        @keyframes v1Pulse{0%,100%{opacity:.12}50%{opacity:.2}}
+        @keyframes v1Connect{from{width:0}to{width:100%}}
+      `}</style>
+
+      <div style={{ background: GRAD, borderRadius: 14, overflow: "hidden", position: "relative", fontFamily: sans, maxWidth: 820, margin: "0 auto" }}>
+        <div style={{ position: "absolute", top: "-30%", right: "-10%", width: "60%", height: "160%", background: "radial-gradient(ellipse at center, rgba(var(--warm-gold-rgb),0.12) 0%, transparent 70%)", pointerEvents: "none", animation: "v1Pulse 4s ease-in-out infinite" }}/>
+
+        {/* Top bar */}
+        <div style={{ position: "relative", padding: "14px 22px", display: "flex", justifyContent: "space-between", alignItems: "center", borderBottom: `1px solid ${rgba(0.06)}` }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <svg width="13" height="13" viewBox="0 0 24 24" fill={S1}><circle cx="7" cy="7" r="3.5"/><circle cx="17" cy="7" r="3.5"/><circle cx="7" cy="17" r="3.5"/><circle cx="17" cy="17" r="3.5"/></svg>
+            <span style={{ fontSize: 13, fontWeight: 700, color: S1 }}>Runbooks</span>
+          </div>
+          <div style={{ display: "flex", gap: 6 }}>
+            {PHASES.map((_, i) => (
+              <div key={i} style={{ width: i === phase ? 22 : 7, height: 7, borderRadius: 4, background: i === phase ? WG : i < phase ? "rgba(var(--warm-gold-rgb),0.4)" : rgba(0.1), transition: "all 0.5s cubic-bezier(.4,0,.2,1)" }}/>
+            ))}
+          </div>
+          <div style={{ fontSize: 11, fontWeight: 500, color: rgba(0.3) }}>{PHASES[phase].label}</div>
+        </div>
+
+        {/* Split content */}
+        <div style={{ position: "relative", display: "grid", gridTemplateColumns: "1fr 1fr", height: 420 }}>
+
+          {/* LEFT: Code */}
+          <div style={{ borderRight: `1px solid ${rgba(0.06)}`, padding: "20px 22px" }}>
+            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 12 }}>
+              <Overline style={{ marginBottom: 0 }}>Engineer writes</Overline>
+              <div style={{ fontFamily: mono, fontSize: 9, color: rgba(0.2) }}>.runbook.sql</div>
+            </div>
+            <div style={{ background: rgba(0.04), border: `1px solid ${rgba(0.08)}`, borderRadius: 10, padding: "14px 16px", fontFamily: mono, fontSize: 12, lineHeight: 2 }}>
+              {lines.map((l, i) => {
+                let color = rgba(0.55);
+                if (l.t === "comment") color = S5;
+                if (l.t === "kw") color = WG;
+                const isP = l.t === "param";
+                return (
+                  <div key={i} style={{ position: "relative" }}>
+                    {isP && <div style={{
+                      position: "absolute", left: -6, right: -6, top: 2, bottom: 2,
+                      background: paramActive ? "rgba(var(--warm-gold-rgb),0.1)" : "transparent",
+                      borderRadius: 4,
+                      border: paramActive ? "1px solid rgba(var(--warm-gold-rgb),0.3)" : "1px solid transparent",
+                      transition: "all 0.5s",
+                    }}/>}
+                    <span style={{ position: "relative", color: isP && paramActive ? WG : isP ? rgba(0.3) : color, fontWeight: isP && paramActive ? 600 : 400, transition: "all 0.4s" }}>{l.v}</span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* RIGHT: Form / Review / Results */}
+          <div style={{ padding: "20px 22px", display: "flex", flexDirection: "column", gap: 12, overflow: "hidden" }}>
+            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 0 }}>
+              <Overline style={{ marginBottom: 0 }}>Team runs</Overline>
+              <div style={{ fontFamily: sans, fontSize: 9, color: rgba(0.2), display: "flex", alignItems: "center", gap: 4 }}>
+                <div style={{ width: 5, height: 5, borderRadius: "50%", background: phase >= 1 ? WG : rgba(0.15), transition: "background 0.3s" }}/>
+                {phase >= 3 ? "Done" : phase >= 1 ? "Active" : "Waiting"}
+              </div>
+            </div>
+
+            {/* Form */}
+            <div style={{
+              background: rgba(0.04), border: `1px solid ${rgba(0.08)}`, borderRadius: 10, padding: "14px 16px",
+              opacity: phase >= 1 ? 1 : 0.3, transition: "opacity 0.5s",
+            }}>
+              <div style={{ fontSize: 11, fontFamily: sans, fontWeight: 500, color: rgba(0.5), marginBottom: 5 }}>
+                Customer ID <span style={{ fontSize: 9, color: "rgba(var(--warm-gold-rgb),0.5)", fontStyle: "italic" }}>required</span>
+              </div>
+              <div style={{
+                background: rgba(0.03), border: typedDone ? "1px solid rgba(var(--warm-gold-rgb),0.35)" : `1px solid ${rgba(0.1)}`,
+                borderRadius: 6, padding: "8px 12px", fontFamily: mono, fontSize: 13, color: S1,
+                minHeight: 18, transition: "border-color 0.3s", display: "flex", alignItems: "center",
+              }}>
+                {phase >= 1 ? typed : ""}
+                {phase === 1 && !typedDone && <span style={{ display: "inline-block", width: 2, height: 15, background: WG, marginLeft: 1, animation: "v1Blink 1s step-end infinite" }}/>}
+              </div>
+              {typedDone && phase >= 1 && (
+                <div style={{ display: "inline-flex", alignItems: "center", gap: 5, marginTop: 8, background: "rgba(var(--warm-gold-rgb),0.08)", border: "1px solid rgba(var(--warm-gold-rgb),0.2)", borderRadius: 14, padding: "3px 10px", fontSize: 10, fontWeight: 500, color: WG, animation: "v1Up 0.3s ease-out" }}>
+                  <svg width="9" height="9" viewBox="0 0 16 16" fill="none"><path d="M3 8.5L6.5 12L13 4" stroke={WG} strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"/></svg>
+                  Valid
+                </div>
+              )}
+            </div>
+
+            {/* Review */}
+            <div style={{
+              background: rgba(0.04), border: `1px solid ${rgba(0.08)}`, borderRadius: 10, padding: "14px 16px",
+              opacity: phase >= 2 ? 1 : 0, maxHeight: phase >= 2 ? 150 : 0, overflow: "hidden",
+              transition: "opacity 0.4s 0.1s, max-height 0.4s cubic-bezier(.4,0,.2,1)",
+            }}>
+              <Overline>Access Review</Overline>
+              <div style={{ display: "flex", flexDirection: "column", gap: 7 }}>
+                <Check checked={checks >= 1} label="Guardrails passed" />
+                <Check checked={checks >= 2} label="Data masking on" />
+                <Check checked={checks >= 3} label="Policy approved" />
+              </div>
+            </div>
+
+            {/* Results */}
+            <div style={{
+              background: rgba(0.04), border: `1px solid ${rgba(0.08)}`, borderRadius: 10, padding: 0, overflow: "hidden",
+              opacity: phase >= 3 ? 1 : 0, maxHeight: phase >= 3 ? 200 : 0,
+              transition: "opacity 0.4s 0.1s, max-height 0.4s cubic-bezier(.4,0,.2,1)",
+            }}>
+              <div style={{ background: rgba(0.03), borderBottom: `1px solid ${rgba(0.06)}`, padding: "8px 14px", display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                <Overline style={{ marginBottom: 0 }}>Results</Overline>
+                <span style={{ fontFamily: mono, fontSize: 9, color: rgba(0.2) }}>1 row · 42ms</span>
+              </div>
+              <div style={{ padding: "0 14px" }}>
+                <div style={{ display: "grid", gridTemplateColumns: "50px 1fr 1fr 60px", padding: "6px 0", borderBottom: `1px solid ${rgba(0.04)}`, fontFamily: sans, fontSize: 9, fontWeight: 600, color: rgba(0.25), textTransform: "uppercase", letterSpacing: "0.05em" }}>
+                  <span>ID</span><span>Name</span><span>Email</span><span>Status</span>
+                </div>
+                <div style={{ display: "grid", gridTemplateColumns: "50px 1fr 1fr 60px", padding: "8px 0", fontFamily: mono, fontSize: 11, color: rgba(0.55), animation: "v1Up 0.4s ease-out" }}>
+                  <span>40192</span><span>Acme Corp</span>
+                  <span style={{ color: WG, fontWeight: 500 }}>a●●●@acme.io</span>
+                  <span><span style={{ background: "rgba(var(--warm-gold-rgb),0.08)", border: "1px solid rgba(var(--warm-gold-rgb),0.2)", borderRadius: 10, padding: "1px 6px", fontSize: 8.5, fontFamily: sans, fontWeight: 600, color: WG, textTransform: "uppercase" }}>active</span></span>
+                </div>
+              </div>
+              <div style={{ borderTop: `1px solid ${rgba(0.04)}`, padding: "7px 14px", display: "flex", gap: 10, fontSize: 9, color: rgba(0.18) }}>
+                <span>Recorded</span><span>·</span><span>Audited</span><span>·</span><span>Masked</span>
+              </div>
+            </div>
+          </div>
+
+          {/* Connecting line removed — caused visual misalignment */}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,210 @@
+/* ==========================================================================
+   Hoop.dev Grayscale Theme
+   Minimal overrides on top of Mintlify's built-in system.
+   Only uses documented safe selectors: #navbar, #sidebar, #footer, #body-content
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Design Tokens
+   -------------------------------------------------------------------------- */
+
+:root {
+  --hoop-near-black: #0A0A0A;
+  --hoop-strong: #1A1A1A;
+  --hoop-body: #1A1A1A;
+  --hoop-secondary: #333333;
+  --hoop-muted: #6E6E6E;
+  --hoop-slate: #444444;
+  --hoop-slate-dark: #1A1A1A;
+  --hoop-charcoal: #1A1A1A;
+  --hoop-silver: #B0B0B0;
+  --hoop-gray-100: #F7F7F7;
+  --hoop-gray-200: #EBEBEB;
+  --hoop-gray-300: #DEDEDE;
+  --hoop-gray-400: #C4C4C4;
+
+  /* Animation design tokens (grayscale variant) */
+  --warm-gold: #B0B0B0;
+  --warm-gold-rgb: 176,176,176;
+  --bronze: #5A5A5A;
+  --bronze-rgb: 90,90,90;
+  --bronze-dark: #333333;
+  --bronze-dark-rgb: 51,51,51;
+  --espresso: #1A1A1A;
+  --espresso-rgb: 26,26,26;
+  --sand-100: #F7F7F7;
+  --sand-100-rgb: 247,247,247;
+  --sand-200: #EBEBEB;
+  --sand-300: #DEDEDE;
+  --sand-400: #C4C4C4;
+  --sand-500: #8E8E8E;
+  --sand-500-rgb: 142,142,142;
+  --error: #6E6E6E;
+  --error-rgb: 110,110,110;
+  --success: #8E8E8E;
+  --success-rgb: 142,142,142;
+  --prompt: #B0B0B0;
+  --gradient-dark-start: #111111;
+  --gradient-dark-start-rgb: 17,17,17;
+  --gradient-dark-mid: #1A1A1A;
+  --gradient-dark-end: #2A2A2A;
+  --mono: 'JetBrains Mono', 'SF Mono', monospace;
+  --sans: 'DM Sans', system-ui, -apple-system, sans-serif;
+  --display: 'Sora', 'DM Sans', system-ui, sans-serif;
+}
+
+/* --------------------------------------------------------------------------
+   2. Light Mode Typography (high contrast)
+   -------------------------------------------------------------------------- */
+
+:root:not(.dark) #body-content,
+:root:not(.dark) #body-content p,
+:root:not(.dark) #body-content li,
+:root:not(.dark) #body-content dd,
+:root:not(.dark) #body-content blockquote,
+:root:not(.dark) #body-content span,
+:root:not(.dark) #body-content td {
+  color: #1A1A1A !important;
+}
+
+:root:not(.dark) #body-content h1,
+:root:not(.dark) #body-content h2,
+:root:not(.dark) #body-content h3,
+:root:not(.dark) #body-content h4,
+:root:not(.dark) #body-content h5,
+:root:not(.dark) #body-content h6,
+:root:not(.dark) #body-content strong {
+  color: #0A0A0A !important;
+  letter-spacing: -0.02em;
+}
+
+:root:not(.dark) #body-content a {
+  color: #1A1A1A !important;
+  text-decoration-color: #C4C4C4;
+  text-underline-offset: 2px;
+  transition: text-decoration-color 0.15s ease;
+}
+
+:root:not(.dark) #body-content a:hover {
+  text-decoration-color: #1A1A1A;
+}
+
+:root:not(.dark) #body-content :not(pre) > code {
+  background: #EBEBEB;
+  color: #1A1A1A !important;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.875em;
+}
+
+:root:not(.dark) #body-content table thead th {
+  color: #0A0A0A !important;
+  font-weight: 600;
+}
+
+/* --------------------------------------------------------------------------
+   3. Light Mode Sidebar
+   -------------------------------------------------------------------------- */
+
+:root:not(.dark) #sidebar a {
+  color: #333333;
+  transition: color 0.15s ease;
+}
+
+:root:not(.dark) #sidebar a:hover {
+  color: #0A0A0A;
+}
+
+:root:not(.dark) #sidebar a[data-active="true"] {
+  color: #0A0A0A;
+  font-weight: 500;
+}
+
+/* --------------------------------------------------------------------------
+   4. Light Mode Navbar
+   -------------------------------------------------------------------------- */
+
+:root:not(.dark) #navbar {
+  border-bottom: 1px solid #EBEBEB;
+}
+
+/* --------------------------------------------------------------------------
+   5. Light Mode Cards
+   -------------------------------------------------------------------------- */
+
+:root:not(.dark) .card {
+  border: 1px solid #EBEBEB;
+  border-radius: 10px;
+  transition: border-color 0.15s ease;
+}
+
+:root:not(.dark) .card:hover {
+  border-color: #C4C4C4;
+}
+
+/* --------------------------------------------------------------------------
+   6. Light Mode Code Blocks
+   -------------------------------------------------------------------------- */
+
+:root:not(.dark) .code-block {
+  border-radius: 8px;
+  border: 1px solid #EBEBEB;
+}
+
+/* --------------------------------------------------------------------------
+   7. Light Mode Footer
+   -------------------------------------------------------------------------- */
+
+:root:not(.dark) #footer {
+  border-top: 1px solid #EBEBEB;
+}
+
+/* --------------------------------------------------------------------------
+   8. Light Mode Tabs
+   -------------------------------------------------------------------------- */
+
+:root:not(.dark) .tabs [data-active="true"] {
+  color: #0A0A0A;
+  border-color: #1A1A1A;
+}
+
+/* --------------------------------------------------------------------------
+   9. Badges (both modes)
+   -------------------------------------------------------------------------- */
+
+[data-badge] {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* --------------------------------------------------------------------------
+   10. Selection (both modes)
+   -------------------------------------------------------------------------- */
+
+::selection {
+  background: rgba(90, 90, 90, 0.15);
+}
+
+/* --------------------------------------------------------------------------
+   11. Scrollbar (both modes)
+   -------------------------------------------------------------------------- */
+
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--hoop-gray-300);
+  border-radius: 3px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--hoop-gray-400);
+}


### PR DESCRIPTION
## Summary
- Adapt 40 animation components from the marketing site for Mintlify (removed React imports, named exports, self-contained components)
- Embed animations as hero sections across 20 documentation pages
- Add grayscale CSS design tokens in `style.css` with high-contrast light mode typography
- Dark gradient wrappers for animations designed for dark backgrounds
- Fixed-height containers to prevent layout shift during animation cycles
- Light mode overrides scoped with `:root:not(.dark)` to preserve Mintlify dark mode

## Test plan
- [ ] Verify animations render on all 20 pages in light mode
- [ ] Verify animations render on all 20 pages in dark mode
- [ ] Confirm sidebar and navbar are visible in both modes
- [ ] Check text contrast is high on light mode (body text should be near-black)
- [ ] Confirm no layout shift when animations cycle
- [ ] Run `npm run build` to verify no build errors