### PR TITLE
docs: rename Connection to Resource/Resource Role across the docs

### DIFF
--- a/clients/cli-resources.mdx
+++ b/clients/cli-resources.mdx
@@ -233,7 +233,7 @@ Sessions are visible in the Web App under **Provisioning → Sessions** and in t
     Every plan and apply is a full audit session — explore what gets captured
   </Card>
   <Card title="Access Control" icon="lock" href="/learn/features/access-control">
-    Restrict provisioned connections to specific user groups after roles are applied
+    Restrict provisioned resource roles to specific user groups after roles are applied
   </Card>
   <Card title="CLI Reference" icon="terminal" href="/clients/cli">
     Full CLI installation and authentication guide

--- a/clients/cli.mdx
+++ b/clients/cli.mdx
@@ -153,7 +153,7 @@ Every `hoop exec` call that shares the same correlation value is tagged on the s
 
 ## Programmatic API Access
 
-This authentication method is designed for administrators who need programmatic access to the API for tasks such as managing connections,
+This authentication method is designed for administrators who need programmatic access to the API for tasks such as managing resource roles,
 configuring policies, or executing operations within automation pipelines.
 
 Programmatic access requires static authentication credentials that can be obtained through the following methods:
@@ -228,7 +228,7 @@ hoop config create
 ```
 
 <Note>
-  This flag is optional and used only to interact with connections.
+  This flag is optional and used only to interact with resource roles.
   The `--grpc-url` is obtained automatically from the Api when a user Sign In (issue the `hoop login` command)
 </Note>
 

--- a/clients/hsh.mdx
+++ b/clients/hsh.mdx
@@ -10,11 +10,11 @@ import Prerequisites from '/snippets/GettingStartedPrerequisites.mdx';
 `hsh` is a small companion CLI that wraps `ssh` and `kubectl` so they
 work against resources behind your Hoop gateway without any workflow
 changes. You keep typing the commands you already know; `hsh` handles
-authentication, finds the right Hoop connection, and routes the call
+authentication, finds the right Hoop resource role, and routes the call
 through the gateway.
 
 <Note>
-  `hsh` is **separate from the `hoop` CLI**. They can be installed side-by-side and don't conflict. Use `hoop` for administrative and automation tasks (managing connections, running `hoop exec`, configuring policies). Use `hsh` for day-to-day terminal work where you want `ssh`/`kubectl` to "just work".
+  `hsh` is **separate from the `hoop` CLI**. They can be installed side-by-side and don't conflict. Use `hoop` for administrative and automation tasks (managing resource roles, running `hoop exec`, configuring policies). Use `hsh` for day-to-day terminal work where you want `ssh`/`kubectl` to "just work".
 </Note>
 
 ## Installation
@@ -110,7 +110,7 @@ through the gateway.
     Restart your shell (or `source` the file you just edited). From now on, plain `ssh` and `kubectl` commands are intercepted by `hsh`.
 
     <Tip>
-      `hsh` only intercepts commands that match a Hoop connection. Anything else falls straight through to your native `ssh`/`kubectl` binary, untouched.
+      `hsh` only intercepts commands that match a Hoop resource role. Anything else falls straight through to your native `ssh`/`kubectl` binary, untouched.
     </Tip>
   </Step>
 </Steps>
@@ -123,19 +123,19 @@ Once the shell plugin is active, the workflow for connecting to a Hoop-managed h
 ssh production-db
 ```
 
-`hsh` recognizes `production-db` as a Hoop connection, mints a short-lived access token, and feeds it to `ssh` via the standard `SSH_ASKPASS` mechanism. You don't see a token, you don't paste anything \u2014 the password prompt is answered for you.
+`hsh` recognizes `production-db` as a Hoop resource role, mints a short-lived access token, and feeds it to `ssh` via the standard `SSH_ASKPASS` mechanism. You don't see a token, you don't paste anything \u2014 the password prompt is answered for you.
 
 <Note>
   Automatic token injection requires **OpenSSH 8.4 or newer** (which honors `SSH_ASKPASS_REQUIRE=force`). On older clients, `hsh` falls back to the legacy flow: it prints the token in a box and you paste it at the password prompt. To disable injection on a single invocation, run `HSH_SSH_ASKPASS=0 ssh <host>`.
 </Note>
 
-If the host doesn't match any Hoop connection (e.g. a personal VPS, your CI runner, GitHub), `ssh` runs unchanged \u2014 `hsh` doesn't get in the way.
+If the host doesn't match any Hoop resource role (e.g. a personal VPS, your CI runner, GitHub), `ssh` runs unchanged \u2014 `hsh` doesn't get in the way.
 
 ### What hsh does behind the scenes
 
 1. Parses your ssh arguments (`user@host`, `-p`, `-l`, `-i`, etc.).
 2. Verifies your `~/.hsh/auth.json` is still valid; if not, exits with a clear "run hsh login" message.
-3. Searches your Hoop connections for one matching the host you typed.
+3. Searches your Hoop resource roles for one matching the host you typed.
 4. Creates a session and asks the gateway for a one-time access token.
 5. Writes a small SSH askpass shim, runs `ssh` with `SSH_ASKPASS` pointing at it, and lets ssh authenticate normally.
 
@@ -148,7 +148,7 @@ kubectl get pods
 kubectl --context my-eks-cluster logs deploy/api
 ```
 
-`hsh` looks at your current `kubectl` context (or `--context=<name>`), finds the matching Hoop connection, requests a short-lived proxy URL + token, and merges them into your kubeconfig before running `kubectl`. The original kubeconfig is restored when the command exits.
+`hsh` looks at your current `kubectl` context (or `--context=<name>`), finds the matching Hoop resource role, requests a short-lived proxy URL + token, and merges them into your kubeconfig before running `kubectl`. The original kubeconfig is restored when the command exits.
 
 If you want a long-lived kubeconfig you can use from any tool (kubens, k9s, lens, etc.), generate one explicitly:
 
@@ -183,7 +183,7 @@ HSH_DEBUG=1 kubectl get pods 2>debug.log
 
 Output goes to **stderr only**, so it never pollutes the program's stdout. Common things to look for:
 
-- **`match: level=null`** \u2014 the host or context didn't match any Hoop connection at any matching level. `hsh` runs the native command unchanged.
+- **`match: level=null`** \u2014 the host or context didn't match any Hoop resource role at any matching level. `hsh` runs the native command unchanged.
 - **`api: fetch failed reason=timeout`** \u2014 the gateway is unreachable. `hsh` falls open to native `ssh`/`kubectl` after \u22483s. Run `hsh status` to confirm the API URL.
 - **`cache: hit expire_at=...`** \u2014 `hsh` reused a cached credential. Run `hsh logout` (clears every cache file) to force a fresh issue.
 

--- a/clients/webapp/managing-access.mdx
+++ b/clients/webapp/managing-access.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Managing Access"
-description: "Learn how to control and organize access to your connections through user groups and permissions"
+description: "Learn how to control and organize access to your resource roles through user groups and permissions"
 ---
 
 import { SessionAnimation } from '/snippets/annimations/SessionAnimation.jsx';
@@ -9,7 +9,7 @@ import { SessionAnimation } from '/snippets/annimations/SessionAnimation.jsx';
   <SessionAnimation />
 </div>
 
-Hoop.dev provides a comprehensive access management system that allows administrators to control who can access specific connections. This is primarily managed through user groups and connection-specific configurations.
+Hoop.dev provides a comprehensive access management system that allows administrators to control who can access specific resource roles. This is primarily managed through user groups and resource-role-specific configurations.
 
 ## Managing Users and Groups
 
@@ -36,30 +36,30 @@ Groups are the primary way to organize users and control access:
   </Step>
 </Steps>
 
-## Configuring Connection Access
+## Configuring Resource Role Access
 
 <Frame>
-  <img src="/images/clients/webapp/managing-access-connection.png" alt="Connection Access Configuration" />
+  <img src="/images/clients/webapp/managing-access-connection.png" alt="Resource Role Access Configuration" />
 </Frame>
 
-Administrators can set up access controls in the Configuration options of a connection:
+Administrators can set up access controls in the Configuration options of a resource role:
 
 ### Access Requests Configuration
 <Steps>
   <Step title="Enable Access Requests">
-    Enable the Access Requests toggle to require approval for connection access.
+    Enable the Access Requests toggle to require approval for resource role access.
   </Step>
 
   <Step title="Select Groups">
     Select which groups:
-    - Can access the connection
+    - Can access the resource role
     - Need approval before accessing
     - Can approve access requests
   </Step>
 </Steps>
 
 ### Access Modes
-Configure how users interact with the connection:
+Configure how users interact with the resource role:
 
 <CardGroup cols={2}>
   <Card title="Runbooks" icon="book">
@@ -91,7 +91,7 @@ Configure how users interact with the connection:
   </Card>
 
   <Card title="Access Monitoring" icon="eye">
-    Use session monitoring to track and audit connection usage
+    Use session monitoring to track and audit resource role usage
   </Card>
 </CardGroup>
 
@@ -99,7 +99,7 @@ Configure how users interact with the connection:
 
 <CardGroup cols={2}>
   <Card title="Monitoring Sessions" icon="video" href="/clients/webapp/monitoring-sessions">
-    Learn how to track and audit connection usage
+    Learn how to track and audit resource role usage
   </Card>
 
   <Card title="Access Requests" icon="shield-check" href="/learn/features/access-requests/jit">

--- a/clients/webapp/monitoring-sessions.mdx
+++ b/clients/webapp/monitoring-sessions.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Monitoring Sessions"
-description: "Learn how to track and audit connection usage through the Sessions interface"
+description: "Learn how to track and audit resource role usage through the Sessions interface"
 ---
 
 import { AuditTrailDemo } from '/snippets/annimations/AuditTrailDemo.jsx';
@@ -9,13 +9,13 @@ import { AuditTrailDemo } from '/snippets/annimations/AuditTrailDemo.jsx';
   <AuditTrailDemo />
 </div>
 
-The Sessions interface provides a comprehensive view of all connection activities across your organization. You can monitor active sessions, review past activities, and investigate specific actions taken by users.
+The Sessions interface provides a comprehensive view of all resource role activities across your organization. You can monitor active sessions, review past activities, and investigate specific actions taken by users.
 
 ## Sessions Overview
 
-The Sessions page displays a list of all connection activities with key information:
+The Sessions page displays a list of all resource role activities with key information:
 - User who initiated the session
-- Connection name and type
+- Resource role name and type
 - Session ID for reference
 - Timestamp and duration
 - Status indicators
@@ -24,8 +24,8 @@ The Sessions page displays a list of all connection activities with key informat
 
 Use the top filters to narrow down sessions:
 - **User**: Filter by specific team members
-- **Connection**: View sessions for particular connections
-- **Type**: Filter by connection type (database, application, etc.)
+- **Resource Role**: View sessions for particular resource roles
+- **Type**: Filter by resource role type (database, application, etc.)
 - **Period**: Select a specific time range
 
 ## Session Details
@@ -36,18 +36,18 @@ Use the top filters to narrow down sessions:
 
 Clicking on a session opens a detailed view that shows:
 
-### Connection Information
+### Resource Role Information
 - Session start and end times
-- Connection type and name
+- Resource role type and name
 - User who initiated the session
 
 ### Activity Log
-For database connections:
+For database resource roles:
 - SQL queries executed
 - Query results
 - Execution timestamps
 
-For application and SSH connections:
+For application and SSH resource roles:
 - Commands executed
 - Command output
 - Terminal sessions
@@ -64,7 +64,7 @@ From the session details view, you can:
 
 <CardGroup cols={2}>
   <Card title="JIT Access Requests" icon="clock">
-    Sessions may require approval before starting if JIT access requests are enabled for the connection
+    Sessions may require approval before starting if JIT access requests are enabled for the resource role
   </Card>
 
   <Card title="Action Access Requests" icon="terminal">
@@ -88,7 +88,7 @@ From the session details view, you can:
   </Card>
   
   <Card title="Performance" icon="chart-line">
-    Monitor session patterns to optimize connection usage
+    Monitor session patterns to optimize resource role usage
   </Card>
 </CardGroup>
 

--- a/clients/webapp/overview.mdx
+++ b/clients/webapp/overview.mdx
@@ -9,13 +9,13 @@ import { ProductMock } from '/snippets/annimations/ProductMock.jsx';
   <ProductMock />
 </div>
 
-Our Web App is your central interface for managing secure access to your infrastructure. It provides a modern, intuitive interface for creating and managing connections, controlling access policies, and monitoring user sessions - all while maintaining robust security through AI-powered features.
+Our Web App is your central interface for managing secure access to your infrastructure. It provides a modern, intuitive interface for creating and managing resource roles, controlling access policies, and monitoring user sessions - all while maintaining robust security through AI-powered features.
 
 ## Key Features
 
 <CardGroup cols={2}>
-  <Card title="Connection Management" icon="plug">
-    Create and manage secure connections to your databases, servers, and cloud services. Configure access settings, security policies, and monitoring options all in one place.
+  <Card title="Resource Role Management" icon="plug">
+    Create and manage secure resource roles to your databases, servers, and cloud services. Configure access settings, security policies, and monitoring options all in one place.
   </Card>
   
   <Card title="Access Control" icon="lock">
@@ -34,14 +34,14 @@ Our Web App is your central interface for managing secure access to your infrast
 ## Core Components
 
 ### Dashboard
-Your central hub for monitoring activity, managing connections, and accessing key features:
-- Quick access to all your connections
+Your central hub for monitoring activity, managing resource roles, and accessing key features:
+- Quick access to all your resource roles
 - Activity monitoring and alerts
 - System status and health metrics
 - Recent session history
 
-### Connection Manager
-Create and manage connections to various resources:
+### Resource Role Manager
+Create and manage resource roles to various resources:
 - Databases (PostgreSQL, MySQL, MongoDB, etc.)
 - Cloud Services (AWS, Kubernetes)
 - Web Applications and APIs
@@ -68,8 +68,8 @@ Access Hoop.dev's web interface at [use.hoop.dev](https://use.hoop.dev) for our 
 ## Next Steps
 
 <CardGroup cols={2}>
-  <Card title="Creating Connections" icon="plus" href="/clients/webapp/creating-resource-roles">
-    Learn how to set up and configure different types of connections.
+  <Card title="Creating Resource Roles" icon="plus" href="/clients/webapp/creating-resource-roles">
+    Learn how to set up and configure different types of resource roles.
     <br />
     **Get Started** <Icon icon="arrow-right" />
   </Card>

--- a/integrations/aws.mdx
+++ b/integrations/aws.mdx
@@ -1,6 +1,6 @@
 ---
 title: "AWS Connect"
-description: "Database Resource Discovery and Automatic Connection Creation."
+description: "Database Resource Discovery and Automatic Resource Role Creation."
 ---
 
 This feature enables you to discover and provision common database roles to your RDS databases in AWS seamlessly.
@@ -215,7 +215,7 @@ This security group is configured with the following properties:
 
 You have the option to manage these security groups directly to customize connectivity settings as needed.
 
-## Roles and Connection Management
+## Roles and Resource Role Management
 
 The provisioner will reset the master database credentials using a random password.
 The user and password are stored in Hoop's database. Subsequent requests for provisioning roles reuse the master credentials stored in Hoop.
@@ -229,15 +229,15 @@ The provisioner will create three static user roles for all existing databases d
 If you run the process multiple times, some database users might be removed and recreated.
 The default behavior is to provision the role if it doesn't exist and change the password if the role already exists.
 
-In the final step of the provisioning process, it creates connections with the credentials of each role.
-Three connections are provisioned as the outcome:
+In the final step of the provisioning process, it creates resource roles with the credentials of each role.
+Three resource roles are provisioned as the outcome:
 
 - `<connection-name-prefix>-ro`
 - `<connection-name-prefix>-rw`
 - `<connection-name-prefix>-ddl`
 
 <Frame>
-  <img src="/images/integrations/aws-connect-4.png" alt="Connection Configuration" />
+  <img src="/images/integrations/aws-connect-4.png" alt="Resource Role Configuration" />
 </Frame>
 
 The database user roles permissions are static and described below:
@@ -452,7 +452,7 @@ print('response status: ', response['status'])
 This integration enables you to delegate the management of secrets to HashiCorp Vault, a robust secrets management solution.
 When enabled, all provisioned roles are securely stored in Vault.
 
-For deployments with connection provisioning enabled, the integration automatically adds the necessary reference secrets provider and secret ID.
+For deployments with resource role provisioning enabled, the integration automatically adds the necessary reference secrets provider and secret ID.
 
 <Note>
     For this integration to function properly, the agent must be configured with the correct Vault credentials.

--- a/integrations/jira.mdx
+++ b/integrations/jira.mdx
@@ -75,21 +75,21 @@ For a step-by-step setup and advanced options, see [Advanced Configuration](#adv
     To create a Jira Template, fill out the following information:
     - **Integration details:** Name, Description, Project Key, and Request Type.
     <Info>For more information about how to get Jira information check [Jira Templates](#jira-templates).</Info>
-    - **Automated Mapping:** Append additional information to created Jira tickets when executing commands in a connection.
+    - **Automated Mapping:** Append additional information to created Jira tickets when executing commands in a resource role.
     <Info>For more information about available hoop.dev fields, check [Automated Mapping](#automated-mapping).</Info>
     - **Manual Prompt:** Request additional information from users when executing commands to be appended to created Jira tickets.
     <Info>For more information, check [Manual Prompt](#manual-prompt).</Info>
     - **Configuration Management Database (CMDB):** Optionally relate CMDBs and hoop.dev services.
   </Step>
-  <Step title="Adding templates to a connection">
+  <Step title="Adding templates to a resource role">
     <Frame>
       <img src="/images/integrations/jira-4.png" />
     </Frame>
-    While creating or configuring a connection, navigate to <code>Advanced Settings</code> and select a Jira Template.
-    <Info>To keep your default workflow, Access Requests must be enabled for this connection. Connections without Access Requests enabled will mark Jira tickets as done after executing a command.</Info>
+    While creating or configuring a resource role, navigate to <code>Advanced Settings</code> and select a Jira Template.
+    <Info>To keep your default workflow, Access Requests must be enabled for this resource role. Resource roles without Access Requests enabled will mark Jira tickets as done after executing a command.</Info>
   </Step>
   <Step title="Executing session">
-    When a command is executed in a connection with a Jira Template, all configured information is checked (and requested, if needed) and appended to the session while a Jira ticket is created to the workflow.
+    When a command is executed in a resource role with a Jira Template, all configured information is checked (and requested, if needed) and appended to the session while a Jira ticket is created to the workflow.
   </Step>
 </Steps>
 
@@ -140,7 +140,7 @@ https://yourcompany.atlassian.net/jira/servicedesk/projects/PROJ/settings/issuet
 
 ### Automated Mapping
 
-Appends additional information to Jira cards when executing commands in a connection.
+Appends additional information to Jira cards when executing commands in a resource role.
 
 | Field         | Values   | Usage                                                      |
 |---------------|----------|------------------------------------------------------------|
@@ -151,13 +151,13 @@ Appends additional information to Jira cards when executing commands in a connec
 | **Description**|`string` | Optional information used to identify a mapping item.      |
 
 **Preset values include:**  
-Session ID, User Email, User ID, User Name, Connection Type, Connection Name, Connection Tags, Session Status, Session Start Date, Session Type, Session Script
+Session ID, User Email, User ID, User Name, Resource Role Type, Resource Role Name, Resource Role Tags, Session Status, Session Start Date, Session Type, Session Script
 
 ---
 
 ### Manual Prompt
 
-Requests manual input from users to get additional information when executing commands in a connection.
+Requests manual input from users to get additional information when executing commands in a resource role.
 
 | Field         | Values   | Usage                                                      |
 |---------------|----------|------------------------------------------------------------|

--- a/integrations/ms-presidio.mdx
+++ b/integrations/ms-presidio.mdx
@@ -67,6 +67,6 @@ Microsoft Presidio works seamlessly with other Hoop.dev capabilities:
     | `MSPRESIDIO_ANONYMIZER_URL` | `<host-to-anonymizer:port>` |
   </Step>
   <Step title="Run hoop.dev's Gateway with the new configs">
-    After setting up the environment variables, hoop.dev will use Microsoft Presidio to mask sensitive data in real-time in the data stream of any connection you configure.
+    After setting up the environment variables, hoop.dev will use Microsoft Presidio to mask sensitive data in real-time in the data stream of any resource role you configure.
   </Step>
 </Steps>

--- a/integrations/slack.mdx
+++ b/integrations/slack.mdx
@@ -121,7 +121,7 @@ hoop admin create plugin slack \
 
 We need to go to the Slack plugin page and access the menu → Manage plugins → Slack.
 
-Then, click on settings and add all the channels (separated by commas) you would like to receive access request notifications from that connection.
+Then, click on settings and add all the channels (separated by commas) you would like to receive access request notifications from that resource role.
 
 <Frame>
   <img src="/images/integrations/slack-3.gif" />
@@ -157,9 +157,9 @@ You can copy the ID of other members too on Slack.
 
 ## Usage
 
-To use this integration, access requests must be enabled for a connection. When interacting with it, a message will be sent to the configured Slack channel.
+To use this integration, access requests must be enabled for a resource role. When interacting with it, a message will be sent to the configured Slack channel.
 
-**Associate the connection with the `slack` plugin and configure reviewers**
+**Associate the resource role with the `slack` plugin and configure reviewers**
 
 ```bash
 hoop admin create conn bash \
@@ -170,7 +170,7 @@ hoop admin create conn bash \
     -- bash
 ```
 
-Then, interacting with the connection will send a message to your Slack channel. After it’s approved, it will send a message to the creator.
+Then, interacting with the resource role will send a message to your Slack channel. After it’s approved, it will send a message to the creator.
 
 ```bash
 hoop connect bash

--- a/integrations/teams.mdx
+++ b/integrations/teams.mdx
@@ -55,9 +55,9 @@ In the "Overview" tab, the test with the sent event will be displayed.
   <img src="/images/integrations/teams-3.png" />
 </Frame>
 
-## Connections
+## Resource Roles
 
-Now, you can define which connections will send this event based on the plugin configuration. Update or add a new connection to enable this plugin.
+Now, you can define which resource roles will send this event based on the plugin configuration. Update or add a new resource role to enable this plugin.
 
 ```bash
 hoop admin create conn bash -a <agent-name> --overwrite \
@@ -65,7 +65,7 @@ hoop admin create conn bash -a <agent-name> --overwrite \
   --reviewers admin -- bash
 ```
 
-Interacting with the connection via the webapp or the CLI will trigger an alert indicating that an access request has been created. A message will be sent to the Microsoft Teams channel.
+Interacting with the resource role via the webapp or the CLI will trigger an alert indicating that an access request has been created. A message will be sent to the Microsoft Teams channel.
 
 ```bash
 hoop exec bash -i 'ls -l'

--- a/introduction/getting-started.mdx
+++ b/introduction/getting-started.mdx
@@ -43,7 +43,7 @@ Hoop.dev enforces controls inline at the wire protocol for engineers, AI agents,
     **Learn more** <Icon icon="arrow-right" />
   </Card>
   <Card title="Access Control" icon="lock" href="/learn/features/access-control">
-    Define granular access policies determining which users or groups can access specific connections. Integrate with your existing identity provider to maintain consistent access governance.
+    Define granular access policies determining which users or groups can access specific resources. Integrate with your existing identity provider to maintain consistent access governance.
 
     <br />
 

--- a/learn/features/abac.mdx
+++ b/learn/features/abac.mdx
@@ -120,7 +120,7 @@ One attribute then covers every resource role it applies to—you do not need to
 
 <CardGroup cols={2}>
   <Card title="Access Control" icon="lock" href="/learn/features/access-control">
-    Restrict who can use which connections
+    Restrict who can use which resources
   </Card>
   <Card title="Guardrails" icon="shield" href="/learn/features/guardrails">
     Block dangerous queries with pattern-based rules

--- a/learn/features/access-control.mdx
+++ b/learn/features/access-control.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Access Control"
-description: "Control who can access which connections with group-based permissions"
+description: "Control who can access which resource roles with group-based permissions"
 ---
 
 import { ObservabilityAnimation } from '/snippets/annimations/ObservabilityAnimation.jsx';
@@ -11,7 +11,7 @@ import { ObservabilityAnimation } from '/snippets/annimations/ObservabilityAnima
 
 ## What You'll Accomplish
 
-Access Control lets you restrict which users can see and use specific connections. Instead of giving everyone access to everything, you can:
+Access Control lets you restrict which users can see and use specific resource roles. Instead of giving everyone access to everything, you can:
 
 - Limit production database access to senior engineers
 - Give read-only access to analysts
@@ -22,7 +22,7 @@ Access Control lets you restrict which users can see and use specific connection
 
 ## How It Works
 
-Access Control uses **groups** to manage permissions. Users belong to groups, and connections are configured to allow access from specific groups.
+Access Control uses **groups** to manage permissions. Users belong to groups, and resource roles are configured to allow access from specific groups.
 
 <Steps>
   <Step title="User Authenticates">
@@ -32,10 +32,10 @@ Access Control uses **groups** to manage permissions. Users belong to groups, an
     User's group memberships are synced from the identity provider
   </Step>
   <Step title="Access Evaluated">
-    When accessing a connection, Hoop checks if the user's groups are allowed
+    When accessing a resource role, Hoop checks if the user's groups are allowed
   </Step>
   <Step title="Access Granted or Denied">
-    User sees the connection if allowed, or gets an access denied error
+    User sees the resource role if allowed, or gets an access denied error
   </Step>
 </Steps>
 
@@ -57,12 +57,12 @@ import Prerequisites from '/snippets/LearnPrerequisites.mdx';
 <Prerequisites />
 
 - Groups configured in your identity provider
-- Admin access to configure connections
+- Admin access to configure resource roles
 
 ### Step 1: Enable Access Control
 
 <Warning>
-Enabling Access Control will hide connections from users who don't have explicit access. Plan your group assignments before enabling.
+Enabling Access Control will hide resource roles from users who don't have explicit access. Plan your group assignments before enabling.
 </Warning>
 
 <Steps>
@@ -78,21 +78,21 @@ Enabling Access Control will hide connections from users who don't have explicit
   </Step>
 </Steps>
 
-### Step 2: Configure Connection Access
+### Step 2: Configure Resource Role Access
 
 <Steps>
-  <Step title="Select a Connection">
-    Find the connection you want to configure and click on it
+  <Step title="Select a Resource Role">
+    Find the resource role you want to configure and click on it
   </Step>
   <Step title="Toggle Access Control">
-    Enable the Access Control toggle for this connection
+    Enable the Access Control toggle for this resource role
 
     <Frame>
-      <img src="/images/learn/features/access-control-activated.png" alt="Enable on connection" />
+      <img src="/images/learn/features/access-control-activated.png" alt="Enable on resource role" />
     </Frame>
   </Step>
   <Step title="Select Allowed Groups">
-    Choose which groups can access this connection
+    Choose which groups can access this resource role
 
     <Frame>
       <img src="/images/learn/features/access-control-add-groups.png" alt="Select groups" />
@@ -106,9 +106,9 @@ Enabling Access Control will hide connections from users who don't have explicit
 ### Step 3: Verify Access
 
 1. Log in as a user in one of the allowed groups
-2. Verify you can see and access the connection
+2. Verify you can see and access the resource role
 3. Log in as a user NOT in the allowed groups
-4. Verify the connection is not visible
+4. Verify the resource role is not visible
 
 ---
 
@@ -137,11 +137,11 @@ Configure your identity provider to include groups in the ID token:
 
 | Role | Description |
 |------|-------------|
-| `admin` | Full access to all connections and settings |
+| `admin` | Full access to all resource roles and settings |
 | `auditor` | Read-only access to sessions and audit logs |
 
 <Note>
-Admin users bypass Access Control and can access all connections. Use admin sparingly.
+Admin users bypass Access Control and can access all resource roles. Use admin sparingly.
 </Note>
 
 ---
@@ -152,7 +152,7 @@ Admin users bypass Access Control and can access all connections. Use admin spar
 
 Restrict production access to senior team members:
 
-| Connection | Allowed Groups |
+| Resource Role | Allowed Groups |
 |------------|----------------|
 | prod-db | `senior-engineers`, `dba` |
 | staging-db | `engineering` |
@@ -162,7 +162,7 @@ Restrict production access to senior team members:
 
 Each team only sees their own resources:
 
-| Connection | Allowed Groups |
+| Resource Role | Allowed Groups |
 |------------|----------------|
 | payments-db | `payments-team` |
 | inventory-db | `inventory-team` |
@@ -172,14 +172,14 @@ Each team only sees their own resources:
 
 Different access levels for different roles:
 
-| Connection | Allowed Groups |
+| Resource Role | Allowed Groups |
 |------------|----------------|
 | prod-db-readwrite | `dba` |
 | prod-db-readonly | `engineering`, `support` |
 | prod-db-analytics | `analytics` |
 
 <Tip>
-Create multiple connections to the same database with different credentials for different access levels.
+Create multiple resource roles to the same database with different credentials for different access levels.
 </Tip>
 
 ### Pattern 4: Contractor Access
@@ -188,7 +188,7 @@ Temporary access for external contractors:
 
 1. Create a `contractors` group
 2. Add contractors to the group
-3. Only allow `contractors` group on specific, limited connections
+3. Only allow `contractors` group on specific, limited resource roles
 4. Remove from group when contract ends
 
 ---
@@ -208,7 +208,7 @@ Access Control works with other Hoop security features:
 
 For a production database:
 
-1. **Access Control:** Only `senior-engineers` can see the connection
+1. **Access Control:** Only `senior-engineers` can see the resource role
 2. **Access Requests:** Require JIT approval before connecting
 3. **Guardrails:** Block `DROP TABLE` and `DELETE` without WHERE
 4. **Live Data Masking:** Redact PII in query results
@@ -218,10 +218,10 @@ For a production database:
 
 ## Troubleshooting
 
-### User Can't See a Connection
+### User Can't See a Resource Role
 
 **Check:**
-1. Access Control is enabled on that connection
+1. Access Control is enabled on that resource role
 2. User's groups are in the allowed list
 3. User has logged out and back in (to sync groups)
 4. Identity provider is sending the `groups` claim
@@ -231,11 +231,11 @@ For a production database:
 2. Find the user and click to view details
 3. Check their group memberships
 
-### User Sees Connection But Can't Connect
+### User Sees Resource Role But Can't Connect
 
 This is likely an Access Request or Guardrail issue, not Access Control. Check:
 1. Is JIT or Action Access Request enabled?
-2. Are there Guardrails blocking the connection?
+2. Are there Guardrails blocking the resource role?
 
 ### Groups Not Syncing from IdP
 
@@ -269,7 +269,7 @@ This is likely an Access Request or Guardrail issue, not Access Control. Check:
 Quarterly, review:
 - [ ] Are all group memberships still appropriate?
 - [ ] Are there users who left but still have access?
-- [ ] Are there connections that should have stricter access?
+- [ ] Are there resource roles that should have stricter access?
 - [ ] Are contractors' access limited to their engagement period?
 
 ---

--- a/learn/features/access-requests/action.mdx
+++ b/learn/features/access-requests/action.mdx
@@ -60,7 +60,7 @@ In Slack (or Teams):
 ```
 🔔 Access Request from alice@company.com
 
-Connection: prod-db
+Resource Role: prod-db
 Command: UPDATE users SET status = 'inactive' WHERE id = 123
 
 [Approve] [Reject]

--- a/learn/features/access-requests/jit.mdx
+++ b/learn/features/access-requests/jit.mdx
@@ -20,7 +20,7 @@ Just-in-Time (JIT) Access Requests let you grant temporary access to production 
 - Enable break-glass access for emergencies with full audit trail
 - Reduce standing privileges by requiring approval for every access request
 
-**The key difference from Action Access Requests:** JIT grants time-based access to a connection. Once approved, the user can run any command within that time window. Action Access Requests require approval for each individual command.
+**The key difference from Action Access Requests:** JIT grants time-based access to a resource role. Once approved, the user can run any command within that time window. Action Access Requests require approval for each individual command.
 
 ---
 
@@ -59,18 +59,18 @@ import Prerequisites from '/snippets/LearnPrerequisites.mdx';
 
 <Prerequisites />
 
-- A connection configured with an agent
+- A resource role configured with an agent
 - At least one user group for approvers (e.g., `admin`, `dba-team`)
 - (Optional) [Slack integration](/integrations/slack) for notifications
 
-### Step 1: Enable JIT Access Requests on a Connection
+### Step 1: Enable JIT Access Requests on a Resource Role
 
 <Steps>
   <Step title="Navigate to Access Requests">
     Go to **Manage > Access Requests** in the Web App
   </Step>
-  <Step title="Select Your Connection">
-    Find the connection you want to protect (e.g., `prod-postgres`) and click **Configure**
+  <Step title="Select Your Resource Role">
+    Find the resource role you want to protect (e.g., `prod-postgres`) and click **Configure**
 
     <Frame>
       <img src="/images/learn/jit-reviews-1.png" alt="Access Requests configuration page" />
@@ -88,7 +88,7 @@ import Prerequisites from '/snippets/LearnPrerequisites.mdx';
     </Warning>
   </Step>
   <Step title="Save Configuration">
-    Click **Save** to enable JIT access requests for this connection
+    Click **Save** to enable JIT access requests for this resource role
   </Step>
 </Steps>
 
@@ -124,7 +124,7 @@ Click the **Approve** button directly in the Slack notification.
 
 1. Go to **Access Requests** in the sidebar
 2. Find the pending request
-3. Review the details (who, what connection, how long)
+3. Review the details (who, what resource role, how long)
 4. Click **Approve** or **Reject**
 
 ### Step 4: Access Granted
@@ -157,7 +157,7 @@ When the duration ends:
 
 ### Access Duration Limits
 
-Control how long users can request access for. Configure this in **Manage > Connections > [connection] > Settings**:
+Control how long users can request access for. Configure this in **Manage > Resources > [resource role] > Settings**:
 
 | Setting | Description |
 |---------|-------------|
@@ -290,7 +290,7 @@ This is expected behavior. Admin users auto-approve their own requests.
 
 **Check:**
 1. The Slack app is installed correctly ([setup guide](/integrations/slack))
-2. The connection has the `slack` plugin enabled
+2. The resource role has the `slack` plugin enabled
 3. The approver has subscribed with `/hoop subscribe`
 4. The notification channel is configured in Slack plugin settings
 
@@ -328,6 +328,6 @@ This is expected behavior. Admin users auto-approve their own requests.
     Audit what happened during approved sessions
   </Card>
   <Card title="Access Control" icon="lock" href="/learn/features/access-control">
-    Configure who can access which connections
+    Configure who can access which resource roles
   </Card>
 </CardGroup>

--- a/learn/features/ai-query-builder.mdx
+++ b/learn/features/ai-query-builder.mdx
@@ -165,7 +165,7 @@ The AI will identify relevant tables based on your schema.
 
 ## Supported Databases
 
-AI Query Builder works with any database connection in Hoop:
+AI Query Builder works with any database resource role in Hoop:
 
 - PostgreSQL
 - MySQL

--- a/learn/features/guardrails.mdx
+++ b/learn/features/guardrails.mdx
@@ -70,7 +70,7 @@ import Prerequisites from '/snippets/LearnPrerequisites.mdx';
 
 <Prerequisites />
 
-- At least one database connection configured
+- At least one database resource role configured
 - Admin access to create guardrails
 
 ### Step 1: Create a Guardrail
@@ -104,10 +104,10 @@ In the **Input Rules** section:
 The `(?i)` makes the pattern case-insensitive, so it catches `update`, `UPDATE`, and `Update`.
 </Note>
 
-### Step 3: Assign to Connections
+### Step 3: Assign to Resource Roles
 
-1. In the **Connections** section, select which connections this guardrail applies to
-2. Choose your production database connections
+1. In the **Resources** section, select which resource roles this guardrail applies to
+2. Choose your production database resource roles
 3. Click **Save**
 
 ### Step 4: Test the Guardrail
@@ -166,7 +166,7 @@ Block all write operations for analyst or read-only user groups.
 | `(?i)^\s*(CREATE\|DROP\|ALTER)\s+` | DDL commands |
 
 <Tip>
-Apply this guardrail only to connections used by read-only groups, not to admin connections.
+Apply this guardrail only to resource roles used by read-only groups, not to admin resource roles.
 </Tip>
 
 ### Recipe 3: Block SELECT * on Large Tables
@@ -219,17 +219,17 @@ Restrict access to sensitive tables like `salaries` or `api_keys`.
 ## Testing Guardrails Safely
 
 <Warning>
-Always test guardrails before applying them to production connections.
+Always test guardrails before applying them to production resource roles.
 </Warning>
 
 ### Testing Process
 
 <Steps>
-  <Step title="Create a Test Connection">
-    Create a separate connection to the same database (e.g., `prod-db-test`)
+  <Step title="Create a Test Resource Role">
+    Create a separate resource role to the same database (e.g., `prod-db-test`)
   </Step>
   <Step title="Apply the Guardrail">
-    Assign the guardrail only to the test connection
+    Assign the guardrail only to the test resource role
   </Step>
   <Step title="Run Test Queries">
     Test both queries that should be blocked and queries that should pass
@@ -238,7 +238,7 @@ Always test guardrails before applying them to production connections.
     Confirm the guardrail blocks what it should and allows what it should
   </Step>
   <Step title="Apply to Production">
-    Once verified, add production connections to the guardrail
+    Once verified, add production resource roles to the guardrail
   </Step>
 </Steps>
 
@@ -303,9 +303,9 @@ If the guardrail is catching legitimate queries, update the pattern:
 
 For specific users or groups that need to bypass certain rules:
 
-1. Create a new connection without the guardrail
-2. Restrict access to that connection to specific groups
-3. Use this "elevated" connection for exceptional cases
+1. Create a new resource role without the guardrail
+2. Restrict access to that resource role to specific groups
+3. Use this "elevated" resource role for exceptional cases
 
 ---
 
@@ -316,7 +316,7 @@ For specific users or groups that need to bypass certain rules:
 **Check:**
 
 1. **Guardrail is enabled** - Verify the toggle is on in Manage > Guardrails
-2. **Connection is assigned** - Check that the connection is in the guardrail's connection list
+2. **Resource role is assigned** - Check that the resource role is in the guardrail's resource role list
 3. **Pattern syntax is valid** - Test your regex at [regex101.com](https://regex101.com)
 4. **Case sensitivity** - Add `(?i)` at the start for case-insensitive matching
 
@@ -358,13 +358,13 @@ Guardrails add minimal latency (typically 1-5ms per query). If you notice slowdo
 | **Guardrails** | Block queries based on patterns | Prevent dangerous operations |
 | **Live Data Masking** | Redact sensitive data in output | Protect PII in query results |
 | **Access Requests** | Require approval for access | Time-limited or command-level approval |
-| **Access Control** | Control who can access connections | Restrict connection visibility |
+| **Access Control** | Control who can access resource roles | Restrict resource role visibility |
 
 These features work together. For example:
 - Guardrails block `DROP TABLE` commands
 - Live Data Masking redacts SSN in `SELECT` results
 - Access Requests require approval before connecting
-- Access Control limits who sees the connection
+- Access Control limits who sees the resource role
 
 ---
 
@@ -378,7 +378,7 @@ These features work together. For example:
     Automatically redact sensitive data in query results
   </Card>
   <Card title="Access Requests" icon="clock" href="/learn/features/access-requests/jit">
-    Require approval for access to sensitive connections
+    Require approval for access to sensitive resource roles
   </Card>
   <Card title="Session Recording" icon="video" href="/learn/features/session-recording">
     Audit all query executions including blocked queries

--- a/learn/features/live-data-masking.mdx
+++ b/learn/features/live-data-masking.mdx
@@ -100,10 +100,10 @@ DLP_MODE=best-effort
 GCP_PROJECT_ID=your-project-id
 ```
 
-### Step 3: Enable on a Connection
+### Step 3: Enable on a Resource Role
 
-1. Go to **Connections** in the Web App
-2. Select a connection and click **Configure**
+1. Go to **Resources** in the Web App
+2. Select a resource role and click **Configure**
 3. Enable **Live Data Masking**
 4. Click **Save**
 
@@ -175,9 +175,9 @@ Live Data Masking detects these sensitive data types by default:
 
 Add or remove fields from detection. See [Supported Fields](/setup/configuration/live-data-masking/fields) for the complete list.
 
-### Per-Connection Settings
+### Per-Resource-Role Settings
 
-Enable or disable masking on individual connections:
+Enable or disable masking on individual resource roles:
 - Enable on production databases with real customer data
 - Disable on development databases with synthetic data
 
@@ -189,7 +189,7 @@ Enable or disable masking on individual connections:
 
 Developers need to debug production issues but shouldn't see customer PII:
 
-- Enable Live Data Masking on production connections
+- Enable Live Data Masking on production resource roles
 - Developers can run diagnostic queries
 - Customer data is automatically protected
 
@@ -205,7 +205,7 @@ Data analysts need aggregate insights but not individual records:
 
 Support teams need to look up customer records:
 
-- Enable masking on support-facing connections
+- Enable masking on support-facing resource roles
 - They can verify account status without seeing SSNs
 - Audit trail shows who accessed what
 
@@ -213,7 +213,7 @@ Support teams need to look up customer records:
 
 External contractors need database access:
 
-- Create a connection with masking enabled
+- Create a resource role with masking enabled
 - Grant access to contractors
 - Sensitive data is never exposed
 
@@ -224,7 +224,7 @@ External contractors need database access:
 ### Data Not Being Masked
 
 **Check:**
-1. Live Data Masking is enabled on the connection
+1. Live Data Masking is enabled on the resource role
 2. DLP provider is running and accessible
 3. Gateway environment variables are set correctly
 4. The data type is in the [supported fields list](/setup/configuration/live-data-masking/fields)
@@ -290,6 +290,6 @@ Live Data Masking is one layer of a defense-in-depth strategy. Combine with [Acc
     Block queries before they execute
   </Card>
   <Card title="Access Control" icon="lock" href="/learn/features/access-control">
-    Control who can access connections
+    Control who can access resource roles
   </Card>
 </CardGroup>

--- a/learn/features/mcp-server.mdx
+++ b/learn/features/mcp-server.mdx
@@ -7,10 +7,10 @@ description: "Connect AI agents to Hoop with the built-in Model Context Protocol
 
 Hoop ships a built-in [Model Context Protocol](https://modelcontextprotocol.io) server that exposes the gateway as a set of tools an AI agent can call. Point Claude Code, Cursor, Devin, or any MCP-compatible client at it and the agent inherits the same controls a human user gets:
 
-- Run queries and commands against connections without ever handling credentials
+- Run queries and commands against resource roles without ever handling credentials
 - Trigger and wait for human approvals before sensitive actions execute
 - Inspect schemas, sessions, and AI risk analysis from inside the agent's loop
-- Manage connections, guardrails, data masking, and review rules — gated by admin roles
+- Manage resource roles, guardrails, data masking, and review rules — gated by admin roles
 
 Every tool call goes through the same authorization, data masking, guardrails, and review gates as the rest of Hoop. The MCP server does not bypass any of them.
 
@@ -142,7 +142,7 @@ import Prerequisites from '/snippets/LearnPrerequisites.mdx';
 <Prerequisites />
 
 - An MCP-compatible client (Claude Code, Cursor, Devin, or any client that supports streamable HTTP transport with OAuth)
-- A user account in Hoop with access to at least one connection
+- A user account in Hoop with access to at least one resource role
 
 ### Step 1: Add the MCP server to your client
 
@@ -189,7 +189,7 @@ Have the agent call `connections_list` (and optionally `serverinfo_get` for gate
 
 ### Step 4: Run a query
 
-Use `exec` to run a command against a connection. The response is one of three envelopes the agent should handle explicitly:
+Use `exec` to run a command against a resource role. The response is one of three envelopes the agent should handle explicitly:
 
 | `status` | Meaning | What the agent does next |
 |---|---|---|
@@ -202,7 +202,7 @@ Use `exec` to run a command against a connection. The response is one of three e
 
 ## The Approval Flow
 
-When a connection requires review, `exec` returns `status=pending_approval` with a `review_id` and `review_url`. The agent should:
+When a resource role requires review, `exec` returns `status=pending_approval` with a `review_id` and `review_url`. The agent should:
 
 <Steps>
   <Step title="Notify the user">
@@ -307,7 +307,7 @@ The MCP server enforces the same controls as every other Hoop interface:
     Input and output guardrails block or modify content before the agent receives it. Same rules as the CLI.
   </Card>
   <Card title="Reviews" icon="user-check">
-    Connections with review rules cannot be executed without human approval. The agent gets `pending_approval` and must wait.
+    Resource roles with review rules cannot be executed without human approval. The agent gets `pending_approval` and must wait.
   </Card>
   <Card title="Audit" icon="file-lines">
     Every `exec` creates a session row, records the input, and runs AI analysis. Sessions are queryable via `sessions_*` tools and exportable via webhooks/SIEM.
@@ -332,7 +332,7 @@ The MCP server enforces the same controls as every other Hoop interface:
     `connection_databases` → `connection_tables` → `connection_columns` lets the agent ground queries in real schemas instead of guessing.
   </Card>
   <Card title="Pair with review rules" icon="user-check">
-    Configure review rules on sensitive connections so agent-initiated actions are gated by human approval.
+    Configure review rules on sensitive resource roles so agent-initiated actions are gated by human approval.
   </Card>
 </CardGroup>
 

--- a/learn/features/runbooks.mdx
+++ b/learn/features/runbooks.mdx
@@ -304,7 +304,7 @@ Files must end with `.runbook.<extension>`:
 | **Guardrails** | Rules apply to runbook-generated queries |
 | **Live Data Masking** | Results are masked automatically |
 | **Session Recording** | All executions are recorded |
-| **Parallel Mode** | Run runbooks across multiple connections |
+| **Parallel Mode** | Run runbooks across multiple resource roles |
 
 ---
 
@@ -365,7 +365,7 @@ If a parameter fails validation:
     Detailed Git setup and template syntax
   </Card>
   <Card title="Parallel Mode" icon="layer-group" href="/learn/features/parallel-mode">
-    Run runbooks across multiple connections
+    Run runbooks across multiple resource roles
   </Card>
   <Card title="Access Requests" icon="clock" href="/learn/features/access-requests/jit">
     Require approval for runbook execution

--- a/learn/features/secrets-manager.mdx
+++ b/learn/features/secrets-manager.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Secrets Management"
-description: "Securely inject credentials into connections without exposing them to users"
+description: "Securely inject credentials into resource roles without exposing them to users"
 ---
 
 import { DataFlowAnimation } from '/snippets/annimations/DataFlowAnimation.jsx';
@@ -15,7 +15,7 @@ Secrets Management lets you connect to databases and servers without exposing cr
 
 - Store credentials in HashiCorp Vault, AWS Secrets Manager, or other providers
 - Inject secrets at runtime—users never see the actual values
-- Rotate credentials without updating connection configs
+- Rotate credentials without updating resource role configs
 - Audit who accessed what, without credential exposure
 
 ---
@@ -26,8 +26,8 @@ Secrets Management lets you connect to databases and servers without exposing cr
   <Step title="Store Secrets">
     Save credentials in your secrets provider (Vault, AWS, etc.)
   </Step>
-  <Step title="Reference in Connection">
-    Configure connections using secret references like `_envs/vault/DB_PASSWORD`
+  <Step title="Reference in Resource Role">
+    Configure resource roles using secret references like `_envs/vault/DB_PASSWORD`
   </Step>
   <Step title="Runtime Resolution">
     When a user connects, Hoop fetches the secret and injects it
@@ -97,9 +97,9 @@ VAULT_ADDR=https://vault.example.com:8200
 VAULT_TOKEN=hvs.your-vault-token
 ```
 
-#### Step 3: Create Connection with Secret Reference
+#### Step 3: Create Resource Role with Secret Reference
 
-In the Web App or via CLI, create a connection that references the secret:
+In the Web App or via CLI, create a resource role that references the secret:
 
 ```bash
 hoop admin create connection prod-postgres \
@@ -112,13 +112,13 @@ Or configure in the Web App:
 - **Username:** `_envs/vault/secret/databases/prod-postgres#username`
 - **Password:** `_envs/vault/secret/databases/prod-postgres#password`
 
-#### Step 4: Test the Connection
+#### Step 4: Test the Resource Role
 
 ```bash
 hoop connect prod-postgres
 ```
 
-The connection works, with credentials fetched from Vault at runtime.
+The resource role works, with credentials fetched from Vault at runtime.
 
 ---
 
@@ -226,7 +226,7 @@ _envs/gcp/<secret-name>
 
 ### 1. Database Credentials
 
-Store database passwords in Vault instead of connection configs:
+Store database passwords in Vault instead of resource role configs:
 
 ```yaml
 # Instead of this (insecure):
@@ -238,7 +238,7 @@ password: _envs/vault/secret/databases/prod#password
 
 ### 2. API Keys
 
-Inject API keys for application connections:
+Inject API keys for application resource roles:
 
 ```bash
 # Command that needs an API key
@@ -271,10 +271,10 @@ One of the biggest benefits of secrets management is seamless credential rotatio
   <Step title="Update Secret in Provider">
     Change the password in Vault/AWS/etc.
   </Step>
-  <Step title="No Connection Changes Needed">
-    Connection configs reference the secret, not the value
+  <Step title="No Resource Role Changes Needed">
+    Resource role configs reference the secret, not the value
   </Step>
-  <Step title="New Connections Use New Credential">
+  <Step title="New Resource Roles Use New Credential">
     Next time someone connects, they get the new password
   </Step>
 </Steps>
@@ -282,7 +282,7 @@ One of the biggest benefits of secrets management is seamless credential rotatio
 ### Rotation Best Practices
 
 1. **Schedule regular rotations** - Monthly or quarterly
-2. **Test after rotation** - Verify connections still work
+2. **Test after rotation** - Verify resource roles still work
 3. **Keep previous version** - Some providers support versioning
 4. **Audit access** - Check who accessed secrets recently
 
@@ -290,7 +290,7 @@ One of the biggest benefits of secrets management is seamless credential rotatio
 
 ## Troubleshooting
 
-### Connection Fails with "Secret Not Found"
+### Resource Role Fails with "Secret Not Found"
 
 **Check:**
 1. Secret path is correct (including mount point for Vault)
@@ -343,7 +343,7 @@ If you see the literal `_envs/...` string instead of the secret value:
 
 ### What NOT to Do
 
-- Don't store secrets in connection configs directly
+- Don't store secrets in resource role configs directly
 - Don't share provider tokens with users
 - Don't use the same credentials across environments
 - Don't skip rotation because "it's working"
@@ -357,10 +357,10 @@ If you see the literal `_envs/...` string instead of the secret value:
     Detailed provider setup instructions
   </Card>
   <Card title="Access Control" icon="lock" href="/learn/features/access-control">
-    Control who can access connections
+    Control who can access resource roles
   </Card>
   <Card title="Session Recording" icon="video" href="/learn/features/session-recording">
-    Audit all connection activity
+    Audit all resource role activity
   </Card>
   <Card title="HashiCorp Vault" icon="vault" href="https://www.vaultproject.io/docs">
     Vault documentation

--- a/learn/features/session-recording.mdx
+++ b/learn/features/session-recording.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Session Recording"
-description: "Record and playback terminal sessions and entire databases connections."
+description: "Record and playback terminal sessions and entire database resource roles."
 ---
 
 import { RiskMetricsAnimation } from '/snippets/annimations/RiskMetricsAnimation.jsx';
@@ -23,7 +23,7 @@ You can audit tracks every action made with Hoop.dev. It provides video recordin
 
 ## Key Features
 
-**Complete Session Capture:** Includes precise timestamps, user identity with organizational context, and connection metadata for every session.
+**Complete Session Capture:** Includes precise timestamps, user identity with organizational context, and resource role metadata for every session.
 
 **Full Input/Output Recording:** Records every command entered and response returned, with optional high-definition video playback and structured log export.
 
@@ -37,7 +37,7 @@ You can audit tracks every action made with Hoop.dev. It provides video recordin
 
 **User**: complete user information inside your organization
 
-**Connection**: the connection used in the session
+**Resource Role**: the resource role used in the session
 
 **Input and Output**: every command and its output an user has executed
 
@@ -69,7 +69,7 @@ For detailed configuration instructions and setup guides, see [Session Recording
 ## Getting Started
 
 1. **Connect Resources:** Add your databases, Kubernetes clusters, or infrastructure endpoints to [hoop.dev](http://hoop.dev) using the appropriate connection strings and credentials.
-2. **Enable Session Recording:** Turn on session recording globally or per-connection. Use granular policies to define what gets recorded and for how long.
+2. **Enable Session Recording:** Turn on session recording globally or per-resource-role. Use granular policies to define what gets recorded and for how long.
 3. **Invite Team Members:** Add users and assign access permissions. All activity is automatically tracked and tied to each individual.
 4. **Use Existing Workflows:** Developers can continue using their preferred CLI or web interface. [hoop.dev](http://hoop.dev) captures sessions in the background—no workflow changes needed.
 

--- a/learn/features/workflow-observability.mdx
+++ b/learn/features/workflow-observability.mdx
@@ -14,8 +14,8 @@ import { WorkflowObservabilityAnimation } from '/snippets/annimations/WorkflowOb
 Workflow Observability lets you see exactly what any headless caller (AI agent, script, CI/CD job, or scheduled batch) did in Hoop, with the same identity, audit, and policy story as an interactive user. You can:
 
 - Authenticate automation with **named identities** instead of shared admin credentials
-- **Scope** each caller's permissions to only the connections and groups it needs
-- **Group** the sessions of the same logical run into one workflow, even across multiple commands or connections
+- **Scope** each caller's permissions to only the resource roles and groups it needs
+- **Group** the sessions of the same logical run into one workflow, even across multiple commands or resource roles
 - Keep a complete **audit trail** of who ran what, when, and as part of which task
 
 ---
@@ -81,7 +81,7 @@ Tag each call with a shared correlation value so the sessions of the same run li
   </Tab>
 </Tabs>
 
-Sessions carrying the same value are stored against one workflow run, so you can trace the full path: which commands ran, against which connections, in what order, with what outcome.
+Sessions carrying the same value are stored against one workflow run, so you can trace the full path: which commands ran, against which resource roles, in what order, with what outcome.
 
 <Note>
   The correlation ID is a free-form printable ASCII string up to 255 characters. Use whatever identifier the caller already has: a CI build number, cron run ID, ticket/task ID, agent workflow ID, or a UUID generated at the start of the run.
@@ -99,7 +99,7 @@ Sessions carrying the same value are stored against one workflow run, so you can
     A deploy pipeline uses a scoped API Key to run migrations, seed data, and health checks. Tagging every step with the build ID answers "what did build #842 actually do in prod?" from the audit log.
   </Card>
   <Card title="Scheduled jobs" icon="clock">
-    A nightly export uses an API Key scoped to a single read-only connection. Tagging each run with its cron run ID lets you trace and replay a failed export without guessing which sessions belong to it.
+    A nightly export uses an API Key scoped to a single read-only resource role. Tagging each run with its cron run ID lets you trace and replay a failed export without guessing which sessions belong to it.
   </Card>
   <Card title="AI agents" icon="robot">
     An agent picks up tasks from a queue and issues many tool calls per task. With a named API Key and task-ID tagging, operators can open any task and see exactly what the agent did, under the same masking and guardrails as any other caller.
@@ -124,7 +124,7 @@ import Prerequisites from '/snippets/LearnPrerequisites.mdx';
     Go to **Settings → API Keys** in the Web App and click **Create new API key**.
   </Step>
   <Step title="Name and scope the key">
-    Name the key after the caller (e.g. `nightly-report`, `deploy-pipeline`, `ticket-agent`). Assign groups that grant only the connections this workflow needs; avoid `admin` unless genuinely required.
+    Name the key after the caller (e.g. `nightly-report`, `deploy-pipeline`, `ticket-agent`). Assign groups that grant only the resource roles this workflow needs; avoid `admin` unless genuinely required.
   </Step>
   <Step title="Store the key">
     Copy the `hpk_…` value at creation (it is shown only once) and load it into your workflow's secret store (CI secret, Vault, Kubernetes Secret, etc.).

--- a/setup/apis/api-key.mdx
+++ b/setup/apis/api-key.mdx
@@ -31,7 +31,7 @@ API Keys are managed from **Settings → API Keys** in the Web App. This section
         Give the key a descriptive, org-unique name (for example `ai-agent-sre` or `payments-automation`). The name identifies the key in the list and in audit logs.
     </Step>
     <Step title="Assign groups">
-        Select one or more groups. The key's permissions are the union of those groups. Use `admin` for admin-level access; otherwise assign the groups that own the connections the key should reach.
+        Select one or more groups. The key's permissions are the union of those groups. Use `admin` for admin-level access; otherwise assign the groups that own the resource roles the key should reach.
     </Step>
     <Step title="Save and copy the key">
         Click **Save**. The Gateway displays the full `hpk_…` value once. Copy it immediately into a secrets manager; once you navigate away, it is no longer retrievable.
@@ -106,9 +106,9 @@ Any REST endpoint that accepts a user access token also accepts an `hpk_` key, s
 An API key has exactly the permissions of its assigned groups:
 
 - A key in `admin` can perform any administrative action.
-- A key in a scoped group (for example `engineering`) can only reach that group's connections and resources.
+- A key in a scoped group (for example `engineering`) can only reach that group's resource roles and resources.
 
-Keep the blast radius small. If automation only needs one query against one connection, scope the key to a group limited to that connection rather than using `admin`.
+Keep the blast radius small. If automation only needs one query against one resource role, scope the key to a group limited to that resource role rather than using `admin`.
 
 ## Security Considerations
 

--- a/setup/apis/webhooks-siem.mdx
+++ b/setup/apis/webhooks-siem.mdx
@@ -17,7 +17,7 @@ Place hook scripts in a `hoop-hooks/` directory in your runbooks repository. Hoo
 
 | File | Event | Description |
 |---|---|---|
-| `hoop-hooks/session-open.runbook.py` | Session open | Fires when a session starts. May fire more than once if the connection has reviews enabled. |
+| `hoop-hooks/session-open.runbook.py` | Session open | Fires when a session starts. May fire more than once if the resource role has reviews enabled. |
 | `hoop-hooks/session-close.runbook.py` | Session close | Fires when a session ends. |
 
 ### Enabling Hooks
@@ -111,7 +111,7 @@ hoop login
 hoop admin create plugin webhooks
 ```
 
-Then enable it for a specific connection:
+Then enable it for a specific resource role:
 
 ```bash
 hoop admin create plugin webhooks --overwrite --connection bash-default
@@ -129,7 +129,7 @@ hoop admin webhooks-dashboard
   The dashboard is only available with Svix SaaS and can only be opened by administrators.
 </Info>
 
-To view activity, interact with any connection. The **Message Logs** link shows all connection events.
+To view activity, interact with any resource role. The **Message Logs** link shows all resource role events.
 
 <Frame>
   <img src="/images/learn/webhooks-1.png" />

--- a/setup/architecture.mdx
+++ b/setup/architecture.mdx
@@ -19,12 +19,12 @@ The gateway is the central hub of the system. It handles all user-facing traffic
 
 The gateway runs as a single binary and exposes:
 
-- **Web UI** — browser-based interface for managing connections, running queries, reviewing sessions, and approving access requests
+- **Web UI** — browser-based interface for managing resource roles, running queries, reviewing sessions, and approving access requests
 - **REST API** — the same API the web UI uses; available for programmatic access and automation
 - **gRPC server** — the internal transport layer used by agents and native clients to stream data
 - **Protocol proxies** — native protocol listeners (PostgreSQL, SSH, RDP, HTTP) that allow standard tools to connect without any Hoop-specific client
 
-The gateway requires a **PostgreSQL database** for storing connections, sessions, users, and audit data.
+The gateway requires a **PostgreSQL database** for storing resource roles, sessions, users, and audit data.
 
 ### Agent
 
@@ -35,7 +35,7 @@ Agents run in two modes:
 - **Standard mode** — a persistent long-lived process, managed as a system service. Best for databases, internal APIs, container platforms, and jump hosts.
 - **Embedded mode** — runs alongside an application process, sharing its runtime context. Best for ad-hoc tasks, REPL consoles, and single-resource connections.
 
-A single agent can serve multiple connections. See the [Agents](/concepts/agents) page for deployment details.
+A single agent can serve multiple resource roles. See the [Agents](/concepts/agents) page for deployment details.
 
 ### Clients
 
@@ -68,7 +68,7 @@ When a user connects to a resource, the following happens:
 
 1. **Authentication** — the user authenticates via your identity provider (OIDC, SAML, or local auth). The gateway verifies the token and loads the user's identity and group membership.
 
-2. **Authorization** — the gateway checks whether the user has access to the requested connection, based on access control rules and the connection's configured access mode
+2. **Authorization** — the gateway checks whether the user has access to the requested resource role, based on access control rules and the resource role's configured access mode
 
 3. **Policy evaluation** — before the session begins, the gateway runs the request through an ordered plugin chain:
    - **Reviews** — if JIT approval is required, the session is held until approved
@@ -77,7 +77,7 @@ When a user connects to a resource, the following happens:
    - **RBAC** — role-based rules are enforced
    - **Webhooks / Runbook hooks** — external systems are notified
 
-4. **Agent dispatch** — the gateway forwards the session to the agent responsible for that connection. If the agent is offline, the connection fails.
+4. **Agent dispatch** — the gateway forwards the session to the agent responsible for that resource role. If the agent is offline, the connection fails.
 
 5. **Execution** — the agent executes the operation against the target resource using native protocols (SQL, SSH, RDP, HTTP, etc.) and streams results back through the gateway.
 

--- a/setup/configuration/access-control-configuration.mdx
+++ b/setup/configuration/access-control-configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Access Control Configuration"
-description: "Configure group-based access policies for your connections"
+description: "Configure group-based access policies for your resource roles"
 ---
 
 import { LayeredAccess } from '/snippets/annimations/layeredaccess.jsx';
@@ -9,7 +9,7 @@ import { LayeredAccess } from '/snippets/annimations/layeredaccess.jsx';
   <LayeredAccess />
 </div>
 
-Access Control lets you restrict which users can see and access specific connections based on their group memberships. This page covers detailed configuration options.
+Access Control lets you restrict which users can see and access specific resource roles based on their group memberships. This page covers detailed configuration options.
 
 <Note>
 For an introduction to Access Control concepts, see [Access Control Overview](/learn/features/access-control).
@@ -20,7 +20,7 @@ For an introduction to Access Control concepts, see [Access Control Overview](/l
 ## Enabling Access Control
 
 <Warning>
-Enabling Access Control will immediately hide connections from users who don't have explicit access. Plan your group assignments before enabling.
+Enabling Access Control will immediately hide resource roles from users who don't have explicit access. Plan your group assignments before enabling.
 </Warning>
 
 ### Step 1: Activate Access Control
@@ -36,7 +36,7 @@ Enabling Access Control will immediately hide connections from users who don't h
   <Step title="Review the Warning">
     Read the activation warning carefully. Understand that:
     - Users without group assignments will lose access
-    - You'll need to configure each connection individually
+    - You'll need to configure each resource role individually
     - Changes take effect immediately
 
     <Frame>
@@ -48,23 +48,23 @@ Enabling Access Control will immediately hide connections from users who don't h
   </Step>
 </Steps>
 
-### Step 2: Configure Connections
+### Step 2: Configure Resource Roles
 
-After activation, configure access for each connection:
+After activation, configure access for each resource role:
 
 <Steps>
-  <Step title="Select a Connection">
-    Find the connection in the list and click to configure
+  <Step title="Select a Resource Role">
+    Find the resource role in the list and click to configure
 
     <Frame>
-      <img src="/images/learn/features/access-control-activated.png" alt="Connection list" />
+      <img src="/images/learn/features/access-control-activated.png" alt="Resource role list" />
     </Frame>
   </Step>
   <Step title="Enable Access Control">
-    Toggle the Access Control switch for this connection
+    Toggle the Access Control switch for this resource role
   </Step>
   <Step title="Add Allowed Groups">
-    Select which groups can access this connection
+    Select which groups can access this resource role
 
     <Frame>
       <img src="/images/learn/features/access-control-add-groups.png" alt="Add groups" />
@@ -103,11 +103,11 @@ Groups can be automatically synced when users log in:
 
 | Group | Description | Permissions |
 |-------|-------------|-------------|
-| `admin` | Administrators | Full access to all connections and settings |
+| `admin` | Administrators | Full access to all resource roles and settings |
 | `auditor` | Audit access | Read-only access to sessions and logs |
 
 <Note>
-Admin users bypass Access Control and can access all connections regardless of group configuration.
+Admin users bypass Access Control and can access all resource roles regardless of group configuration.
 </Note>
 
 ### Group Naming Conventions
@@ -125,14 +125,14 @@ Recommended naming patterns:
 
 ## Permission Types
 
-### Connection Visibility
+### Resource Role Visibility
 
-When Access Control is enabled on a connection:
+When Access Control is enabled on a resource role:
 
-| User's Groups | Connection Visibility |
+| User's Groups | Resource Role Visibility |
 |---------------|----------------------|
-| In allowed groups | Connection is visible and accessible |
-| Not in allowed groups | Connection is hidden completely |
+| In allowed groups | Resource role is visible and accessible |
+| Not in allowed groups | Resource role is hidden completely |
 | Admin group | Always visible (bypasses Access Control) |
 
 ### Combining with Access Requests
@@ -144,7 +144,7 @@ Access Control and Access Requests work together:
 | Allowed | Not enabled | Direct access |
 | Allowed | JIT enabled | Must request time-based access |
 | Allowed | Action enabled | Each command needs approval |
-| Not allowed | Any | Connection not visible |
+| Not allowed | Any | Resource role not visible |
 
 ---
 
@@ -155,13 +155,13 @@ Access Control and Access Requests work together:
 Separate access by environment:
 
 ```
-Connection: prod-database
+Resource Role: prod-database
   Allowed Groups: senior-engineers, dba
 
-Connection: staging-database
+Resource Role: staging-database
   Allowed Groups: engineering, qa
 
-Connection: dev-database
+Resource Role: dev-database
   Allowed Groups: engineering, contractors
 ```
 
@@ -170,26 +170,26 @@ Connection: dev-database
 Each team accesses their own resources:
 
 ```
-Connection: payments-db
+Resource Role: payments-db
   Allowed Groups: payments-team
 
-Connection: inventory-db
+Resource Role: inventory-db
   Allowed Groups: inventory-team
 
-Connection: analytics-warehouse
+Resource Role: analytics-warehouse
   Allowed Groups: analytics-team, data-science
 ```
 
 ### Pattern 3: Read/Write Separation
 
-Create separate connections with different access levels:
+Create separate resource roles with different access levels:
 
 ```
-Connection: prod-db-readonly
+Resource Role: prod-db-readonly
   Allowed Groups: engineering, analytics, support
   (Configured with read-only database user)
 
-Connection: prod-db-readwrite
+Resource Role: prod-db-readwrite
   Allowed Groups: dba, senior-engineers
   (Configured with read-write database user)
 ```
@@ -199,7 +199,7 @@ Connection: prod-db-readwrite
 Limited access for external contractors:
 
 ```
-Connection: contractor-db
+Resource Role: contractor-db
   Allowed Groups: contractors
   (Limited database, Live Data Masking enabled)
 ```
@@ -259,14 +259,14 @@ To see what a user can access:
 1. Go to **Manage > Users**
 2. Click on a user
 3. View their group memberships
-4. Cross-reference with connection configurations
+4. Cross-reference with resource role configurations
 
 ### Access Logs
 
 All access attempts are logged:
 
 1. Go to **Sessions**
-2. Filter by user or connection
+2. Filter by user or resource role
 3. See successful connections and denied attempts
 
 ### Exporting Access Report
@@ -282,18 +282,18 @@ hoop admin get connections -o json | \
 
 ## Troubleshooting
 
-### User Can't See a Connection
+### User Can't See a Resource Role
 
 **Checklist:**
 
-1. **Is Access Control enabled on the connection?**
-   - Go to connection settings
+1. **Is Access Control enabled on the resource role?**
+   - Go to resource role settings
    - Check if Access Control toggle is on
 
 2. **Is the user in an allowed group?**
    - Go to **Manage > Users**
    - Check user's group memberships
-   - Verify groups match connection's allowed groups
+   - Verify groups match resource role's allowed groups
 
 3. **Has the user logged out and back in?**
    - Groups sync on login
@@ -312,13 +312,13 @@ hoop admin get user <email>
 hoop admin get connection <name>
 ```
 
-### User Sees Connection But Can't Connect
+### User Sees Resource Role But Can't Connect
 
 This is likely NOT an Access Control issue. Check:
 
 1. **Access Requests:** Is JIT or Action approval required?
 2. **Guardrails:** Are there blocking rules?
-3. **Connection status:** Is the agent online?
+3. **Resource role status:** Is the agent online?
 
 ### Groups Not Syncing from IdP
 
@@ -354,12 +354,12 @@ This is likely NOT an Access Control issue. Check:
 
 ### Before Enabling Access Control
 
-1. [ ] Inventory all connections
+1. [ ] Inventory all resource roles
 2. [ ] Identify who needs access to each
 3. [ ] Create groups in IdP or Hoop
 4. [ ] Assign users to groups
 5. [ ] Document the access policy
-6. [ ] Test with a non-production connection first
+6. [ ] Test with a non-production resource role first
 
 ### Quarterly Access Review
 

--- a/setup/configuration/access-requests/action-configuration.mdx
+++ b/setup/configuration/access-requests/action-configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Action Access Requests Configuration"
-description: "Configure command-level approval workflows for your connections"
+description: "Configure command-level approval workflows for your resource roles"
 ---
 
 Action Access Requests require approval for each command before it executes. This page covers detailed configuration options.
@@ -16,8 +16,8 @@ For an introduction to Action Access Requests, see [Action Access Requests Overv
 ### Via Web App
 
 <Steps>
-  <Step title="Navigate to Connection">
-    Go to **Connections** and select the connection you want to configure
+  <Step title="Navigate to Resource Role">
+    Go to **Resources** and select the resource role you want to configure
   </Step>
   <Step title="Open Configuration">
     Click the **Additional Configuration** tab
@@ -38,7 +38,7 @@ For an introduction to Action Access Requests, see [Action Access Requests Overv
 
 ### Via CLI
 
-Enable Action Access Requests when creating a connection:
+Enable Action Access Requests when creating a resource role:
 
 ```bash
 hoop admin create connection prod-db \
@@ -49,7 +49,7 @@ hoop admin create connection prod-db \
 
 The `--reviewers` flag specifies which groups can approve commands.
 
-**Add reviewers to an existing connection:**
+**Add reviewers to an existing resource role:**
 
 ```bash
 hoop admin create connection prod-db \
@@ -126,7 +126,7 @@ When a request times out:
 To receive and approve requests in Slack:
 
 1. [Configure the Slack integration](/integrations/slack)
-2. Enable the `slack` plugin on your connection:
+2. Enable the `slack` plugin on your resource role:
 
 ```bash
 hoop admin create connection prod-db \
@@ -280,7 +280,7 @@ Every access request is logged with:
 
 **Check Slack:**
 1. Slack app is installed correctly
-2. Connection has `slack` plugin enabled
+2. Resource role has `slack` plugin enabled
 3. Approver has run `/hoop subscribe`
 4. Notification channel is configured
 
@@ -295,7 +295,7 @@ Admin users auto-approve their own requests. This is expected behavior.
 
 **To test the full workflow:**
 - Use a non-admin test account
-- Or create a connection where the admin is NOT in the approvers group
+- Or create a resource role where the admin is NOT in the approvers group
 
 ### Request Times Out Too Quickly
 
@@ -312,7 +312,7 @@ Restart the gateway after changing.
 
 **Check:**
 1. Request hasn't already expired
-2. You're looking at the correct connection
+2. You're looking at the correct resource role
 3. Filter is set to show **Pending** status
 
 ---

--- a/setup/configuration/access-requests/jit-configuration.mdx
+++ b/setup/configuration/access-requests/jit-configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: "JIT Access Requests Configuration"
-description: "Configure time-based access controls for your connections"
+description: "Configure time-based access controls for your resource roles"
 ---
 
 This page covers the configuration options for Just-in-Time Access Requests. For an introduction to how JIT Access Requests work, see [JIT Access Requests](/learn/features/access-requests/jit).
@@ -13,8 +13,8 @@ This page covers the configuration options for Just-in-Time Access Requests. For
   <Step title="Navigate to Access Requests">
     Go to **Manage > Access Requests** in the Web App
   </Step>
-  <Step title="Activate the Connection">
-    Find your connection and toggle it to **Active**
+  <Step title="Activate the Resource Role">
+    Find your resource role and toggle it to **Active**
 
     <Frame>
       <img src="/images/learn/jit-reviews-1.png" alt="Enable JIT access requests" />
@@ -35,7 +35,7 @@ This page covers the configuration options for Just-in-Time Access Requests. For
 
 ### Via CLI
 
-You can also configure access requests when creating a connection:
+You can also configure access requests when creating a resource role:
 
 ```bash
 hoop admin create conn prod-postgres \
@@ -79,7 +79,7 @@ The CLI will wait for approval:
 
 ### Maximum Access Duration
 
-Limit how long users can request access. Configure in **Manage > Connections > [connection] > Settings**.
+Limit how long users can request access. Configure in **Manage > Resources > [resource role] > Settings**.
 
 ### Multiple Approval Groups
 
@@ -102,7 +102,7 @@ To test the full workflow, use a non-admin account.
 To receive and approve requests in Slack:
 
 1. [Configure the Slack integration](/integrations/slack)
-2. Enable the `slack` plugin on your connection:
+2. Enable the `slack` plugin on your resource role:
 
 ```bash
 hoop admin create conn prod-postgres \
@@ -140,6 +140,6 @@ These environment variables affect JIT Access Requests behavior on the gateway:
     Set up Slack for access request notifications
   </Card>
   <Card title="Access Control" icon="lock" href="/setup/configuration/access-control-configuration">
-    Configure who can access which connections
+    Configure who can access which resource roles
   </Card>
 </CardGroup>

--- a/setup/configuration/guardrails-configuration.mdx
+++ b/setup/configuration/guardrails-configuration.mdx
@@ -22,7 +22,7 @@ For an introduction to what Guardrails do and common use cases, see [Guardrails 
 Guardrails are evaluated by the **Microsoft Presidio Analyzer** — patterns and word lists are sent to Presidio as ad-hoc recognizers, and matching happens inside Presidio.
 
 <Warning>
-**Presidio is required.** There is no fallback engine. If a connection has a guardrail assigned and Presidio is not deployed or the gateway cannot reach it, queries on that connection will fail.
+**Presidio is required.** There is no fallback engine. If a resource role has a guardrail assigned and Presidio is not deployed or the gateway cannot reach it, queries on that resource role will fail.
 </Warning>
 
 Before configuring guardrails, deploy Presidio and point the gateway at it:
@@ -54,8 +54,8 @@ Before configuring guardrails, deploy Presidio and point the gateway at it:
   <Step title="Add Rules">
     Configure Input Rules and/or Output Rules (see below)
   </Step>
-  <Step title="Assign Connections">
-    Select which connections this guardrail applies to
+  <Step title="Assign Resource Roles">
+    Select which resource roles this guardrail applies to
   </Step>
   <Step title="Save">
     Click **Save** to activate the guardrail
@@ -196,21 +196,21 @@ Require Approval uses the same workflow as [Action Access Requests](/learn/featu
 
 ---
 
-## Connection Assignment
+## Resource Role Assignment
 
-Each guardrail can be assigned to multiple connections. You can also have multiple guardrails on a single connection.
+Each guardrail can be assigned to multiple resource roles. You can also have multiple guardrails on a single resource role.
 
 ### Assignment Options
 
 | Option | Description |
 |--------|-------------|
-| **Specific connections** | Select individual connections from the list |
-| **All connections** | Apply to every connection in your organization |
-| **Connection tags** | Apply to connections matching specific tags |
+| **Specific resource roles** | Select individual resource roles from the list |
+| **All resource roles** | Apply to every resource role in your organization |
+| **Resource role tags** | Apply to resource roles matching specific tags |
 
 ### Evaluation Order
 
-When multiple guardrails apply to a connection, they are evaluated in order of priority:
+When multiple guardrails apply to a resource role, they are evaluated in order of priority:
 
 1. **Priority 1** (highest) evaluated first
 2. First matching rule determines the action
@@ -271,7 +271,7 @@ Access audit logs in **Sessions** or export via the API.
     Use Warn mode first to understand impact before blocking
   </Card>
   <Card title="Test in Dev First" icon="flask">
-    Apply guardrails to test connections before production
+    Apply guardrails to test resource roles before production
   </Card>
   <Card title="Be Specific" icon="crosshairs">
     Use precise patterns to avoid false positives
@@ -314,7 +314,7 @@ Access audit logs in **Sessions** or export via the API.
 ### Performance Issues
 
 If queries are slow:
-1. Reduce the number of rules per connection
+1. Reduce the number of rules per resource role
 2. Simplify complex regex patterns
 3. Avoid patterns with excessive backtracking (e.g., `.*.*.*`)
 
@@ -333,6 +333,6 @@ If queries are slow:
     Configure the "Require Approval" action
   </Card>
   <Card title="Access Control" icon="lock" href="/setup/configuration/access-control-configuration">
-    Control who can access which connections
+    Control who can access which resource roles
   </Card>
 </CardGroup>

--- a/setup/configuration/idp/get-started.mdx
+++ b/setup/configuration/idp/get-started.mdx
@@ -60,7 +60,7 @@ If the SAML Assertion contains an attribute value with the name `groups` it will
 
 Groups define who can access or interact with specific resources:
 
-- For **connection** resources, groups control which users can access a specific connection. This is enforced when the **Access Control feature** is enabled.
+- For **resource roles**, groups control which users can access a specific resource role. This is enforced when the **Access Control feature** is enabled.
 - For **access requests**, groups define who can approve an execution. This is enforced when the **Access Requests feature** is enabled.
 
 <Tip>
@@ -72,7 +72,7 @@ Groups define who can access or interact with specific resources:
 
 - The **admin** group grants full access to all resources.
 
-Assign this role to users responsible for managing the Gateway. All other users are standard, meaning they can access their own resources and interact with connections.
+Assign this role to users responsible for managing the Gateway. All other users are standard, meaning they can access their own resources and interact with resource roles.
 
 - The **auditor** group grants read-only access to session resources.
 

--- a/setup/configuration/live-data-masking/get-started.mdx
+++ b/setup/configuration/live-data-masking/get-started.mdx
@@ -56,7 +56,7 @@ Google Cloud Data Loss Prevention (DLP) is still available for existing customer
     | `MSPRESIDIO_ANONYMIZER_URL` | `<host-to-anonymizer:port>` |
   </Step>
   <Step title="Run hoop.dev's Gateway with the new configs">
-    After setting up the environment variables, hoop.dev will use Microsoft Presidio to mask sensitive data in real-time in the data stream of any connection you configure.
+    After setting up the environment variables, hoop.dev will use Microsoft Presidio to mask sensitive data in real-time in the data stream of any resource role you configure.
   </Step>
 </Steps>
 
@@ -64,7 +64,7 @@ Google Cloud Data Loss Prevention (DLP) is still available for existing customer
 
 Create an account at [Google Cloud Data Loss Prevention](https://cloud.google.com/security/products/dlp) and a service account with the permission `roles/dlp.user`.
 
-When installing hoop.dev, you need to set the environment variable `GOOGLE_APPLICATION_CREDENTIALS_JSON` with your GCP DLP credentials in hoop's Gateway. Hoop.dev uses Google Cloud's DLP at our protocol layer to mask sensitive data in real-time in the data stream of any connection you configure.
+When installing hoop.dev, you need to set the environment variable `GOOGLE_APPLICATION_CREDENTIALS_JSON` with your GCP DLP credentials in hoop's Gateway. Hoop.dev uses Google Cloud's DLP at our protocol layer to mask sensitive data in real-time in the data stream of any resource role you configure.
 
 <Note>
   Google Cloud Data Loss Prevention (DLP) is still available for existing customers but is deprecated for new installations.
@@ -86,9 +86,9 @@ This mode will return an error in case it find any redaction issue
 
 - `DLP_MODE=strict`
 
-## Activate to your connections
+## Activate to your resource roles
 
-Navigate to your Web App instance \> Open the Manage toggle \> click at Live Data Masking \> Activate by connection and to configure which fields you want to set, hit the "Configure" button.
+Navigate to your Web App instance \> Open the Manage toggle \> click at Live Data Masking \> Activate by resource role and to configure which fields you want to set, hit the "Configure" button.
 
 <Frame>
   ![](/images/configure/ai-data-masking-activate-connection.png)

--- a/setup/configuration/runbooks-configuration.mdx
+++ b/setup/configuration/runbooks-configuration.mdx
@@ -93,7 +93,7 @@ This functionality enables easier integration with any internal workflow by leve
 
 | File Path                                     | Event Trigger | Environment Variables       |  Description   |
 | --------------------------------------------- | ------------- |---------------------------- |  ------------- |
-| `hoop-hooks/session-open.runbook.py`          | Session Open  | `HOOP_RUNBOOK_HOOK_PAYLOAD` |  It triggers when a session is being opened. It may be triggered more than once in case the connection has access requests enabled. |
+| `hoop-hooks/session-open.runbook.py`          | Session Open  | `HOOP_RUNBOOK_HOOK_PAYLOAD` |  It triggers when a session is being opened. It may be triggered more than once in case the resource role has access requests enabled. |
 | `hoop-hooks/session-close.runbook.py`         | Session Close | `HOOP_RUNBOOK_HOOK_PAYLOAD` |  It triggers when a session is being closed. |
 
 The environment variables are available when the runbook script is called, it contains the payload of the event that triggered the runbook.
@@ -165,7 +165,7 @@ print('connection_name: {}'.format(ev['connection_name']))
 
 ## How the template engine works
 
-Runbooks use the [GO text/template](https://pkg.go.dev/text/template) as the template engine. A runbook is a template to be run against a connection, the placeholders are rendered by inputs provided by an HTTP client.
+Runbooks use the [GO text/template](https://pkg.go.dev/text/template) as the template engine. A runbook is a template to be run against a resource role, the placeholders are rendered by inputs provided by an HTTP client.
 
 To define an input, the runbook must be enclosed with `{{ }}` and the input name must start with a dot. - Example - `{{ .myinput }}`
 

--- a/setup/configuration/secrets-manager-configuration.mdx
+++ b/setup/configuration/secrets-manager-configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Secrets Manager"
-description: "It enables integration with a known secrets manager, allowing the connection environment variable to be dynamically expanded for each connection."
+description: "It enables integration with a known secrets manager, allowing the resource role environment variable to be dynamically expanded for each resource role."
 ---
 
 ## AWS Secrets Manager Provider
@@ -39,7 +39,7 @@ aws secretsmanager create-secret --name pgprod \
     --secret-string file:///tmp/pgconfig.json
 ```
 
-Can be exposed to an environment variable in a connection as:
+Can be exposed to an environment variable in a resource role as:
 
 - `_aws:pgprod:PG_HOST`
 - `_aws:pgprod:PG_PORT`
@@ -52,7 +52,7 @@ The environment key value will be replaced when the user opens a session with th
 
 ### Testing
 
-Create a `bash` connection.
+Create a `bash` resource role.
 
 ```bash
 hoop admin create connection bash --agent test-agent \
@@ -138,7 +138,7 @@ Refer to [Vault App Role documentation]( https://developer.hashicorp.com/vault/d
             DBPORT=5432
         ```
 
-        A connection could be mapped using the following syntax:
+        A resource role could be mapped using the following syntax:
 
         - `_vaultkv1:SECRETNAME:SECRET-KEY`
         <Frame>
@@ -159,7 +159,7 @@ Refer to [Vault App Role documentation]( https://developer.hashicorp.com/vault/d
             DBPORT=5432
         ```
 
-        A connection could be mapped using the following syntax:
+        A resource role could be mapped using the following syntax:
 
         - `_vaultkv2:SECRETNAME:SECRET-KEY`
         <Frame>
@@ -177,7 +177,7 @@ Refer to [Vault App Role documentation]( https://developer.hashicorp.com/vault/d
     </Tabs>
   </Step>
   <Step title="Testing">
-    Go to the Webapp and run a query in this Connection.
+    Go to the Webapp and run a query in this Resource Role.
   </Step>
 </Steps>
 
@@ -195,13 +195,13 @@ So an environment variable configured in an agent:
 
 - `ENV_CONFIG='{"PG_HOST": "127.0.0.1", "PG_DB": "testdb"}'`
 
-Can be exposed to an environment variable in a connection as:
+Can be exposed to an environment variable in a resource role as:
 
 - `_envjson:ENVCONFIG:PG_HOST`
 
 ### Testing
 
-Create a `bash` connection.
+Create a `bash` resource role.
 
 ```bash
 hoop admin create connection bash --agent test-agent \

--- a/setup/deployment/docker-compose.mdx
+++ b/setup/deployment/docker-compose.mdx
@@ -148,7 +148,7 @@ Once you finish the setup, create an account and sign in to the developer portal
   />
 </Frame>
 
-Click to **explore with a demo database** and you will be able to create your first connection and start exploring the platform.
+Click to **explore with a demo database** and you will be able to create your first resource role and start exploring the platform.
 
 ### Running Your First Query
 

--- a/setup/deployment/overview.mdx
+++ b/setup/deployment/overview.mdx
@@ -6,7 +6,7 @@ description: 'See the options to try out hoop.dev'
 ## Get started
 
 Installing hoop.dev in your infrastructure is straightforward.
-After everything is properly installed and configured, you will have a web interface to create and manage access to your connections for everyone you invite to use it.
+After everything is properly installed and configured, you will have a web interface to create and manage access to your resource roles for everyone you invite to use it.
 
 ### Deployment Options
 

--- a/snippets/annimations/AuditTrailDemo.jsx
+++ b/snippets/annimations/AuditTrailDemo.jsx
@@ -138,7 +138,7 @@ export const AuditTrailDemo = () => {
   function MetaPanel({ visible }) {
     const rows = [
       { label: "AGENT", value: SESSION_META.agent },
-      { label: "CONNECTION", value: SESSION_META.connection },
+      { label: "RESOURCE ROLE", value: SESSION_META.connection },
       { label: "STARTED", value: SESSION_META.started },
       { label: "DURATION", value: SESSION_META.duration },
       { label: "STATUS", value: SESSION_META.status, badge: true },

--- a/snippets/annimations/SessionRecording.jsx
+++ b/snippets/annimations/SessionRecording.jsx
@@ -109,7 +109,7 @@ export const SessionRecording = () => {
   const MetaPanel = ({ visible }) => {
     const rows = [
       { label: "USER", value: SESSION_META.user, sub: SESSION_META.email },
-      { label: "CONNECTION", value: SESSION_META.connection },
+      { label: "RESOURCE ROLE", value: SESSION_META.connection },
       { label: "STARTED", value: SESSION_META.started },
       { label: "DURATION", value: SESSION_META.duration },
       { label: "STATUS", value: SESSION_META.status, badge: true },

--- a/snippets/annimations/actionaccessrequest.jsx
+++ b/snippets/annimations/actionaccessrequest.jsx
@@ -342,8 +342,8 @@ export const ActionAccessAnimation = () => {
                     <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
                       <span style={{
                         fontFamily: "'Inter', sans-serif", fontSize: 11,
-                        color: "rgba(var(--sand-100-rgb),0.30)", minWidth: 70,
-                      }}>Connection</span>
+                        color: "rgba(var(--sand-100-rgb),0.30)", minWidth: 84,
+                      }}>Resource Role</span>
                       <span style={{
                         fontFamily: "'JetBrains Mono', monospace", fontSize: 11,
                         color: "rgba(var(--sand-100-rgb),0.50)",
@@ -352,7 +352,7 @@ export const ActionAccessAnimation = () => {
                     <div style={{ display: "flex", gap: 8, alignItems: "flex-start" }}>
                       <span style={{
                         fontFamily: "'Inter', sans-serif", fontSize: 11,
-                        color: "rgba(var(--sand-100-rgb),0.30)", minWidth: 70,
+                        color: "rgba(var(--sand-100-rgb),0.30)", minWidth: 84,
                       }}>Command</span>
                       <span style={{
                         fontFamily: "'JetBrains Mono', monospace", fontSize: 11,

--- a/snippets/annimations/recording.jsx
+++ b/snippets/annimations/recording.jsx
@@ -106,7 +106,7 @@ export const SessionRecording = () => {
   function MetaPanel({ visible }) {
     const rows = [
       { label: "USER", value: SESSION_META.user, sub: SESSION_META.email },
-      { label: "CONNECTION", value: SESSION_META.connection },
+      { label: "RESOURCE ROLE", value: SESSION_META.connection },
       { label: "STARTED", value: SESSION_META.started },
       { label: "DURATION", value: SESSION_META.duration },
       { label: "STATUS", value: SESSION_META.status, badge: true },


### PR DESCRIPTION
## What

Aligns the documentation with the product rename of **Connection**:

- **Resource Role** — the configurable object users access, run commands against, or enable features on (Access Control, Access Requests, Guardrails, Live Data Masking, secrets, etc.)
- **Resources** — at overview/conceptual altitude and for the web app section/list

Spans `learn/`, `setup/`, `clients/`, `integrations/`, `introduction/`, and the hero/session animations (41 files).

## Left untouched intentionally

These are *not* the renamed concept and would break accuracy if changed:

- CLI commands — `hoop admin create connection`/`conn`, `hoop connect`, `--connection`, `--reviewers`
- MCP tool names — `connections_list`, `connection_databases`, …
- API paths & JSON fields — `/connections/`, `connection_name`, `connection_type`
- OAuth scopes (`connections:write`), config directives (`worker_connections`), naming placeholders, image filenames
- Generic networking wording — connection strings, gRPC/TLS connections, "connection established/closed", least-connections

## Not in this PR (deferred)

- `changelog/` — historical records
- `quickstart/` — auto-generated from `store/connections/*.yml` (needs the YAML-source approach)
- `event-routing.mdx`, `iam-federation-gcp.mdx`, `cli-federation.mdx` — tightly coupled to the `--connection` CLI flag / API fields / a data model; pending a decision on whether the CLI/API itself is renamed

> Note: the Action Access Requests **concept/config split** is a separate branch (`docs/fix-access-requests-content-split`) and intentionally not included here. The two touch disjoint regions of the shared files and merge cleanly in either order.