### PR TITLE
DEP-91: document Hoop container image options

### DIFF
--- a/concepts/agents.mdx
+++ b/concepts/agents.mdx
@@ -59,6 +59,7 @@ This installs a system service (`hoop-agent`) that starts automatically on login
 | Variable | Description | Default |
 |---|---|---|
 | `HOOP_KEY` | Agent authentication DSN (required) | — |
+| `HOOP_GATEWAY_URL` | Gateway HTTP/HTTPS base URL. When set, `hoop start agent` also starts the Rust agent used by RDP and connects it to the gateway's `/api/ws` endpoint. Required for the RDP PII guard. | — |
 | `LOG_LEVEL` | Log level: `debug`, `info`, `warn`, `error` | `info` |
 | `LOG_ENCODING` | Log format: `json`, `console`, `human`, `verbose` | auto |
 | `HOOP_TLSCA` | Path to a custom TLS CA certificate | — |

--- a/docs.json
+++ b/docs.json
@@ -183,6 +183,7 @@
                 "group": "Deployment",
                 "pages": [
                   "setup/deployment/overview",
+                  "setup/deployment/container-images",
                   "setup/deployment/docker-compose",
                   "setup/deployment/kubernetes",
                   "setup/deployment/presidio",

--- a/setup/deployment/container-images.mdx
+++ b/setup/deployment/container-images.mdx
@@ -1,0 +1,179 @@
+---
+title: 'Container Images'
+description: 'Choose the Hoop gateway and agent images for your deployment'
+---
+
+Hoop publishes separate gateway and agent images. They are not interchangeable: the gateway runs the control plane, while agents connect to the gateway and reach your protected resources.
+
+Use the same Hoop release for the gateway and its agents. In production, select an explicit release tag and pin the image by digest when you need immutable bytes.
+
+## Choose an image line
+
+| Goal | Gateway | Agent | Recommendation |
+| --- | --- | --- | --- |
+| Broadest compatibility | `hoophq/hoop` | `hoophq/hoopdev` | The default. Use it when agents need the bundled database, cloud, and shell tooling. |
+| Smallest runtime and lowest dependency surface | `hoophq/hoop` | `hoophq/hoopdev-minimal` | Use it for native database, HTTP, and TCP proxy connections, or as a base for your own agent image. |
+| AGPL/SSPL-free image repositories | `hoophq/hoop-ng` | `hoophq/hoopdev-ng` | Use the `-ng` Helm charts when your software policy requires the clean-only image line. |
+| Realtime PII protection for RDP | `hoophq/hoop` | `hoophq/hoop-agent-ocr` | Use only for agents that run the RDP PII guard. Choose the CPU or GPU tag. |
+
+<Note>
+`minimal` and `-ng` solve different problems. The minimal agent removes bundled client toolchains to reduce image size and vulnerability surface. The `-ng` line keeps a broad toolkit but excludes AGPL/SSPL components and uses repositories with clean-only history.
+</Note>
+
+## Gateway images
+
+### `hoophq/hoop`
+
+The standard gateway image runs the Hoop API, web application, gateway listeners, and database migrations. It can also run an agent, but production deployments normally use a separate agent image.
+
+**Use it when:** you are using the standard Docker Compose or Helm deployment. This is the default gateway image.
+
+### `hoophq/hoop-ng`
+
+The clean-line gateway is a manifest-for-manifest copy of the standard gateway published in a dedicated clean-only repository. The gateway contents are already AGPL/SSPL-free; the separate repository provides a bright-line image history for compliance controls.
+
+**Use it when:** your policy requires the entire deployment to pull from clean-only repositories. Pair it with `hoophq/hoopdev-ng` through the `hoop-ng` Helm chart.
+
+## Agent images
+
+### `hoophq/hoopdev`
+
+The compatibility-first agent includes the Hoop agent and a broad runtime toolkit, including:
+
+- PostgreSQL, MySQL, MongoDB, Microsoft SQL Server, Oracle, ODBC, and Redis clients
+- `kubectl`, AWS CLI and Session Manager Plugin, and Google Cloud CLI
+- Node.js, npm, Python, OpenSSH, and common shell utilities
+- both modern `mongosh` and the legacy MongoDB 5 `mongo` shell
+
+The legacy `mongo` shell depends on end-of-life OpenSSL 1.1 and is retained only to avoid breaking existing customers.
+
+**Use it when:** you need the widest out-of-the-box compatibility, use exec-based connections, or are not yet sure which external clients your connections require. It remains the Helm and Docker Compose default.
+
+### `hoophq/hoopdev-minimal`
+
+The minimal agent contains the Hoop agent plus only its required runtime packages. It does not include database or cloud CLIs, Node.js, Python, OpenSSH, OCR, or development headers.
+
+These connection types work without adding another binary because the agent handles them in process:
+
+- native PostgreSQL, MySQL, Microsoft SQL Server, MongoDB, and Oracle proxy connections
+- HTTP proxy connections
+- TCP proxy connections
+
+Exec-based sessions and connections that launch an external client require a custom image. Examples include `bash`, `python`, `clickhouse-client`, `kubectl`, `aws`, `gcloud`, and `bq`.
+
+**Use it when:** you only use the in-process connection types above, or you want a lean base and will install exactly the clients your deployment needs. If you need most of the bundled toolkit, use `hoophq/hoopdev` instead.
+
+Opt into the stock minimal image in the agent Helm chart:
+
+```yaml
+image:
+  minimal: true
+```
+
+An explicit `image.repository` takes precedence over `image.minimal`. To add selected tools, derive your own image and restore the unprivileged runtime user:
+
+```dockerfile
+FROM hoophq/hoopdev-minimal:<release>
+
+USER root
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends postgresql-client && \
+    rm -rf /var/lib/apt/lists/*
+USER hoop
+```
+
+Then select it in the agent chart:
+
+```yaml
+image:
+  repository: registry.example.com/hoop-agent
+  tag: <your-tag>
+```
+
+### `hoophq/hoopdev-ng`
+
+The clean-line agent has the same role and broad client coverage as `hoophq/hoopdev`, but it excludes the SSPL-licensed legacy MongoDB 5 `mongo` shell and its OpenSSL 1.1 dependency. It includes modern `mongosh` and uses the clean train's updated tool versions.
+
+**Use it when:** you need bundled database and cloud clients but cannot accept AGPL/SSPL components. Confirm that no connection or script still invokes the legacy `mongo` command before switching; use `mongosh` instead.
+
+The clean Helm charts wrap the standard charts, so their values must be nested under the dependency name. Do not pass an existing standard-chart values file unchanged. Move every existing gateway setting under `hoop-chart` and every existing agent setting under `hoopagent-chart`:
+
+```yaml
+# clean-gateway-values.yaml
+hoop-chart:
+  config:
+    POSTGRES_DB_URI: <database-uri>
+    API_URL: https://hoop.example.com
+  # Move the rest of your existing gateway values here.
+
+# clean-agent-values.yaml
+hoopagent-chart:
+  config:
+    HOOP_KEY: <agent-key>
+  # Move the rest of your existing agent values here.
+```
+
+If the old values explicitly set an image repository, remove that override or change it to `hoophq/hoop-ng` for the gateway and `hoophq/hoopdev-ng` for the agent. Then install the clean chart artifacts:
+
+```bash
+VERSION=$(curl -s https://releases.hoop.dev/release/latest.txt)
+
+helm upgrade --install hoop \
+  --namespace <existing-namespace> \
+  https://releases.hoop.dev/release/$VERSION/hoop-ng-chart-$VERSION.tgz \
+  -f clean-gateway-values.yaml
+
+helm upgrade --install hoopagent \
+  --namespace <existing-namespace> \
+  https://releases.hoop.dev/release/$VERSION/hoopagent-ng-chart-$VERSION.tgz \
+  -f clean-agent-values.yaml
+```
+
+Use the namespace that contains the existing `hoop` and `hoopagent` releases. For a new deployment, choose the target namespace and add `--create-namespace`. The installed Helm release names remain unchanged, so the commands perform an in-place upgrade only when the release name and namespace both match and after the values are nested and the rendered manifests are reviewed. Top-level values from the standard charts are ignored if they are passed to the wrapper charts without this migration.
+
+### `hoophq/hoop-agent-ocr`
+
+This specialized agent bundles a RapidOCR service for realtime RDP PII detection. OCR runs on loopback inside the same container, so screen pixels do not leave the agent boundary for recognition. A Presidio analyzer is still required for PII classification.
+
+| Tag | Architecture | Use it when |
+| --- | --- | --- |
+| `:<release>` | `linux/amd64`, `linux/arm64` | CPU inference is sufficient. |
+| `:<release>-gpu` | `linux/amd64` | The pod has a supported NVIDIA GPU, container runtime, and Kubernetes device plugin. |
+
+The image defaults to the all-in-one `hoop-default-agent.sh` launcher, which requires direct database access and replaces `HOOP_KEY` with credentials for a local gateway. A standalone agent must override that command and provide all three of these settings:
+
+- `HOOP_KEY` — the agent DSN for the gateway's gRPC endpoint
+- `HOOP_GATEWAY_URL` — the gateway HTTP/WS URL required to start the RDP agent
+- `MSPRESIDIO_ANALYZER_URL` — the Presidio analyzer URL; the standard Helm service listens on port `3000`
+
+The current stock agent Helm chart does not expose a container-command override. Changing only `image.repository` to the OCR image will run the wrong launcher and fail without `POSTGRES_DB_URI`. Use a custom Kubernetes workload or Docker Compose service that explicitly runs the standalone agent:
+
+```yaml
+services:
+  agent:
+    image: hoophq/hoop-agent-ocr:<release> # or <release>-gpu
+    command: ["hoop", "start", "agent"]
+    environment:
+      HOOP_KEY: ${HOOP_KEY}
+      HOOP_GATEWAY_URL: https://hoop.example.com
+      MSPRESIDIO_ANALYZER_URL: http://presidio-analyzer:3000
+```
+
+For Kubernetes, set the same `command` and environment variables in the container specification and source `HOOP_KEY` from a Secret.
+
+**Use it when:** the RDP PII guard is enabled for the organization. Do not use it for ordinary agents; its OCR models and runtime add significant image and memory overhead. See [Deploy Presidio](/setup/deployment/presidio) for the analyzer deployment.
+
+## Tags and update policy
+
+| Tag | Behavior | Production guidance |
+| --- | --- | --- |
+| `:<release>` | Identifies a Hoop release, such as `:1.126.3`. | Recommended baseline. Keep the gateway and agent on the same release. |
+| `:latest` | Moves whenever a new release is published. | Use for evaluation or when your deployment process intentionally tracks releases. |
+| `@sha256:<digest>` | Identifies exact image bytes. | Use when reproducibility or admission policy requires immutability. |
+| `hoopdev-minimal:<release>-<YYYYMMDD>` | Captures a weekly OS-patched minimal image. | Use when you want a dated patch snapshot; pin its digest for strict immutability. |
+
+`hoophq/hoopdev-minimal:latest` is rebuilt weekly between Hoop releases to pick up current Ubuntu security patches. Its plain `:<release>` tag is updated by the release workflow, not by the weekly rebuild. Application dependency fixes still require a new Hoop release.
+
+## Internal build image
+
+`hoophq/agent-tools` is the build base used to produce `hoophq/hoopdev` and `hoophq/hoopdev-ng`. It does not contain the released Hoop agent binary and is not a supported deployment image. Do not configure it as a gateway or agent container.

--- a/setup/deployment/container-images.mdx
+++ b/setup/deployment/container-images.mdx
@@ -140,13 +140,13 @@ This specialized agent bundles a RapidOCR service for realtime RDP PII detection
 | `:<release>` | `linux/amd64`, `linux/arm64` | CPU inference is sufficient. |
 | `:<release>-gpu` | `linux/amd64` | The pod has a supported NVIDIA GPU, container runtime, and Kubernetes device plugin. |
 
-The image defaults to the all-in-one `hoop-default-agent.sh` launcher, which requires direct database access and replaces `HOOP_KEY` with credentials for a local gateway. A standalone agent must override that command and provide all three of these settings:
+The image defaults to the all-in-one `hoop-default-agent.sh` launcher, which requires direct database access and replaces `HOOP_KEY` with credentials for a local gateway. A standalone agent must replace the image's default arguments while preserving its ENTRYPOINT, which starts and supervises OCR, and provide all three of these settings:
 
 - `HOOP_KEY` — the agent DSN for the gateway's gRPC endpoint
-- `HOOP_GATEWAY_URL` — the gateway HTTP/WS URL required to start the RDP agent
-- `MSPRESIDIO_ANALYZER_URL` — the Presidio analyzer URL; the standard Helm service listens on port `3000`
+- [`HOOP_GATEWAY_URL`](/concepts/agents#configuration-reference) — the gateway HTTP/HTTPS base URL required to start the RDP agent
+- `MSPRESIDIO_ANALYZER_URL` — the Presidio analyzer endpoint. With the standard Presidio Helm deployment, use `http://presidio-envoy-lb:3010`. The Docker Compose example below talks directly to its analyzer service on port `3000`.
 
-The current stock agent Helm chart does not expose a container-command override. Changing only `image.repository` to the OCR image will run the wrong launcher and fail without `POSTGRES_DB_URI`. Use a custom Kubernetes workload or Docker Compose service that explicitly runs the standalone agent:
+The current stock agent Helm chart does not expose a container `args` override. Changing only `image.repository` to the OCR image will run the wrong launcher and fail without `POSTGRES_DB_URI`. Use a custom Kubernetes workload or Docker Compose service that preserves the image ENTRYPOINT and replaces only its default arguments:
 
 ```yaml
 services:
@@ -159,7 +159,7 @@ services:
       MSPRESIDIO_ANALYZER_URL: http://presidio-analyzer:3000
 ```
 
-For Kubernetes, set the same `command` and environment variables in the container specification and source `HOOP_KEY` from a Secret.
+For Kubernetes, keep the image ENTRYPOINT and set `args: ["hoop", "start", "agent"]`. Source `HOOP_KEY` from a Secret, set `HOOP_GATEWAY_URL` to the gateway's HTTP/HTTPS base URL, and, with the standard Presidio Helm deployment, set `MSPRESIDIO_ANALYZER_URL=http://presidio-envoy-lb:3010`. Do not set `command`: Kubernetes uses it to replace the ENTRYPOINT, which would bypass OCR startup.
 
 **Use it when:** the RDP PII guard is enabled for the organization. Do not use it for ordinary agents; its OCR models and runtime add significant image and memory overhead. See [Deploy Presidio](/setup/deployment/presidio) for the analyzer deployment.
 
@@ -170,7 +170,7 @@ For Kubernetes, set the same `command` and environment variables in the containe
 | `:<release>` | Identifies a Hoop release, such as `:1.126.3`. | Recommended baseline. Keep the gateway and agent on the same release. |
 | `:latest` | Moves whenever a new release is published. | Use for evaluation or when your deployment process intentionally tracks releases. |
 | `@sha256:<digest>` | Identifies exact image bytes. | Use when reproducibility or admission policy requires immutability. |
-| `hoopdev-minimal:<release>-<YYYYMMDD>` | Captures a weekly OS-patched minimal image. | Use when you want a dated patch snapshot; pin its digest for strict immutability. |
+| `:<release>-<YYYYMMDD>` | Captures a weekly OS-patched `hoophq/hoopdev-minimal` image. | Use when you want a dated patch snapshot; pin its digest for strict immutability. |
 
 `hoophq/hoopdev-minimal:latest` is rebuilt weekly between Hoop releases to pick up current Ubuntu security patches. Its plain `:<release>` tag is updated by the release workflow, not by the weekly rebuild. Application dependency fixes still require a new Hoop release.
 

--- a/setup/deployment/overview.mdx
+++ b/setup/deployment/overview.mdx
@@ -38,5 +38,9 @@ After everything is properly installed and configured, you will have a web inter
   </Card>
 </CardGroup>
 
+## Choose container images
+
+Self-hosted deployments use separate gateway and agent images. Review the [container image guide](/setup/deployment/container-images) to choose between the compatibility-first default, the minimal agent, the AGPL/SSPL-free image line, and the RDP OCR agent.
+
 > ### Managed Service
 > Alternatively to self-deploying Hoop.dev, you can use our managed service. No complex setup required - just register and begin with a demo database or connecting your resources. [Create a free account](https://use.hoop.dev) to get started.


### PR DESCRIPTION
## Summary

- explain the gateway, standard agent, minimal agent, clean-line, and OCR image roles
- document safe Helm selection, migration requirements, tags, and update cadence
- add the image guide to deployment navigation and overview

## Dependency

This documentation is only meaningful after the DEP-91 stack in `hoophq/hoop` is merged and its image and Helm changes are available: hoophq/hoop#1683, hoophq/hoop#1684, hoophq/hoop#1685, hoophq/hoop#1686, hoophq/hoop#1687, hoophq/hoop#1688, hoophq/hoop#1689.

The `hoophq/hoopdev-minimal` image and the `image.minimal` Helm toggle described here ship in hoophq/hoop#1685. (That stack replaces the original hoophq/hoop#1662, which was split for reviewability.) Keep this PR blocked until at least hoophq/hoop#1685 lands.

## How to test

### Setup

```bash
npm ci
npm run dev
```

### Steps

1. Open `http://localhost:3000/setup/deployment/overview`.
   - **Expected:** a **Choose container images** section links to the new guide.
2. Open the guide from that link.
   - **Expected:** the page renders under **Deployment → Container Images** and covers `hoop`, `hoop-ng`, `hoopdev`, `hoopdev-minimal`, `hoopdev-ng`, and the CPU/GPU OCR image.
3. Review the minimal and clean-line guidance.
   - **Expected:** `minimal` is described as the low-dependency bring-your-own-tools option; `-ng` is described as the broad-toolkit AGPL/SSPL-free line. Clean Helm values are nested under `hoop-chart` or `hoopagent-chart`, and upgrades preserve the existing namespace.
4. Review the OCR safety guidance.
   - **Expected:** it warns that changing only the stock chart image is unsupported, requires `command: ["hoop", "start", "agent"]`, and uses the Presidio service on port `3000`.

### Link check

```bash
npx mint broken-links
```

- **Expected:** no new broken link originates from this change. The repository currently reports the pre-existing `concepts/agents.mdx` link to `/api-reference`.

Automated by MisterMal
