### PR TITLE
chore: re-trigger docs deploy to publish Segment removal

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -1,3 +1,5 @@
+// Google Analytics for the hoop.dev docs site. Segment was intentionally removed
+// here (anonymous docs readers were being counted as billed Segment MTU).
 window.dataLayer = window.dataLayer || [];
 function gtag() {
   dataLayer.push(arguments);


### PR DESCRIPTION
## Why
PR #133 (remove anonymous Segment tracking from docs) merged, but its production Mintlify deploy **failed** at the `revalidate subdomain: hoopdev` step — a transient Mintlify infra error, not a content issue. Re-triggering proved tricky: an empty commit was **skipped** (`No changes to preview`), and the Mintlify deploy check is not re-requestable via API. So the already-merged Segment removal has **not published** — the live docs still load Segment.

## What
A one-line comment in `scripts.js` documenting that it is GA-only now (Segment intentionally removed). This is a real content change, so Mintlify will not skip it — merging this re-triggers the production deploy and publishes the Segment removal.

## Note
If this deploy also fails with the same `revalidate subdomain` error, it is a Mintlify domain/SSL config issue for the `hoopdev` project (the `docs.hoop.dev` 525 corroborates) → Mintlify support, not a code problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)