### PR TITLE
docs(changelog): add 1.144.0 entry

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -17,12 +17,12 @@ Browse our latest updates to see what's new:
 
 {/* changelog-cards:start */}
 <CardGroup cols={2}>
-  <Card title="Latest Release" icon="rocket" href="/changelog/1.136.1">
-    Version 1.136.1 - Global header, Server Logs, AI inspection and much more
+  <Card title="Latest Release" icon="rocket" href="/changelog/1.144.0">
+    Version 1.144.0 - Kerberos, agentic AI analysis, RDP resolutions and faster sessions
   </Card>
 
-  <Card title="Patch 1.126.3" icon="note" href="/changelog/1.126.3">
-    Version 1.126.3 - MSSQL guardrails, license features, MCP OAuth and much more
+  <Card title="Patch 1.136.1" icon="note" href="/changelog/1.136.1">
+    Version 1.136.1 - Global header, Server Logs, AI inspection and much more
   </Card>
 </CardGroup>
 {/* changelog-cards:end */}

--- a/changelog/1.144.0.mdx
+++ b/changelog/1.144.0.mdx
@@ -14,7 +14,7 @@ description: "Kerberos-authenticated MSSQL and Postgres inspection, an agentic A
 **Deeper inspection, smarter analysis, and more control over your sessions.**
 
 - **Kerberos support for MSSQL and Postgres**
-  hoop can now inspect, mask, and audit Microsoft SQL Server traffic, including sessions where the user authenticates with Kerberos, and Postgres connections from Kerberos-enabled clients can no longer slip past inspection. Audit records for those sessions now name the user who ran each statement.
+  Hoop can now inspect, mask, and audit Microsoft SQL Server traffic, including sessions where the user authenticates with Kerberos, and Postgres connections from Kerberos-enabled clients can no longer slip past inspection. Audit records for those sessions now name the user who ran each statement.
   [PR #1698](https://github.com/hoophq/hoop/pull/1698)
 
 - **Agentic AI Session Analyzer**

--- a/changelog/1.144.0.mdx
+++ b/changelog/1.144.0.mdx
@@ -1,0 +1,92 @@
+---
+title: "1.144.0"
+description: "Kerberos-authenticated MSSQL and Postgres inspection, an agentic AI Session Analyzer, AI risk analysis for MSSQL, policy verdicts you can defer to your own Rego, selectable RDP resolutions, and dramatically faster session listing."
+---
+
+### TL;DR
+- **New Features:** Kerberos support for MSSQL and Postgres inspection, an agentic AI Session Analyzer, AI risk analysis for MSSQL, OPA-backed policy verdicts, selectable RDP desktop resolutions, and a lightweight onboarding survey.
+- **Improvements:** Open native connections now sort to the top of the drawer, and MCP can filter connections by key/value tags.
+- **Bug Fixes:** Much faster session listing, bounded terminal output, RDP masking that honors per-connection rules, a stable setup checklist, and a sharper destructive-write SQL scanner.
+
+---
+
+### New Features
+**Deeper inspection, smarter analysis, and more control over your sessions.**
+
+- **Kerberos support for MSSQL and Postgres**
+  hoop can now inspect, mask, and audit Microsoft SQL Server traffic, including sessions where the user authenticates with Kerberos, and Postgres connections from Kerberos-enabled clients can no longer slip past inspection. Audit records for those sessions now name the user who ran each statement.
+  [PR #1698](https://github.com/hoophq/hoop/pull/1698)
+
+- **Agentic AI Session Analyzer**
+  The AI Session Analyzer can now investigate before assigning a risk level, drawing on the user's past sessions, read-only metadata queries against the target database, and the connection's governance context, with the full reasoning and tool-call trace shown on the session detail page and in the Slack review message. It is opt-in per rule, so existing rules keep their single-shot behavior unchanged.
+  [PR #1702](https://github.com/hoophq/hoop/pull/1702)
+
+- **AI risk analysis for MSSQL**
+  Protocol-aware inspection can now classify Microsoft SQL Server statements with the AI analyzer, extending risk scoring to your MSSQL connections.
+  [PR #1712](https://github.com/hoophq/hoop/pull/1712)
+
+- **Defer policy verdicts to your own Rego**
+  Inspection rules can now match locally and hand the final verdict to the Rego policies your InfoSec team already owns, so decisions like blocking a taxpayer id unless the caller is on the finance team become expressible.
+  [PR #1704](https://github.com/hoophq/hoop/pull/1704)
+
+- **Selectable RDP desktop resolutions**
+  RDP users can now pick a stable desktop resolution from browser-fit plus six fixed presets before opening the browser client, with browser-fit remaining the default.
+  [PR #1713](https://github.com/hoophq/hoop/pull/1713)
+
+- **Onboarding survey that never gets in the way**
+  New users are asked how they heard about Hoop during their first week through a small floating button that expands into a card, takes one click to answer, and never comes back.
+  [PR #1701](https://github.com/hoophq/hoop/pull/1701)
+
+---
+
+### Improvements
+**Quicker access to the connections and data you need.**
+
+- **Open connections first in the native drawer**
+  The Native Connections drawer now lists your open connections at the top, so live sessions are always the first thing you see.
+  [PR #1707](https://github.com/hoophq/hoop/pull/1707)
+
+- **Filter connections by tag over MCP**
+  Agents can now filter connections by their key/value tags through MCP using the same key=value,key!=value syntax as the REST API, replacing a full connection dump with a scoped list on large installs.
+  [PR #1706](https://github.com/hoophq/hoop/pull/1706)
+
+---
+
+### Bug Fixes
+**Faster listings, tighter masking, and steadier terminals.**
+
+- **Dramatically faster session listing**
+  Listing sessions is now far faster on large workspaces and no longer risks slowing the rest of the API, with the speedup applied automatically across the sessions page, both CLI listings, the MCP tool, and the AI analyzer. Totals above 10,000 are reported as a floor unless an exact count is requested, and the counts shown to people, like the dashboard's sessions-today card, stay exact.
+  [PR #1714](https://github.com/hoophq/hoop/pull/1714)
+
+- **RDP masking honors per-connection rules**
+  RDP live masking now uses the Data Masking rules assigned to the selected connection instead of gateway-wide entity and confidence settings, with unsupported custom entities failing closed.
+  [PR #1711](https://github.com/hoophq/hoop/pull/1711)
+
+- **Bounded terminal output and clearer draft limits**
+  Running a command that returns very large output no longer freezes the terminal tab; output above 512KB is capped for display with a pointer to the full result, and scripts too large for browser storage now show a clear "Draft not saved" message instead of an endless spinner.
+  [PR #1703](https://github.com/hoophq/hoop/pull/1703)
+
+- **Setup checklist stays checked**
+  The onboarding setup checklist is now computed on the server, so completed steps no longer untick themselves.
+  [PR #1709](https://github.com/hoophq/hoop/pull/1709)
+
+- **Sharper destructive-write detection**
+  Several SQL statements that previously slipped past destructive-write rules are now caught, including data-modifying CTEs, MERGE delete branches, and multi-statement queries hidden behind an escape string.
+  [PR #1704](https://github.com/hoophq/hoop/pull/1704)
+
+- **Steadier expired-credential cleanup**
+  Expired-credential audit sessions are now marked done on a fixed 15-second schedule rather than whenever someone happens to load the sessions page, keeping cleanup off the read paths.
+  [PR #1708](https://github.com/hoophq/hoop/pull/1708)
+
+- **Reliable OCR startup on large hosts**
+  Fixed a startup crash in the OCR sidecar on high-core hosts by bounding its thread pools, so masking deployments come up cleanly on big machines.
+  [PR #1658](https://github.com/hoophq/hoop/pull/1658)
+
+- **Security update for gRPC**
+  Updated the gRPC library to the latest version to address a known security advisory.
+  [PR #1697](https://github.com/hoophq/hoop/pull/1697)
+
+---
+
+Less friction, deeper inspection, faster connections.

--- a/docs.json
+++ b/docs.json
@@ -304,6 +304,7 @@
           {
             "group": "Releases",
             "pages": [
+              "changelog/1.144.0",
               "changelog/1.136.1",
               "changelog/1.126.3",
               "changelog/1.121.0",


### PR DESCRIPTION
Automated weekly changelog entry for **1.144.0**, covering releases `1.136.1` (exclusive) through `1.144.0`.

- Included changes: **15**
- Excluded changes: **4**

## Reviewer checklist

- [ ] Voice and framing read like the existing entries
- [ ] Nothing feature-flag-gated or internal leaked into the entry
- [ ] TL;DR and release cards look right

## Excluded from this entry

The generator withheld these; promote by hand if any should be announced.

| Version | PR | Reason |
|---|---|---|
| 1.137.0 | [#1674](https://github.com/hoophq/hoop/pull/1674) EVL-147: remove the CLJS guardrails pages shadowed by React | author labeled it skip-release (not release content) |
| 1.140.0 | [#1700](https://github.com/hoophq/hoop/pull/1700) chore(deps): alcatraz v0.16.0 for the Brazilian identifiers | internal-only title prefix: chore |
| 1.140.3 | [#1710](https://github.com/hoophq/hoop/pull/1710) refactor: optimize ListSessions query and add session index creation | author labeled it skip-release (not release content) |
| 1.144.0 | [#1692](https://github.com/hoophq/hoop/pull/1692) refactor(webapp): remove the CLJS access control and access request pages (EVL-184) | author labeled it skip-release (not release content) |

---

Generated by [hoophq/changelog](https://github.com/hoophq/changelog) — [run](https://github.com/hoophq/changelog/actions/runs/32034795980).
