### PR TITLE
chore: nudge workflow-observability animation deploy

### DIFF
--- a/clients/cli.mdx
+++ b/clients/cli.mdx
@@ -174,6 +174,7 @@ hoop login --api-key hpk_your_key_value
 
 - Refer to the [API Keys guide for more information](/setup/apis/api-key)
 
+
 ### Service Account
 
 Service Account authentication is available if your identity provider supports the

--- a/setup/apis/api-key.mdx
+++ b/setup/apis/api-key.mdx
@@ -3,6 +3,7 @@ title: 'API Keys'
 description: 'Create, rotate, and revoke API keys for headless access to the Hoop Gateway'
 ---
 
+
 API Keys authenticate to the Hoop Gateway without an interactive browser login. Each key is a random string prefixed with `hpk_` that works as a bearer token for both the REST API and the CLI.
 
 Unlike the legacy static `API_KEY` environment variable, managed keys are:

--- a/snippets/annimations/WorkflowObservabilityAnimation.jsx
+++ b/snippets/annimations/WorkflowObservabilityAnimation.jsx
@@ -4,7 +4,7 @@ export const WorkflowObservabilityAnimation = () => {
       caller: "deploy-pipeline",
       keyHash: "hpk_xR9a",
       icon: "ci",
-      correlationId: "deploy-2026-04-24-17a",
+      correlationId: "deploy-2026-04-28-17a",
       sessions: [
         { connection: "postgres-migrate",   command: "ALTER TABLE users ADD COLUMN locale TEXT", duration: 340 },
         { connection: "postgres-migrate",   command: "INSERT INTO schema_versions VALUES ('2026_04_24_a')", duration: 89 },
@@ -16,11 +16,11 @@ export const WorkflowObservabilityAnimation = () => {
       caller: "nightly-report",
       keyHash: "hpk_m4Tk",
       icon: "cron",
-      correlationId: "cron-2026-04-24T02:00",
+      correlationId: "cron-2026-04-28T02:00",
       sessions: [
         { connection: "warehouse-read",   command: "SELECT * FROM fact_sales WHERE ds = CURRENT_DATE - 1", duration: 612 },
         { connection: "warehouse-read",   command: "SELECT * FROM dim_customer", duration: 418 },
-        { connection: "s3-exports",       command: "PUT s3://reports/2026-04-24/daily.parquet", duration: 204 },
+        { connection: "s3-exports",       command: "PUT s3://reports/2026-04-28/daily.parquet", duration: 204 },
         { connection: "slack-notify",     command: "POST /notify #data-reports", duration: 93 },
       ],
     },


### PR DESCRIPTION
## Summary

The `WorkflowObservabilityAnimation` component renders correctly in `mint dev` and in PR previews, but on production the wrapper div is empty. Inspecting the served HTML reveals Mintlify's MDX compiler is emitting:

```
/*Component WorkflowObservabilityAnimation does not exist.*/
```

The file is committed to `main` (`snippets/annimations/WorkflowObservabilityAnimation.jsx`), parses cleanly, and the import path/casing match — so this is a Mintlify build/cache issue, not a code bug.

This PR makes a no-op edit to the snippet (bumps `2026-04-24` → `2026-04-28` in the demo correlation IDs) to force Mintlify to re-register the snippet on deploy.

## Test plan

- [ ] After merge, confirm https://hoop.dev/docs/learn/features/workflow-observability shows the animated session stream instead of an empty gradient box
- [ ] Confirm the served HTML no longer contains `Component WorkflowObservabilityAnimation does not exist`
- [ ] If the issue persists, follow up by renaming the component/file to a shorter name and/or contacting Mintlify support