### PR TITLE
docs: reciprocal Action <-> JIT 'See also' callouts

### DIFF
--- a/learn/features/access-requests/action.mdx
+++ b/learn/features/access-requests/action.mdx
@@ -9,6 +9,10 @@ import { ActionAccessAnimation } from '/snippets/annimations/actionaccessrequest
   <ActionAccessAnimation />
 </div>
 
+<Info>
+  **See also:** [Just-in-Time (JIT) Access Requests](/learn/features/access-requests/jit) — grant time-boxed access to a resource instead of approving each command.
+</Info>
+
 ## What You'll Accomplish
 
 Action Access Requests require approval for each command before it executes. Unlike JIT Access Requests (which grant time-based access), Action requests give you command-level control:

--- a/learn/features/access-requests/jit.mdx
+++ b/learn/features/access-requests/jit.mdx
@@ -11,6 +11,10 @@ import { LayeredAccess } from '/snippets/annimations/layeredaccess.jsx';
   </div>
 </div>
 
+<Info>
+  **See also:** [Action-based Access Requests](/learn/features/access-requests/action) — approve individual commands instead of granting time-boxed access.
+</Info>
+
 ## What You'll Accomplish
 
 Just-in-Time (JIT) Access Requests let you grant temporary access to production resources with automatic expiration. Instead of giving permanent access, you can:

--- a/setup/configuration/access-requests/action-configuration.mdx
+++ b/setup/configuration/access-requests/action-configuration.mdx
@@ -9,6 +9,10 @@ Action Access Requests require approval for each command before it executes. Thi
 For an introduction to Action Access Requests, see [Action Access Requests Overview](/learn/features/access-requests/action).
 </Note>
 
+<Info>
+  Configuring time-based access instead? See [JIT Access Requests Configuration](/setup/configuration/access-requests/jit-configuration).
+</Info>
+
 ---
 
 ## Enabling Action Access Requests

--- a/setup/configuration/access-requests/jit-configuration.mdx
+++ b/setup/configuration/access-requests/jit-configuration.mdx
@@ -5,6 +5,10 @@ description: "Configure time-based access controls for your resource roles"
 
 This page covers the configuration options for Just-in-Time Access Requests. For an introduction to how JIT Access Requests work, see [JIT Access Requests](/learn/features/access-requests/jit).
 
+<Info>
+  Configuring per-command approvals instead? See [Action Access Requests Configuration](/setup/configuration/access-requests/action-configuration).
+</Info>
+
 ## Enabling JIT Access Requests
 
 ### Via Web App


### PR DESCRIPTION
Generic Access Request links now all land on **JIT** (the shared Access Requests homepage was removed), so the sibling flavor is easy to miss.

Adds a prominent top-of-page **"See also"** callout on all four Access Requests pages, linking to the other flavor:

- `learn/features/access-requests/action.mdx` → JIT (concept)
- `learn/features/access-requests/jit.mdx` → Action (concept)
- `setup/configuration/access-requests/action-configuration.mdx` → JIT (config)
- `setup/configuration/access-requests/jit-configuration.mdx` → Action (config)

Concept→concept and config→config. Uses `<Info>` so it contrasts with the existing concept-link `<Note>` on the config pages. The bottom Next Steps/Related cards already cross-linked the sibling — this just surfaces it up top.

Builds clean; `mintlify broken-links` shows only the pre-existing unrelated `concepts/agents.mdx → /api-reference`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)