### PR TITLE
docs: cover the clean image line and agent Presidio wiring

### DIFF
--- a/concepts/agents.mdx
+++ b/concepts/agents.mdx
@@ -59,6 +59,7 @@ This installs a system service (`hoop-agent`) that starts automatically on login
 | Variable | Description | Default |
 |---|---|---|
 | `HOOP_KEY` | Agent authentication DSN (required) | — |
+| `HOOP_GATEWAY_URL` | Gateway HTTP/HTTPS base URL, for example `https://hoop.example.com`. When set, `hoop start agent` also starts the Rust agent that serves Remote Desktop connections, connecting to the gateway's `/api/ws` endpoint. Required for live RDP redaction. This is the API endpoint, not the gRPC endpoint used in `HOOP_KEY`. | — |
 | `LOG_LEVEL` | Log level: `debug`, `info`, `warn`, `error` | `info` |
 | `LOG_ENCODING` | Log format: `json`, `console`, `human`, `verbose` | auto |
 | `HOOP_TLSCA` | Path to a custom TLS CA certificate | — |

--- a/setup/deployment/container-images.mdx
+++ b/setup/deployment/container-images.mdx
@@ -119,6 +119,30 @@ do not have. The chart refuses to render if you try. Deploy the slim image as a
 standalone agent with the `hoopagent` chart instead.
 </Warning>
 
+#### Between releases: weekly base-OS patches
+
+A release tag such as `hoophq/hoopagent:1.136.1-minimal` never changes, so it
+slowly accumulates OS package CVEs until the next release. A weekly job
+rebuilds the `minimal` flavour against the current Ubuntu base and republishes
+it only if the result has no fixable CRITICAL or HIGH vulnerabilities:
+
+| Tag | Moves | Use it when |
+|---|---|---|
+| `hoophq/hoopagent:<version>-minimal` | Never | You pin an exact release and upgrade deliberately |
+| `hoophq/hoopagent:<version>-minimal-<YYYYMMDD>` | Never | You want a specific patched rebuild, pinned |
+| `hoophq/hoopagent:latest-minimal` | Weekly | You want OS patches automatically between releases |
+
+The `distroless` flavour has no such tags: it installs no OS packages, so a
+re-patch would change nothing.
+
+Each rebuilt image records the release it carries in its labels, so you can
+always tell which Hoop version a moving tag is currently serving:
+
+```bash
+docker inspect --format '{{index .Config.Labels "dev.hoop.release.version"}}' \
+  hoophq/hoopagent:latest-minimal
+```
+
 ### `hoophq/hoop-agent-ocr` — Agent with a bundled OCR engine
 
 `hoophq/hoopdev` plus an OCR engine, for **live redaction of Remote Desktop
@@ -184,8 +208,20 @@ counterpart. Choose the clean line when you need bundled clients *and* a clean
 licence history; choose `hoophq/hoopagent` when you need neither.
 </Note>
 
-Before switching, confirm nothing invokes the legacy `mongo` command — use
-`mongosh` instead.
+Before switching, check three things:
+
+- Nothing invokes the legacy `mongo` command — use `mongosh` instead.
+- Nothing in an image built **on top of** `hoophq/hoopdev-ng` compiles a native
+  extension at build time. The clean line omits the Python, unixODBC and kernel
+  build headers (`python3-dev`, `unixodbc-dev`, `alien`, `elfutils`,
+  `libelf-dev`) that the standard line keeps — that is a large part of why it
+  carries fewer CVEs. A `pip install` of something like `pyodbc` or `pymssql`
+  that falls back to building from source will fail unless your own Dockerfile
+  installs those packages first, or you restrict yourself to prebuilt wheels.
+  The ODBC *runtime* is present either way.
+- Your connections tolerate newer client versions. The clean line tracks more
+  recent releases of `kubectl`, `sqlcmd`, `mongosh`, the MongoDB tools, Node.js,
+  the AWS CLI and the Google Cloud CLI than the standard line does.
 
 Install the clean line with its own chart artifacts. These charts **wrap** the
 standard charts, so every value must be nested under the dependency name:
@@ -262,10 +298,27 @@ build needs to map one to the other — the example below does this.
 
 ### Option 1: starting from a base image of your choice
 
-Each example downloads the tarball, verifies it against the published
-`checksums.txt`, and extracts the binary. The verification runs inside the
-build, so a corrupted or tampered download fails the build rather than
-producing a broken image.
+Each example downloads the tarball, checks it against the published
+`checksums.txt`, and extracts the binary. The check runs inside the build, so a
+corrupted or truncated download fails the build rather than producing a broken
+image.
+
+<Warning>
+That check detects corruption, not tampering. The archive and the checksum come
+from the same host, so anyone able to serve you altered bytes can serve a
+matching checksum too. To authenticate the bytes, pin the digest yourself:
+take the SHA-256 from the [GitHub release
+assets](https://github.com/hoophq/hoop/releases) — GitHub records an immutable
+digest for every asset it hosts — and pass it into the build:
+
+```docker
+ARG HOOP_SHA256
+RUN echo "${HOOP_SHA256}  /tmp/${TARBALL}" | sha256sum -c -
+```
+
+A digest you reviewed once and keep in your own build config is what makes the
+check meaningful; it also pins you to exactly the release you tested.
+</Warning>
 
 Pick the base you already standardise on. Add the tooling your connections need
 where the comment indicates.
@@ -436,7 +489,7 @@ tag to use is the one referenced by the Hoop release you are targeting.
 
 ### Verifying a download outside a build
 
-The Dockerfiles above verify the tarball as part of the build. To check one by
+The Dockerfiles above check the tarball as part of the build. To check one by
 hand — when mirroring releases to an internal artifact store, for example:
 
 ```bash
@@ -452,6 +505,17 @@ The paths in `checksums.txt` are build-time paths, so match on the filename
 rather than the whole line. Each architecture is listed under two equivalent
 names (`x86_64` and `amd64`, `arm64` and `aarch64`) with the same hash;
 anchoring the match to the end of the line picks exactly one.
+
+As above, this catches a corrupted or truncated copy. When you are mirroring —
+the case where the bytes then live in your own artifact store and get trusted
+for a long time — take the expected digest from the [GitHub release
+assets](https://github.com/hoophq/hoop/releases) instead, and record it
+alongside the mirrored file:
+
+```bash
+EXPECTED=<sha256 copied from the GitHub release asset>
+echo "${EXPECTED}  ${TARBALL}" | sha256sum -c -
+```
 
 ## Requirements for a custom agent image
 

--- a/setup/deployment/container-images.mdx
+++ b/setup/deployment/container-images.mdx
@@ -127,8 +127,17 @@ container runtime installed.
 | `hoophq/hoop-agent-ocr:<version>-gpu` | `linux/amd64` only | The deployment target. Built against CUDA, so there is no ARM64 build; needs a GPU host |
 | `hoophq/hoop-agent-ocr:<version>` | `linux/amd64`, `linux/arm64` | CPU build. Functional for evaluation, but not fast enough to redact a live session |
 
-Live redaction is enabled per organisation and also needs a Presidio analyzer —
-see [Presidio](/setup/deployment/presidio).
+Live redaction is enabled per organisation and also needs a Presidio analyzer.
+The agent calls Presidio directly, so set `MSPRESIDIO_ANALYZER_URL` on the
+**agent**, not only on the gateway. With the standard Presidio Helm deployment
+that endpoint is the Envoy load balancer:
+
+```yaml
+config:
+  MSPRESIDIO_ANALYZER_URL: http://presidio-envoy-lb:3010
+```
+
+See [Presidio](/setup/deployment/presidio) for the analyzer deployment.
 
 ### `hoophq/agent-tools` — Base image
 
@@ -136,6 +145,75 @@ The base layer `hoophq/hoopdev` is built from: the bundled client tooling
 without the Hoop binary. Published so you can build your own agent image on the
 same tooling set — see [Extending the tooling
 image](#option-2-extending-the-tooling-image) below.
+
+### The clean image line (`-ng`)
+
+Every image above ships from a repository whose history may contain AGPL or
+SSPL components, because `hoophq/hoopdev` bundles the legacy MongoDB shell. If
+your policy forbids those licences anywhere in an image's history, use the
+clean line instead:
+
+| Standard | Clean equivalent |
+|---|---|
+| `hoophq/hoop` | `hoophq/hoop-ng` |
+| `hoophq/hoopdev` | `hoophq/hoopdev-ng` |
+
+`hoophq/hoop-ng` is a manifest-for-manifest copy of the gateway, which is
+already licence-clean; the separate repository exists to give it a clean
+history. `hoophq/hoopdev-ng` keeps the same broad client tooling as
+`hoophq/hoopdev` but excludes the SSPL-licensed legacy MongoDB 5 `mongo` shell
+and its end-of-life OpenSSL 1.1 dependency, shipping only `mongosh`.
+
+<Note>
+`hoophq/hoopagent` is already clean-only by construction, so it has no `-ng`
+counterpart. Choose the clean line when you need bundled clients *and* a clean
+licence history; choose `hoophq/hoopagent` when you need neither.
+</Note>
+
+Before switching, confirm nothing invokes the legacy `mongo` command — use
+`mongosh` instead.
+
+Install the clean line with its own chart artifacts. These charts **wrap** the
+standard charts, so every value must be nested under the dependency name:
+
+```yaml
+# clean-gateway-values.yaml
+hoop-chart:
+  config:
+    POSTGRES_DB_URI: <database-uri>
+    API_URL: https://hoop.example.com
+  # Move the rest of your existing gateway values here.
+
+# clean-agent-values.yaml
+hoopagent-chart:
+  config:
+    HOOP_KEY: <agent-key>
+  # Move the rest of your existing agent values here.
+```
+
+<Warning>
+Passing an existing standard-chart values file to a wrapper chart unchanged
+silently ignores every top-level value, including database and API settings.
+Nest them first, and review the rendered manifests before upgrading.
+</Warning>
+
+```bash
+VERSION=$(curl -s https://releases.hoop.dev/release/latest.txt)
+
+helm upgrade --install hoop \
+  --namespace <existing-namespace> \
+  https://releases.hoop.dev/release/$VERSION/hoop-ng-chart-$VERSION.tgz \
+  -f clean-gateway-values.yaml
+
+helm upgrade --install hoopagent \
+  --namespace <existing-namespace> \
+  https://releases.hoop.dev/release/$VERSION/hoopagent-ng-chart-$VERSION.tgz \
+  -f clean-agent-values.yaml
+```
+
+The release names stay `hoop` and `hoopagent`, so this is an in-place upgrade
+when the release name and namespace both match. If your values set an image
+repository explicitly, remove that override or point it at the `-ng` repository.
 
 ## Building a custom image
 

--- a/setup/deployment/container-images.mdx
+++ b/setup/deployment/container-images.mdx
@@ -106,6 +106,19 @@ SSPL-licensed components.
 and a release, for example `hoophq/hoopagent:1.135.1-minimal`.
 </Warning>
 
+Neither flavour serves **Remote Desktop**: RDP is handled by a companion
+binary (`hoop_rs`) that these images do not carry. Setting `HOOP_GATEWAY_URL`
+on a slim flavour is still fine — the agent logs that it is starting without
+Remote Desktop support and serves everything else normally — but RDP
+connections need `hoophq/hoopdev`.
+
+<Warning>
+Do not use a slim flavour for the gateway chart's `defaultAgent` sidecar. That
+sidecar runs a startup script that needs a shell and `psql`, which these images
+do not have. The chart refuses to render if you try. Deploy the slim image as a
+standalone agent with the `hoopagent` chart instead.
+</Warning>
+
 ### `hoophq/hoop-agent-ocr` — Agent with a bundled OCR engine
 
 `hoophq/hoopdev` plus an OCR engine, for **live redaction of Remote Desktop
@@ -148,10 +161,11 @@ image](#option-2-extending-the-tooling-image) below.
 
 ### The clean image line (`-ng`)
 
-Every image above ships from a repository whose history may contain AGPL or
-SSPL components, because `hoophq/hoopdev` bundles the legacy MongoDB shell. If
-your policy forbids those licences anywhere in an image's history, use the
-clean line instead:
+`hoophq/hoopdev` bundles the legacy MongoDB shell, so its repository — and the
+`hoophq/hoop` gateway repository alongside it — has a history that may contain
+AGPL or SSPL components. (`hoophq/hoopagent` is the exception: it is clean-only
+by construction, as described below.) If your policy forbids those licences
+anywhere in an image's history, use the clean line instead:
 
 | Standard | Clean equivalent |
 |---|---|


### PR DESCRIPTION
## Summary

Follow-up to #158, which is already merged. That page covers the published images well; this adds the four things it does not yet mention. Each was verified against `hoophq/hoop@main`.

- **The clean image line (`-ng`)** — `hoophq/hoop-ng` and `hoophq/hoopdev-ng` exist (charts `hoop-ng` / `hoopagent-ng`, 32 references in `release.yml`) but were undocumented. Includes when to choose them over `hoophq/hoopagent`, which is already clean-only.
- **Wrapper-chart values nesting** — the `-ng` charts wrap the standard charts, so values must be nested under `hoop-chart:` / `hoopagent-chart:`. Passing an existing values file unchanged silently ignores every top-level value, including the database URI. Called out with a warning.
- **Agent-side Presidio endpoint** — live RDP redaction needs `MSPRESIDIO_ANALYZER_URL` on the **agent**, not only the gateway, and with the standard Presidio Helm deployment that is the Envoy load balancer `presidio-envoy-lb:3010`.
- **`HOOP_GATEWAY_URL`** — present in the agent chart secret and required to start the Rust agent that serves RDP, but missing from the agent configuration reference.

This supersedes #156, which is closed: its `hoophq/hoopdev-minimal` content is obsolete now that hoophq/hoop#1693 shipped `hoophq/hoopagent` instead.

## How to test

```bash
npm ci
npm run dev
```

1. Open `/setup/deployment/container-images`.
   - **Expected:** a **The clean image line (`-ng`)** section under Published images, with the standard-to-clean mapping table, the nesting warning, and the `helm upgrade` commands carrying `--namespace`.
2. Check the OCR section just above it.
   - **Expected:** it now shows `MSPRESIDIO_ANALYZER_URL: http://presidio-envoy-lb:3010`, consistent with `/setup/deployment/presidio` and the guardrails page.
3. Open `/concepts/agents` and find **Configuration Reference**.
   - **Expected:** a `HOOP_GATEWAY_URL` row noting it is the API endpoint, not the gRPC endpoint used in `HOOP_KEY`.

```bash
npx mint broken-links
```

- **Expected:** no new broken links. The pre-existing `concepts/agents.mdx → /api-reference` report is unrelated to this change.

Automated by MisterMal