### PR TITLE
docs(changelog): add 1.121.0 entry

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -17,12 +17,12 @@ Browse our latest updates to see what's new:
 
 {/* changelog-cards:start */}
 <CardGroup cols={2}>
-  <Card title="Latest Release" icon="rocket" href="/changelog/1.119.4">
-    Version 1.119.4 - Tunnels, machine identities, AI analysis and much more
+  <Card title="Latest Release" icon="rocket" href="/changelog/1.121.0">
+    Version 1.121.0 - Protection Profiles, license-clean images and more
   </Card>
 
-  <Card title="Patch 1.43.1" icon="note" href="/changelog/1.43.1">
-    Version 1.43.1 - Bug fixes
+  <Card title="Patch 1.119.4" icon="note" href="/changelog/1.119.4">
+    Version 1.119.4 - Tunnels, machine identities, AI analysis and much more
   </Card>
 </CardGroup>
 {/* changelog-cards:end */}

--- a/changelog/1.121.0.mdx
+++ b/changelog/1.121.0.mdx
@@ -4,7 +4,7 @@ description: "Introducing Protection Profiles for one-click compliance-ready sec
 ---
 
 ### TL;DR
-- **New Features:** Protection Profiles apply curated guardrails, data masking, access request, and AI analyzer rules in a single selection, alongside a new license-clean image line.
+- **New Features:** Protection Profiles apply curated guardrails, data masking, access request, and AI Session Analyzer rules in a single selection, alongside a new license-clean image line.
 
 ---
 

--- a/changelog/1.121.0.mdx
+++ b/changelog/1.121.0.mdx
@@ -1,0 +1,24 @@
+---
+title: "1.121.0"
+description: "Introducing Protection Profiles for one-click compliance-ready security presets, plus a new license-clean image line so you always deploy exactly what you intend."
+---
+
+### TL;DR
+- **New Features:** Protection Profiles apply curated guardrails, data masking, access request, and AI analyzer rules in a single selection, alongside a new license-clean image line.
+
+---
+
+### New Features
+**Ready-made security presets and cleaner deployments.**
+
+- **Protection Profiles for one-click security posture**
+  Choose an organization-level protection profile like HIPAA-ready, SOC 2 Type 2, or permissive, medium, and high presets to instantly apply a curated set of guardrails, data masking, access request, and AI session analyzer rules across your connections. New connections are tagged automatically while a profile is active, switching profiles migrates your connections cleanly, and you can revert to manual configuration at any time.
+  [PR #1627](https://github.com/hoophq/hoop/pull/1627)
+
+- **License-clean image line**
+  A new clean image line lets you deploy a gateway and agent free of AGPL and SSPL components, while existing deployments that depend on the legacy MongoDB shell keep working unchanged. Opt in when you're ready, with no disruption to current setups.
+  [PR #1629](https://github.com/hoophq/hoop/pull/1629)
+
+---
+
+Less friction, stronger protection out of the box.

--- a/docs.json
+++ b/docs.json
@@ -289,6 +289,7 @@
           {
             "group": "Releases",
             "pages": [
+              "changelog/1.121.0",
               "changelog/1.119.4",
               "changelog/1.43.1",
               "changelog/1.43.0",


### PR DESCRIPTION
Automated weekly changelog entry for **1.121.0**, covering releases `1.119.4` (exclusive) through `1.121.0`.

- Included changes: **2**
- Excluded changes: **0**

## Reviewer checklist

- [ ] Voice and framing read like the existing entries
- [ ] Nothing feature-flag-gated or internal leaked into the entry
- [ ] TL;DR and release cards look right

---

Generated by [hoophq/changelog](https://github.com/hoophq/changelog) — [run](https://github.com/hoophq/changelog/actions/runs/30272516244).
