### PR TITLE
Add SQL Guardrail Recipes page and fix multi-line pattern examples

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -204,6 +204,7 @@
                   "setup/configuration/access-control-configuration",
                   "setup/configuration/abac-configuration",
                   "setup/configuration/guardrails-configuration",
+                  "setup/configuration/guardrails-sql-recipes",
                   "setup/configuration/guardrails-http",
                   "setup/configuration/runbooks-configuration",
                   "setup/configuration/event-routing-configuration",

--- a/learn/features/guardrails.mdx
+++ b/learn/features/guardrails.mdx
@@ -82,7 +82,7 @@ These features work together. For example:
 ---
 
 <Note>
-Ready to set it up? The [Guardrails configuration guide](/setup/configuration/guardrails-configuration) covers prerequisites, creating rules, pattern syntax, actions, recipes, testing, and troubleshooting.
+Ready to set it up? The [Guardrails configuration guide](/setup/configuration/guardrails-configuration) covers prerequisites, creating rules, pattern syntax, actions, testing, and troubleshooting. For complex SQL (multi-line queries, subqueries, CTEs), see the [SQL Guardrail Recipes](/setup/configuration/guardrails-sql-recipes).
 </Note>
 
 ## Next Steps
@@ -90,6 +90,9 @@ Ready to set it up? The [Guardrails configuration guide](/setup/configuration/gu
 <CardGroup cols={2}>
   <Card title="Guardrails Configuration" icon="gear" href="/setup/configuration/guardrails-configuration">
     Detailed configuration options and rule syntax
+  </Card>
+  <Card title="SQL Guardrail Recipes" icon="database" href="/setup/configuration/guardrails-sql-recipes">
+    Tested patterns for subqueries, CTEs, joins, and missing WHERE clauses
   </Card>
   <Card title="Live Data Masking" icon="mask" href="/learn/features/live-data-masking">
     Automatically redact sensitive data in query results

--- a/setup/configuration/guardrails-configuration.mdx
+++ b/setup/configuration/guardrails-configuration.mdx
@@ -153,7 +153,7 @@ This is a textual check: a `LIMIT` inside a subquery also satisfies it, even tho
 | `(?i)^\s*INSERT\s+INTO` | INSERT statements |
 | `(?i)^\s*UPDATE\s+` | UPDATE statements |
 | `(?i)^\s*DELETE\s+FROM` | DELETE statements |
-| `(?i)^\s*(CREATE|DROP|ALTER)\s+` | DDL commands |
+| `(?i)^\s*(CREATE\|DROP\|ALTER)\s+` | DDL commands |
 
 <Tip>
 Apply read-only patterns only to resource roles used by read-only groups, not to admin resource roles.
@@ -434,7 +434,7 @@ For specific users or groups that need to bypass certain rules:
 | Missing word boundaries | `DELETE` | `\bDELETE\b` |
 | Anchoring too strict | `^DROP` | `^\s*DROP` (allows leading whitespace) |
 | Lookahead blind to later lines | `(?i)UPDATE\s+(?!.*WHERE)` | `(?is)\bupdate\b(?![^;]*\bwhere\b)` (`[^;]*` crosses line breaks) |
-| Anchor misses later statements | `(?i)^\s*UPDATE` | `(?is)\bupdate\b` scoped with `[^;]*(?:;|$)` |
+| Anchor misses later statements | `(?i)^\s*UPDATE` | `(?is)\bupdate\b` scoped with `[^;]*` to the statement end |
 
 ### Too Many False Positives
 

--- a/setup/configuration/guardrails-configuration.mdx
+++ b/setup/configuration/guardrails-configuration.mdx
@@ -109,17 +109,23 @@ Guardrail patterns are compiled by **Microsoft Presidio**, which uses Python's `
 | `.*` | Any characters | `SELECT.*FROM` matches anything between |
 | `(?!...)` | Negative lookahead | `(?!.*WHERE)` means "not followed by WHERE" |
 
+<Warning>
+Two defaults break most SQL rules: `.` does not cross line breaks (a lookahead like `(?!.*WHERE)` only inspects the first line of a multi-line query), and `^` only matches the start of the payload (it misses the UPDATE in `SELECT 1; UPDATE ...`). Start patterns with `(?is)` and scope them by statement with `[^;]*` instead of `.*`. See [SQL Guardrail Recipes](/setup/configuration/guardrails-sql-recipes) for the full explanation.
+</Warning>
+
 ### Common Patterns
 
 **Block UPDATE without WHERE:**
 ```regex
-(?i)^\s*UPDATE\s+\w+\s+SET\s+(?!.*WHERE)
+(?is)\bupdate\b(?![^;]*\bwhere\b)[^;]*(?:;|$)
 ```
 
 **Block DELETE without WHERE:**
 ```regex
-(?i)^\s*DELETE\s+FROM\s+\w+(?!.*WHERE)
+(?is)\bdelete\b(?![^;]*\bwhere\b)[^;]*(?:;|$)
 ```
+
+Both patterns work on multi-line queries and on scripts with multiple statements: `[^;]*` in the lookahead crosses line breaks and stops at the statement boundary.
 
 **Block all DDL:**
 ```regex
@@ -133,8 +139,12 @@ Guardrail patterns are compiled by **Microsoft Presidio**, which uses Python's `
 
 **Require LIMIT clause:**
 ```regex
-(?i)SELECT\s+(?!.*\bLIMIT\b).*FROM
+(?is)\bselect\b(?![^;]*\blimit\b)[^;]*(?:;|$)
 ```
+
+<Note>
+This is a textual check: a `LIMIT` inside a subquery also satisfies it, even though the outer query stays unbounded. No regex can tell the two apart. See [What regex cannot catch](/setup/configuration/guardrails-sql-recipes#what-regex-cannot-catch) for layered alternatives.
+</Note>
 
 **Enforce read-only access** (create separate rules for each):
 
@@ -423,6 +433,8 @@ For specific users or groups that need to bypass certain rules:
 | Missing case-insensitive | `DROP TABLE` | `(?i)DROP TABLE` |
 | Missing word boundaries | `DELETE` | `\bDELETE\b` |
 | Anchoring too strict | `^DROP` | `^\s*DROP` (allows leading whitespace) |
+| Lookahead blind to later lines | `(?i)UPDATE\s+(?!.*WHERE)` | `(?is)\bupdate\b(?![^;]*\bwhere\b)` (`[^;]*` crosses line breaks) |
+| Anchor misses later statements | `(?i)^\s*UPDATE` | `(?is)\bupdate\b` scoped with `[^;]*(?:;|$)` |
 
 ### Too Many False Positives
 
@@ -447,6 +459,9 @@ If queries are slow:
 ## Related
 
 <CardGroup cols={2}>
+  <Card title="SQL Guardrail Recipes" icon="database" href="/setup/configuration/guardrails-sql-recipes">
+    Tested patterns for tautologies, subqueries, CTEs, joins, and missing WHERE clauses
+  </Card>
   <Card title="Guardrails Overview" icon="shield" href="/learn/features/guardrails">
     Learn what guardrails do and see common recipes
   </Card>

--- a/setup/configuration/guardrails-sql-recipes.mdx
+++ b/setup/configuration/guardrails-sql-recipes.mdx
@@ -1,0 +1,233 @@
+---
+title: "SQL Guardrail Recipes"
+description: "Tested regex recipes for complex SQL: tautologies, subqueries, CTEs, joins, and missing WHERE clauses"
+---
+
+Simple patterns catch simple mistakes. Real queries span multiple lines, hide writes behind CTEs, and scope deletes with subqueries. This page gives you **tested patterns for those harder cases**, plus safe queries to verify each rule before it reaches production.
+
+Every pattern here was validated against Python's `re` module, the engine that evaluates guardrails, using both queries that must be blocked and legitimate queries that must pass.
+
+<Note>
+For rule creation, actions, and pattern syntax basics, see [Guardrails Configuration](/setup/configuration/guardrails-configuration).
+</Note>
+
+---
+
+## Two pitfalls that break most SQL rules
+
+Real queries span multiple lines. Real scripts contain more than one statement. These two regex details cause most false positives and false negatives:
+
+**1. `.` does not cross line breaks.** Without the `s` flag, a lookahead like `(?!.*\bWHERE\b)` only inspects the first line. This rule blocks a multi-line UPDATE **even though it has a WHERE clause**:
+
+```sql
+UPDATE users
+SET active = false
+WHERE id = 123;  -- blocked anyway: the lookahead never sees line 3
+```
+
+Fix: scope the lookahead by statement with `[^;]*` instead of `.*`. It crosses line breaks and stops at the statement boundary.
+
+**2. `^` only matches the start of the payload.** Without the `m` flag, a rule anchored on `^UPDATE` misses the UPDATE in `SELECT 1; UPDATE t SET a = 1;`. Prefer `\b` word boundaries plus per-statement scoping over anchors.
+
+The recipes below apply both fixes. They share a common shape: `(?is)` at the start (case-insensitive, dot crosses lines) and `[^;]*` to stay inside one statement.
+
+---
+
+## Recipes
+
+Each recipe is one input rule with the **Block** action, unless noted. Rule names follow the `block-*` convention; use them as-is or rename to match your setup.
+
+### block-tautology-where
+
+Blocks statements where the WHERE clause exists but does not restrict anything: `WHERE 1=1`, `WHERE TRUE`, `WHERE '1'='1'`.
+
+```regex
+(?is)\bwhere\s+\(*\s*(?:1\s*=\s*1|'1'\s*=\s*'1'|true)\s*\)*\s*(?:;|$|\breturning\b)
+```
+
+| Query | Result |
+|-------|--------|
+| `UPDATE users SET active = false WHERE 1 = 1;` | Blocked |
+| `SELECT * FROM users WHERE TRUE;` | Blocked |
+| `UPDATE t SET a = 1 WHERE (1=1) RETURNING id;` | Blocked |
+| `UPDATE users SET active = false WHERE id = 10;` | Allowed |
+| `SELECT * FROM users WHERE 1=1 AND tenant_id = 5;` | Allowed |
+| `SELECT * FROM flags WHERE enabled = true;` | Allowed |
+
+The pattern only matches when the tautology is the **last or only condition**, followed by `;`, end of input, or `RETURNING`. That keeps the common query-builder idiom `WHERE 1=1 AND <real condition>` working. To block that idiom too, remove the `;|$` alternatives.
+
+### block-write-with-subquery
+
+Blocks UPDATE and DELETE statements whose scope comes from a subquery: `IN (SELECT ...)`, `EXISTS (SELECT ...)`, `= (SELECT ...)`. These writes are hard to review because the affected rows are invisible until execution.
+
+```regex
+(?is)\b(?:update|delete)\b[^;]*\bwhere\b[^;]*\(\s*select\b
+```
+
+| Query | Result |
+|-------|--------|
+| `UPDATE users SET active = false WHERE id IN (SELECT id FROM temp_users);` | Blocked |
+| `UPDATE users SET active = false WHERE EXISTS (SELECT 1 FROM sessions s WHERE s.user_id = users.id);` | Blocked |
+| `DELETE FROM users WHERE id = (SELECT max(id) FROM audit);` | Blocked |
+| `SELECT * FROM customers WHERE id IN (SELECT customer_id FROM orders LIMIT 10);` | Allowed |
+| `UPDATE users SET active = false WHERE id = 10;` | Allowed |
+
+Reads with subqueries stay allowed. Column names like `updated_at` do not trigger the rule: `\b` requires the exact word.
+
+### block-cte-write
+
+Blocks writes hidden behind a CTE: `WITH ... UPDATE`, `WITH ... DELETE`, `WITH ... INSERT`, `WITH ... MERGE`. A rule that only inspects the first keyword of a query sees `WITH` and lets the write through.
+
+```regex
+(?is)(?:^|;)\s*with\b[^;]*\b(?:update|delete|insert|merge)\b
+```
+
+| Query | Result |
+|-------|--------|
+| `WITH recent AS (SELECT * FROM orders) UPDATE orders SET processed = true FROM recent WHERE orders.id = recent.id;` | Blocked |
+| `SELECT 1; WITH x AS (SELECT id FROM t) DELETE FROM t USING x WHERE t.id = x.id;` | Blocked |
+| `WITH recent AS (SELECT * FROM orders) SELECT * FROM recent;` | Allowed |
+| `WITH x AS (SELECT last_update FROM t) SELECT * FROM x;` | Allowed |
+
+Read-only CTEs pass. The rule requires `WITH` at the start of a statement, so table hints like `WITH (NOLOCK)` in the middle of a query do not trigger it.
+
+### block-excessive-joins
+
+Matches statements with **3 or more JOINs**. Regex cannot parse query structure, but it can count occurrences. Adjust `{2}` to N-1 for a different threshold.
+
+```regex
+(?is)\bjoin\b(?:[^;]*\bjoin\b){2}
+```
+
+| Query | Result |
+|-------|--------|
+| `SELECT * FROM a JOIN b ON ... JOIN c ON ... LEFT JOIN (SELECT ...) x ON ...;` | Matched (4 joins) |
+| `SELECT * FROM a JOIN b ON a.id = b.id LEFT JOIN c ON b.id = c.id;` | Allowed (2 joins) |
+| `SELECT ... 2 joins ...; SELECT ... 2 joins ...;` | Allowed (per statement) |
+
+<Tip>
+Use **Require Approval** instead of Block for this rule. A complex join is not always wrong, but it usually deserves a second pair of eyes. See [Actions](/setup/configuration/guardrails-configuration#actions).
+</Tip>
+
+### block-write-without-where
+
+Blocks UPDATE and DELETE statements that have no WHERE clause at all. This is the corrected, multi-line-safe version of the classic rule.
+
+```regex
+(?is)\b(?:update|delete)\b(?![^;]*\bwhere\b)[^;]*(?:;|$)
+```
+
+| Query | Result |
+|-------|--------|
+| `UPDATE users SET active = false;` | Blocked |
+| `DELETE FROM tmp_sessions` (no trailing `;`) | Blocked |
+| `SELECT 1; UPDATE t SET a = 1;` | Blocked (second statement) |
+| Multi-line `UPDATE ... WHERE id = 123;` | Allowed |
+| `UPDATE t SET a = 1 WHERE b IN (SELECT id FROM x);` | Allowed |
+
+This rule and `block-tautology-where` are complementary and never overlap: `UPDATE ... WHERE 1=1;` triggers the tautology rule, not this one. Assign both to the same resource role for full coverage.
+
+---
+
+## Test before you deploy
+
+Never test a blocking rule with a query that would be destructive if the block fails. A typo in the pattern, or a guardrail assigned to the wrong resource role, means the query runs.
+
+The test queries below are safe on any database, including production:
+
+- **"Must block" queries** never reach the database when the rule works. They also reference tables that do not exist (`gr_test_zz`, `gr_tmp_zz`, `gr_orders_zz`), so even if the rule fails, Postgres returns `relation does not exist` and nothing changes. For an extra layer, wrap writes in `BEGIN; ...; ROLLBACK;` (neither keyword triggers these rules).
+- **"Must pass" queries** execute for real. They only read Postgres catalogs (`pg_tables`, `pg_class`) with a `LIMIT`, and the single write targets a temp table created in the same payload, discarded when the session ends. On a read-only resource role, the temp table control fails on permissions, which is harmless.
+
+With all 5 rules active on the same resource role, each blocking query below triggers **only its own rule**, so the error message tells you which rule fired.
+
+**block-tautology-where**
+```sql
+-- must block:
+UPDATE gr_test_zz SET active = false WHERE 1 = 1;
+-- must pass:
+SELECT * FROM pg_tables WHERE 1=1 AND schemaname = 'public';
+```
+
+**block-write-with-subquery**
+```sql
+-- must block:
+UPDATE gr_test_zz SET active = false WHERE id IN (SELECT id FROM gr_tmp_zz);
+-- must pass:
+SELECT * FROM pg_tables WHERE tablename IN (SELECT tablename FROM pg_tables LIMIT 5);
+```
+
+**block-cte-write**
+```sql
+-- must block:
+WITH recent AS (SELECT * FROM gr_orders_zz) UPDATE gr_orders_zz SET processed = true FROM recent WHERE gr_orders_zz.id = recent.id;
+-- must pass:
+WITH t AS (SELECT tablename FROM pg_tables) SELECT * FROM t LIMIT 5;
+```
+
+**block-excessive-joins**
+```sql
+-- must block (4 joins):
+SELECT * FROM pg_class a JOIN pg_namespace b ON a.relnamespace = b.oid JOIN pg_attribute c ON c.attrelid = a.oid LEFT JOIN (SELECT oid FROM pg_type) d ON d.oid = c.atttypid LIMIT 1;
+-- must pass (1 join):
+SELECT a.relname FROM pg_class a JOIN pg_namespace b ON a.relnamespace = b.oid LIMIT 5;
+```
+
+**block-write-without-where**
+```sql
+-- must block:
+UPDATE gr_test_zz SET active = false;
+-- must pass (single payload, temp table):
+CREATE TEMP TABLE gr_test_ok (id int, active bool); INSERT INTO gr_test_ok VALUES (1, true); UPDATE gr_test_ok SET active = false WHERE id = 1;
+```
+
+Two extra checks worth running:
+
+1. An `UPDATE ... WHERE id = 1` split across several lines must **pass** `block-write-without-where`. Multi-line queries are the main source of false positives in older rule styles.
+2. `UPDATE ... WHERE 1 = 1;` must trigger `block-tautology-where`, **not** `block-write-without-where`.
+
+---
+
+## What regex cannot catch
+
+**A `LIMIT` that only exists in a subquery is not detectable with regex.** Consider:
+
+```sql
+SELECT *
+FROM customers
+WHERE id IN (
+  SELECT customer_id FROM orders LIMIT 10
+);
+-- the outer SELECT is still unbounded
+```
+
+Two reasons no pattern can catch this reliably:
+
+1. Deciding whether the `LIMIT` belongs to the outer query or the subquery requires parsing nested parentheses. That is grammar, and regex does not parse structure.
+2. A "SELECT without LIMIT" rule does not help either: the word `LIMIT` **is present** in the text, so any textual check considers the query bounded.
+
+The same limit applies to string literals and comments: a guardrail sees plain text, so `SET note = 'where true'` can trip a tautology rule, and `/* where */` can satisfy an absence check. Rare in practice, but real. A guardrail is a textual safety belt, not a SQL parser.
+
+For unbounded reads, layer your defenses instead:
+
+- **Require Approval**: route mass-read verbs on production resource roles through [approval](/setup/configuration/guardrails-configuration#require-approval). The approver sees the query structure that regex cannot.
+- **Database-level controls**: give the resource role's database user a `statement_timeout`, a read-only role, or views with built-in limits on sensitive tables. The guardrail blocks the text; the database limits the actual cost.
+- **[Runbooks](/learn/features/runbooks)**: parameterized queries for day-to-day operations. Users fill in parameters instead of writing free-form SQL.
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Guardrails Configuration" icon="gear" href="/setup/configuration/guardrails-configuration">
+    Rule creation, actions, pattern syntax, and troubleshooting
+  </Card>
+  <Card title="Guardrails Overview" icon="shield" href="/learn/features/guardrails">
+    What guardrails do and how they fit with other features
+  </Card>
+  <Card title="Action Access Requests" icon="clock" href="/setup/configuration/access-requests/action-configuration">
+    Configure the Require Approval action
+  </Card>
+  <Card title="Runbooks" icon="book" href="/learn/features/runbooks">
+    Parameterized queries instead of free-form SQL
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## What this changes

Customer feedback ([EVL-89](https://linear.app/hoophq/issue/EVL-89/guardrails-guidance)) asked for guardrail guidance on complex SQL: tautology WHERE clauses, writes scoped by subqueries, writes hidden in CTEs, join complexity, and missing WHERE clauses. While researching, we found that some of the docs' own pattern examples fail on multi-line queries.

### Fixes to existing examples (`setup/configuration/guardrails-configuration.mdx`)

The "Block UPDATE/DELETE without WHERE" and "Require LIMIT" patterns used `(?!.*WHERE)`-style lookaheads without `(?s)`, plus `^` anchors. Validated against Python `re` (the Presidio engine that evaluates guardrails):

* **False positive**: `.` never crosses the first line break, so a multi-line `UPDATE ... WHERE id = 123;` gets blocked even though it has a WHERE clause.
* **False negative**: `^` only matches the start of the payload, so the UPDATE in `SELECT 1; UPDATE t SET a = 1;` passes.

Replaced with statement-scoped patterns using `[^;]*`, which cross line breaks and stop at the statement boundary. Also added a `<Warning>` about these two pitfalls in Pattern Syntax and two new rows in the Troubleshooting mistakes table.

### New page: `setup/configuration/guardrails-sql-recipes.mdx`

A recipes page for the harder SQL cases, following the `guardrails-http` sibling-page precedent:

* The two pitfalls that break most SQL rules (multi-line, multi-statement)
* 5 named recipes (`block-tautology-where`, `block-write-with-subquery`, `block-cte-write`, `block-excessive-joins`, `block-write-without-where`), each with block/allow tables
* Safe test queries that work on any database (nonexistent tables for "must block", catalog reads and temp tables for "must pass")
* "What regex cannot catch": why a `LIMIT` inside a subquery is not detectable by any pattern, with layered alternatives (Require Approval, database-level controls, Runbooks)

Every pattern in this PR was validated against Python `re` with both queries that must be blocked and legitimate queries that must pass.

### Navigation and cross-links

* Registered the new page in `docs.json` between `guardrails-configuration` and `guardrails-http`
* Added cards/links from the Guardrails overview and configuration pages

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)

[https://claude.ai/code/session_01QTotrGf5cZfze4hrPTyaca](<https://claude.ai/code/session_01QTotrGf5cZfze4hrPTyaca>)

---

*Generated by [Claude Code](<https://claude.ai/code/session_01QTotrGf5cZfze4hrPTyaca>)*