### PR TITLE
fix(analytics): remove anonymous Segment tracking from docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -318,10 +318,5 @@
       "github": "https://github.com/hoophq",
       "linkedin": "https://www.linkedin.com/company/hoopdev"
     }
-  },
-  "integrations": {
-    "segment": {
-      "key": "043Lv52mAcoGOHWVq7n3bxZAVvocyqx0"
-    }
   }
 }

--- a/mint-deprecated.json
+++ b/mint-deprecated.json
@@ -225,10 +225,5 @@
     "x": "https://x.com/hoopdotdev",
     "github": "https://github.com/hoophq",
     "linkedin": "https://www.linkedin.com/company/hoopdev"
-  },
-  "analytics": {
-    "segment": {
-      "key": "043Lv52mAcoGOHWVq7n3bxZAVvocyqx0"
-    }
   }
 }

--- a/scripts.js
+++ b/scripts.js
@@ -5,10 +5,3 @@ function gtag() {
 gtag('js', new Date());
 
 gtag('config', 'G-ZS8J67B1SX');
-
-function segment(){var i="analytics",analytics=window[i]=window[i]||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","screen","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware","register"];analytics.factory=function(e){return function(){if(window[i].initialized)return window[i][e].apply(window[i],arguments);var n=Array.prototype.slice.call(arguments);if(["track","screen","alias","group","page","identify"].indexOf(e)>-1){var c=document.querySelector("link[rel='canonical']");n.push({__t:"bpc",c:c&&c.getAttribute("href")||void 0,p:location.pathname,u:location.href,s:location.search,t:document.title,r:document.referrer})}n.unshift(e);analytics.push(n);return analytics}};for(var n=0;n<analytics.methods.length;n++){var key=analytics.methods[n];analytics[key]=analytics.factory(key)}analytics.load=function(key,n){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.setAttribute("data-global-segment-analytics-key",i);t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var r=document.getElementsByTagName("script")[0];r.parentNode.insertBefore(t,r);analytics._loadOptions=n};analytics._writeKey="043Lv52mAcoGOHWVq7n3bxZAVvocyqx0";;analytics.SNIPPET_VERSION="5.2.0";
-analytics.load("043Lv52mAcoGOHWVq7n3bxZAVvocyqx0");
-analytics.page();
-}};
-
-segment();


### PR DESCRIPTION
## Problem
The docs site loaded Segment and fired `analytics.page()` for every anonymous reader, contributing to the Segment MTU overage. Docs never calls `identify()`, so it only ever tracked anonymous users.

## Change
- Remove the Segment loader + `analytics.page()` from `scripts.js`.
- Remove the Segment integration from `docs.json` and the stale Segment block from the deprecated `mint-deprecated.json` config.
- Google Analytics (gtag) still covers docs traffic.

## Impact
Stops anonymous docs readers from counting as billed Segment MTU. No identify flows existed, so nothing is lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)