### PR TITLE
Add note HTTP DNS wildcard

### DIFF
--- a/quickstart/web-applications/grafana-proxy.mdx
+++ b/quickstart/web-applications/grafana-proxy.mdx
@@ -80,4 +80,8 @@ import { ConnectionTemplate } from '/snippets/connection-template.jsx';
   }
 }} />
 
+<Note>
+  If your domain has a wildcard DNS record configured (e.g., `*.yourdomain.com`), you can access the proxy directly at `<connection_name>.yourdomain.com` — where `<connection_name>` is the name of your Hoop connection.
+</Note>
+
 

--- a/quickstart/web-applications/http-proxy.mdx
+++ b/quickstart/web-applications/http-proxy.mdx
@@ -79,4 +79,8 @@ import { ConnectionTemplate } from '/snippets/connection-template.jsx';
   }
 }} />
 
+<Note>
+  If your domain has a wildcard DNS record configured (e.g., `*.yourdomain.com`), you can access the proxy directly at `<connection_name>.yourdomain.com` — where `<connection_name>` is the name of your Hoop connection.
+</Note>
+
 

--- a/quickstart/web-applications/kibana-proxy.mdx
+++ b/quickstart/web-applications/kibana-proxy.mdx
@@ -81,4 +81,8 @@ import { ConnectionTemplate } from '/snippets/connection-template.jsx';
   }
 }} />
 
+<Note>
+  If your domain has a wildcard DNS record configured (e.g., `*.yourdomain.com`), you can access the proxy directly at `<connection_name>.yourdomain.com` — where `<connection_name>` is the name of your Hoop connection.
+</Note>
+
 

--- a/quickstart/web-applications/webapps-and-apis.mdx
+++ b/quickstart/web-applications/webapps-and-apis.mdx
@@ -84,4 +84,8 @@ import { ConnectionTemplate } from '/snippets/connection-template.jsx';
   }
 }} />
 
+<Note>
+  If your domain has a wildcard DNS record configured (e.g., `*.yourdomain.com`), you can access the proxy directly at `<connection_name>.yourdomain.com` — where `<connection_name>` is the name of your Hoop connection.
+</Note>
+
 

--- a/setup/deployment/kubernetes.mdx
+++ b/setup/deployment/kubernetes.mdx
@@ -986,6 +986,9 @@ proxyService:
   - name: rdpproxy
     port: 13389
     targetPort: 13389
+  - name: httpproxy
+    port: 18888
+    targetPort: 18888
 ```
 
 <Note>


### PR DESCRIPTION
## Summary
Added an informational note to the Grafana, Kibana, HTTP Proxy, and Web Applications & APIs quickstart pages explaining that users with a wildcard DNS record (*.yourdomain.com) can access proxied connections directly at <connection_name>.yourdomain.com.
Added the missing httpproxy port (18888) to the Kubernetes proxy service configuration example.


## Changed files
quickstart/web-applications/grafana-proxy.mdx
quickstart/web-applications/http-proxy.mdx
quickstart/web-applications/kibana-proxy.mdx
quickstart/web-applications/webapps-and-apis.mdx
setup/deployment/kubernetes.mdx